### PR TITLE
Add CLI command to inspect message delivery receipts

### DIFF
--- a/cmd/october-bus/main.go
+++ b/cmd/october-bus/main.go
@@ -260,7 +260,7 @@ func inspectReceipt(args []string) error {
 	flags.SetOutput(os.Stderr)
 	jsonOutput := flags.Bool("json", false, "print machine-readable JSON")
 	address := flags.String("address", "", "October Bus address")
-	if err := flags.Parse(args); err != nil {
+	if err := flags.Parse(receiptFlagArgs(args)); err != nil {
 		return err
 	}
 	positional := flags.Args()
@@ -294,6 +294,31 @@ func inspectReceipt(args []string) error {
 		return nil
 	}
 	return printReceiptHuman(receipt)
+}
+
+// receiptFlagArgs moves supported flags before the message id so the command
+// accepts flags on either side of its single positional argument. The standard
+// flag package otherwise stops parsing at the first positional argument.
+func receiptFlagArgs(args []string) []string {
+	flags := make([]string, 0, len(args))
+	positional := make([]string, 0, 1)
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if argument == "--" {
+			positional = append(positional, args[index+1:]...)
+			break
+		}
+		if !strings.HasPrefix(argument, "-") || argument == "-" {
+			positional = append(positional, argument)
+			continue
+		}
+		flags = append(flags, argument)
+		if (argument == "-address" || argument == "--address") && index+1 < len(args) {
+			index++
+			flags = append(flags, args[index])
+		}
+	}
+	return append(flags, positional...)
 }
 
 // printReceiptHuman renders a DeliveryReceipt as a stable, multi-line summary.

--- a/cmd/october-bus/main.go
+++ b/cmd/october-bus/main.go
@@ -24,6 +24,7 @@ Usage:
   october-bus status
   october-bus doctor [--json]
   october-bus scope create [scope-id]
+  october-bus message receipt <message-id> [--json] [--address <addr>]
   october-bus agent run --id <id> --name <name> [--connect-to <peer>] -- <command> [args...]
   october-bus demo
   october-bus version
@@ -227,6 +228,100 @@ func createScope(id string) error {
 	return nil
 }
 
+// resolveBusAddress returns the daemon address to talk to for a CLI subcommand
+// that uses an agent credential. Precedence: explicit flag, then the
+// OCTOBER_BUS_ADDRESS environment variable, then the daemon run file.
+func resolveBusAddress(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if env := os.Getenv("OCTOBER_BUS_ADDRESS"); env != "" {
+		return env, nil
+	}
+	paths, err := bus.DefaultDaemonPaths()
+	if err != nil {
+		return "", err
+	}
+	run, err := bus.ReadRunFile(paths.RunFile)
+	if err != nil {
+		return "", err
+	}
+	return run.Address, nil
+}
+
+// inspectReceipt implements `october-bus message receipt <message-id>`.
+//
+// It reads the agent credential from OCTOBER_BUS_AGENT_TOKEN and fetches the
+// delivery receipt through the public client API. The receipt deliberately
+// exposes only delivery state and timestamps; message bodies and shared
+// context are never included.
+func inspectReceipt(args []string) error {
+	flags := flag.NewFlagSet("message receipt", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	jsonOutput := flags.Bool("json", false, "print machine-readable JSON")
+	address := flags.String("address", "", "October Bus address")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	positional := flags.Args()
+	if len(positional) != 1 {
+		return errors.New("message receipt requires a single <message-id> argument")
+	}
+	messageID := strings.TrimSpace(positional[0])
+	if messageID == "" {
+		return errors.New("message id must not be empty")
+	}
+	token := os.Getenv("OCTOBER_BUS_AGENT_TOKEN")
+	if token == "" {
+		return errors.New("OCTOBER_BUS_AGENT_TOKEN is required")
+	}
+	resolved, err := resolveBusAddress(*address)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	receipt, err := (bus.Client{Address: resolved, Token: token}).Receipt(ctx, messageID)
+	if err != nil {
+		return fmt.Errorf("could not inspect message receipt: %w", err)
+	}
+	if *jsonOutput {
+		encoded, err := json.MarshalIndent(receipt, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(encoded))
+		return nil
+	}
+	return printReceiptHuman(receipt)
+}
+
+// printReceiptHuman renders a DeliveryReceipt as a stable, multi-line summary.
+// Only state, timestamps, and the linked response message ID are shown; the
+// receipt struct contains no body or shared-context fields, so this view
+// cannot leak message contents.
+func printReceiptHuman(receipt bus.DeliveryReceipt) error {
+	fmt.Printf("Message %s\n", receipt.MessageID)
+	fmt.Printf("State: %s\n", receipt.State)
+	for _, ts := range []struct {
+		label string
+		value string
+	}{
+		{"AcceptedAt", receipt.AcceptedAt},
+		{"DeliveredAt", receipt.DeliveredAt},
+		{"AcknowledgedAt", receipt.AcknowledgedAt},
+		{"RepliedAt", receipt.RepliedAt},
+	} {
+		if ts.value != "" {
+			fmt.Printf("%s: %s\n", ts.label, ts.value)
+		}
+	}
+	if receipt.ResponseMessageID != "" {
+		fmt.Printf("ResponseMessageID: %s\n", receipt.ResponseMessageID)
+	}
+	return nil
+}
+
 func setEnvironment(base []string, values ...string) []string {
 	replacements := map[string]bool{}
 	for i := 0; i < len(values); i += 2 {
@@ -388,6 +483,10 @@ func run() error {
 				id = args[2]
 			}
 			return createScope(id)
+		}
+	case "message":
+		if len(args) >= 2 && args[1] == "receipt" {
+			return inspectReceipt(args[2:])
 		}
 	case "agent":
 		if len(args) >= 2 && args[1] == "run" {

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -117,10 +117,10 @@ func TestRemoveEnvironmentRemovesCredentials(t *testing.T) {
 }
 
 // startTestServer spins up an in-memory bus, registers two linked agents
-// (sender and receiver), and returns the address, the sender's agent token,
-// and a cleanup function. It mirrors the protocol exercised by bus.RunDemo
-// but keeps the scope and ids local to the test.
-func startTestServer(t *testing.T, ctx context.Context, scopeID string) (address, senderToken, receiverToken string, cleanup func()) {
+// (sender and receiver), and returns the address, scope token, both agent
+// tokens, and a cleanup function. It mirrors the protocol exercised by
+// bus.RunDemo but keeps the scope and ids local to the test.
+func startTestServer(t *testing.T, ctx context.Context, scopeID string) (address, scopeToken, senderToken, receiverToken string, cleanup func()) {
 	t.Helper()
 	runtimeValue, err := bus.Open(":memory:")
 	if err != nil {
@@ -155,7 +155,7 @@ func startTestServer(t *testing.T, ctx context.Context, scopeID string) (address
 		server.Stop(context.Background())
 		runtimeValue.Close()
 	}
-	return listenAddr, sender.AgentToken, receiver.AgentToken, cleanup
+	return listenAddr, scope.ScopeToken, sender.AgentToken, receiver.AgentToken, cleanup
 }
 
 func TestInspectReceiptRequiresArgs(t *testing.T) {
@@ -224,7 +224,7 @@ func TestInspectReceiptEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	address, senderToken, receiverToken, cleanup := startTestServer(t, ctx, "receipt-e2e")
+	address, _, senderToken, receiverToken, cleanup := startTestServer(t, ctx, "receipt-e2e")
 	defer cleanup()
 
 	sender := bus.Client{Address: address, Token: senderToken}
@@ -255,7 +255,7 @@ func TestInspectReceiptEndToEnd(t *testing.T) {
 	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", senderToken)
 
 	var jsonOut, humanOut bytes.Buffer
-	if err := runInspectCapturing(&jsonOut, "--json", "--address", address, initial.MessageID); err != nil {
+	if err := runInspectCapturing(&jsonOut, initial.MessageID, "--json", "--address", address); err != nil {
 		t.Fatalf("inspect json: %v", err)
 	}
 	if err := runInspectCapturing(&humanOut, "--address", address, initial.MessageID); err != nil {
@@ -316,7 +316,7 @@ func TestInspectReceiptUnknownMessageReturnsError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	address, senderToken, _, cleanup := startTestServer(t, ctx, "receipt-missing")
+	address, _, senderToken, _, cleanup := startTestServer(t, ctx, "receipt-missing")
 	defer cleanup()
 	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", senderToken)
 
@@ -337,28 +337,12 @@ func TestInspectReceiptRejectsUnauthorizedCaller(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	address, senderToken, _, cleanup := startTestServer(t, ctx, "receipt-authz")
+	address, scopeToken, senderToken, _, cleanup := startTestServer(t, ctx, "receipt-authz")
 	defer cleanup()
 
-	// Register a third agent in an isolated runtime. Their token is unknown
-	// to the original runtime, so the runtime must refuse before it reaches
-	// the receipt query — they cannot even probe whether a message exists.
-	isolatedRuntime, err := bus.Open(":memory:")
-	if err != nil {
-		t.Fatalf("open isolated runtime: %v", err)
-	}
-	defer isolatedRuntime.Close()
-	isolatedServer := bus.NewServer(isolatedRuntime, bus.ServerOptions{})
-	isolatedAddr, err := isolatedServer.Start()
-	if err != nil {
-		t.Fatalf("start isolated server: %v", err)
-	}
-	defer isolatedServer.Stop(context.Background())
-	isolatedScope, err := isolatedRuntime.CreateScope(ctx, bus.CreateScopeInput{ID: "receipt-authz-isolated"})
-	if err != nil {
-		t.Fatalf("create isolated scope: %v", err)
-	}
-	outsider, err := (bus.Client{Address: isolatedAddr, Token: isolatedScope.ScopeToken}).RegisterAgent(ctx, bus.RegisterAgentInput{
+	// Register a third agent in the same scope. Its valid credential proves
+	// receipt authorization is enforced independently of authentication.
+	outsider, err := (bus.Client{Address: address, Token: scopeToken}).RegisterAgent(ctx, bus.RegisterAgentInput{
 		ID: "outsider", DisplayName: "Outsider",
 	})
 	if err != nil {
@@ -372,7 +356,8 @@ func TestInspectReceiptRejectsUnauthorizedCaller(t *testing.T) {
 	}
 
 	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", outsider.AgentToken)
-	err = runInspectCapturing(&bytes.Buffer{}, "--address", address, initial.MessageID)
+	var output bytes.Buffer
+	err = runInspectCapturing(&output, "--address", address, initial.MessageID)
 	if err == nil {
 		t.Fatal("expected error when an outsider inspects a message they did not send or receive")
 	}
@@ -380,12 +365,10 @@ func TestInspectReceiptRejectsUnauthorizedCaller(t *testing.T) {
 	if !errors.As(err, &busErr) {
 		t.Fatalf("expected *bus.BusError, got %T: %v", err, err)
 	}
-	// The outsider's token is from a different runtime, so the runtime has
-	// no record of the principal and rejects with UNAUTHENTICATED. A
-	// NOT_FOUND (token valid but message not visible) is also acceptable;
-	// both outcomes prevent disclosure. Asserting the message body never
-	// appears anywhere in the captured output is the stronger guarantee.
-	if busErr.Code != bus.CodeUnauthenticated && busErr.Code != bus.CodeNotFound {
-		t.Errorf("expected CodeUnauthenticated or CodeNotFound, got %q", busErr.Code)
+	if busErr.Code != bus.CodeNotFound {
+		t.Errorf("expected CodeNotFound, got %q", busErr.Code)
+	}
+	if strings.Contains(output.String(), "secret") {
+		t.Error("receipt inspection leaked the message body")
 	}
 }

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,5 +113,279 @@ func TestRemoveEnvironmentRemovesCredentials(t *testing.T) {
 	result := removeEnvironment([]string{"PATH=/bin", "OCTOBER_BUS_SCOPE_TOKEN=secret", "OTHER=value"}, "october_bus_scope_token")
 	if len(result) != 2 || result[0] != "PATH=/bin" || result[1] != "OTHER=value" {
 		t.Fatalf("unexpected environment: %#v", result)
+	}
+}
+
+// startTestServer spins up an in-memory bus, registers two linked agents
+// (sender and receiver), and returns the address, the sender's agent token,
+// and a cleanup function. It mirrors the protocol exercised by bus.RunDemo
+// but keeps the scope and ids local to the test.
+func startTestServer(t *testing.T, ctx context.Context, scopeID string) (address, senderToken, receiverToken string, cleanup func()) {
+	t.Helper()
+	runtimeValue, err := bus.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open runtime: %v", err)
+	}
+	server := bus.NewServer(runtimeValue, bus.ServerOptions{})
+	listenAddr, err := server.Start()
+	if err != nil {
+		t.Fatalf("start server: %v", err)
+	}
+	scope, err := runtimeValue.CreateScope(ctx, bus.CreateScopeInput{ID: scopeID})
+	if err != nil {
+		server.Stop(context.Background())
+		t.Fatalf("create scope: %v", err)
+	}
+	scopeClient := bus.Client{Address: listenAddr, Token: scope.ScopeToken}
+	sender, err := scopeClient.RegisterAgent(ctx, bus.RegisterAgentInput{ID: "sender", DisplayName: "Sender"})
+	if err != nil {
+		server.Stop(context.Background())
+		t.Fatalf("register sender: %v", err)
+	}
+	receiver, err := scopeClient.RegisterAgent(ctx, bus.RegisterAgentInput{ID: "receiver", DisplayName: "Receiver", ConnectTo: []string{"sender"}})
+	if err != nil {
+		server.Stop(context.Background())
+		t.Fatalf("register receiver: %v", err)
+	}
+	if err := scopeClient.LinkAgents(ctx, "sender", "receiver"); err != nil {
+		server.Stop(context.Background())
+		t.Fatalf("link agents: %v", err)
+	}
+	cleanup = func() {
+		server.Stop(context.Background())
+		runtimeValue.Close()
+	}
+	return listenAddr, sender.AgentToken, receiver.AgentToken, cleanup
+}
+
+func TestInspectReceiptRequiresArgs(t *testing.T) {
+	if err := inspectReceipt(nil); err == nil || !strings.Contains(err.Error(), "<message-id>") {
+		t.Fatalf("expected missing-arg error, got %v", err)
+	}
+	if err := inspectReceipt([]string{"   "}); err == nil || !strings.Contains(err.Error(), "must not be empty") {
+		t.Fatalf("expected empty-id error, got %v", err)
+	}
+}
+
+func TestInspectReceiptRequiresAgentToken(t *testing.T) {
+	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", "")
+	err := inspectReceipt([]string{"--address", "http://127.0.0.1:1", "msg-1"})
+	if err == nil || !strings.Contains(err.Error(), "OCTOBER_BUS_AGENT_TOKEN is required") {
+		t.Fatalf("expected token-required error, got %v", err)
+	}
+}
+
+func TestPrintReceiptHumanOmitsEmptyTimestamps(t *testing.T) {
+	// Capture stdout while rendering, restore on exit.
+	originalStdout := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("pipe: %v", pipeErr)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = originalStdout }()
+
+	receipt := bus.DeliveryReceipt{
+		MessageID:   "msg-1",
+		State:       bus.DeliveryDelivered,
+		AcceptedAt:  "2026-08-31T10:00:00Z",
+		DeliveredAt: "2026-08-31T10:00:01Z",
+		// AcknowledgedAt and RepliedAt intentionally empty.
+	}
+	if err := printReceiptHuman(receipt); err != nil {
+		t.Fatalf("printReceiptHuman: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"Message msg-1",
+		"State: delivered",
+		"AcceptedAt: 2026-08-31T10:00:00Z",
+		"DeliveredAt: 2026-08-31T10:00:01Z",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("human output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"AcknowledgedAt", "RepliedAt", "ResponseMessageID"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("human output unexpectedly contains %q\n--- output ---\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestInspectReceiptEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	address, senderToken, receiverToken, cleanup := startTestServer(t, ctx, "receipt-e2e")
+	defer cleanup()
+
+	sender := bus.Client{Address: address, Token: senderToken}
+	receiver := bus.Client{Address: address, Token: receiverToken}
+
+	// Send a message, pull it on the receiver side, and acknowledge it so the
+	// receipt progresses through delivered and acknowledged states.
+	initial, err := sender.SendMessage(ctx, bus.SendMessageInput{To: "receiver", Body: "ping"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if initial.State != bus.DeliveryQueued {
+		t.Fatalf("expected initial state queued, got %q", initial.State)
+	}
+	inbox, err := receiver.PullInbox(ctx, 10)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("expected one inbox message, got %d", len(inbox))
+	}
+	if _, err := receiver.AcknowledgeMessages(ctx, []string{initial.MessageID}); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+
+	// Now drive inspectReceipt through the CLI layer with the sender token and
+	// the explicit --address, capturing stdout to verify both rendering modes.
+	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", senderToken)
+
+	var jsonOut, humanOut bytes.Buffer
+	if err := runInspectCapturing(&jsonOut, "--json", "--address", address, initial.MessageID); err != nil {
+		t.Fatalf("inspect json: %v", err)
+	}
+	if err := runInspectCapturing(&humanOut, "--address", address, initial.MessageID); err != nil {
+		t.Fatalf("inspect human: %v", err)
+	}
+
+	var decoded bus.DeliveryReceipt
+	if err := json.Unmarshal(jsonOut.Bytes(), &decoded); err != nil {
+		t.Fatalf("json output did not parse as DeliveryReceipt: %v\n--- output ---\n%s", err, jsonOut.String())
+	}
+	if decoded.MessageID != initial.MessageID {
+		t.Errorf("json messageId = %q, want %q", decoded.MessageID, initial.MessageID)
+	}
+	if decoded.State != bus.DeliveryAcknowledged {
+		t.Errorf("json state = %q, want %q", decoded.State, bus.DeliveryAcknowledged)
+	}
+	if decoded.AcceptedAt == "" || decoded.DeliveredAt == "" || decoded.AcknowledgedAt == "" {
+		t.Errorf("expected accepted/delivered/acknowledged timestamps, got %+v", decoded)
+	}
+	// Body and context must never appear in the receipt-shaped output.
+	if strings.Contains(jsonOut.String(), "ping") {
+		t.Errorf("json output leaked message body")
+	}
+	if !strings.Contains(humanOut.String(), "State: acknowledged") {
+		t.Errorf("human output missing state line\n--- output ---\n%s", humanOut.String())
+	}
+	if !strings.Contains(humanOut.String(), "AcknowledgedAt:") {
+		t.Errorf("human output missing AcknowledgedAt line\n--- output ---\n%s", humanOut.String())
+	}
+}
+
+// runInspectCapturing routes inspectReceipt's stdout through a buffer by
+// temporarily swapping os.Stdout. It restores the original handle on exit.
+func runInspectCapturing(buf *bytes.Buffer, args ...string) error {
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(buf, r)
+		close(done)
+	}()
+	invokeErr := inspectReceipt(args)
+	if err := w.Close(); err != nil {
+		os.Stdout = original
+		return err
+	}
+	os.Stdout = original
+	<-done
+	_ = r.Close()
+	return invokeErr
+}
+
+func TestInspectReceiptUnknownMessageReturnsError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	address, senderToken, _, cleanup := startTestServer(t, ctx, "receipt-missing")
+	defer cleanup()
+	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", senderToken)
+
+	err := runInspectCapturing(&bytes.Buffer{}, "--address", address, "no-such-message")
+	if err == nil {
+		t.Fatal("expected error for unknown message, got nil")
+	}
+	var busErr *bus.BusError
+	if !errors.As(err, &busErr) {
+		t.Fatalf("expected *bus.BusError, got %T: %v", err, err)
+	}
+	if busErr.Code != bus.CodeNotFound {
+		t.Errorf("expected CodeNotFound, got %q", busErr.Code)
+	}
+}
+
+func TestInspectReceiptRejectsUnauthorizedCaller(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	address, senderToken, _, cleanup := startTestServer(t, ctx, "receipt-authz")
+	defer cleanup()
+
+	// Register a third agent in an isolated runtime. Their token is unknown
+	// to the original runtime, so the runtime must refuse before it reaches
+	// the receipt query — they cannot even probe whether a message exists.
+	isolatedRuntime, err := bus.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open isolated runtime: %v", err)
+	}
+	defer isolatedRuntime.Close()
+	isolatedServer := bus.NewServer(isolatedRuntime, bus.ServerOptions{})
+	isolatedAddr, err := isolatedServer.Start()
+	if err != nil {
+		t.Fatalf("start isolated server: %v", err)
+	}
+	defer isolatedServer.Stop(context.Background())
+	isolatedScope, err := isolatedRuntime.CreateScope(ctx, bus.CreateScopeInput{ID: "receipt-authz-isolated"})
+	if err != nil {
+		t.Fatalf("create isolated scope: %v", err)
+	}
+	outsider, err := (bus.Client{Address: isolatedAddr, Token: isolatedScope.ScopeToken}).RegisterAgent(ctx, bus.RegisterAgentInput{
+		ID: "outsider", DisplayName: "Outsider",
+	})
+	if err != nil {
+		t.Fatalf("register outsider: %v", err)
+	}
+
+	sender := bus.Client{Address: address, Token: senderToken}
+	initial, err := sender.SendMessage(ctx, bus.SendMessageInput{To: "receiver", Body: "secret"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	t.Setenv("OCTOBER_BUS_AGENT_TOKEN", outsider.AgentToken)
+	err = runInspectCapturing(&bytes.Buffer{}, "--address", address, initial.MessageID)
+	if err == nil {
+		t.Fatal("expected error when an outsider inspects a message they did not send or receive")
+	}
+	var busErr *bus.BusError
+	if !errors.As(err, &busErr) {
+		t.Fatalf("expected *bus.BusError, got %T: %v", err, err)
+	}
+	// The outsider's token is from a different runtime, so the runtime has
+	// no record of the principal and rejects with UNAUTHENTICATED. A
+	// NOT_FOUND (token valid but message not visible) is also acceptable;
+	// both outcomes prevent disclosure. Asserting the message body never
+	// appears anywhere in the captured output is the stronger guarantee.
+	if busErr.Code != bus.CodeUnauthenticated && busErr.Code != bus.CodeNotFound {
+		t.Errorf("expected CodeUnauthenticated or CodeNotFound, got %q", busErr.Code)
 	}
 }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,6 +15,24 @@ october-bus stop
 
 Use `october-bus doctor --json` for machine-readable diagnostics. It reports versions, paths, process state, and endpoint health. It does not print credentials or message content.
 
+## Inspect message delivery state
+
+Agents can inspect the durable delivery state of a message they sent or
+received without opening SQLite or writing a client program. The command
+requires the agent credential and never reveals message bodies or shared
+context — only the receipt.
+
+```bash
+october-bus message receipt <message-id> [--json] [--address <addr>]
+```
+
+The credential is read from `OCTOBER_BUS_AGENT_TOKEN`. The daemon address is
+resolved from `--address`, then the `OCTOBER_BUS_ADDRESS` environment
+variable, then the local run file. The output shows the current delivery
+state plus any timestamps that have been recorded (`accepted`, `delivered`,
+`acknowledged`, `replied`) and, when present, the linked response message
+ID. Use `--json` for a stable machine-readable form.
+
 ## Default paths
 
 | Platform | Data directory | Runtime directory |


### PR DESCRIPTION
## Summary

Adds `october-bus message receipt <message-id> [--json] [--address <addr>]` so an agent developer can inspect durable delivery state without opening SQLite or writing a client program.

Closes #17.

## What it does

- Reads the agent credential from `OCTOBER_BUS_AGENT_TOKEN`.
- Resolves the daemon address from `--address`, then `OCTOBER_BUS_ADDRESS`, then the local run file.
- Fetches the receipt through the existing public client API (`bus.Client.Receipt`).
- Renders state plus any recorded timestamps (`accepted`, `delivered`, `acknowledged`, `replied`) and the linked response message ID when present.
- Provides a stable `--json` form for tooling.

## Safety

The receipt is a metadata view by type — `DeliveryReceipt` carries only delivery state, timestamps, and the linked response message ID. Message bodies and shared context cannot appear in the output because they are never on the struct. Unauthorized callers (tokens from a different runtime, or agents that did not send/receive the message) are rejected with `UNAUTHENTICATED` or `NOT_FOUND`; both outcomes prevent disclosure.

## Tests

- `TestInspectReceiptRequiresArgs` — missing/empty message id.
- `TestInspectReceiptRequiresAgentToken` — missing env var.
- `TestPrintReceiptHumanOmitsEmptyTimestamps` — only present fields render.
- `TestInspectReceiptEndToEnd` — sends a message through an in-memory bus, pulls and acks it, then exercises both `--json` and human output via the CLI layer; asserts state progression, timestamp presence, and that the body never appears.
- `TestInspectReceiptUnknownMessageReturnsError` — `CodeNotFound`.
- `TestInspectReceiptRejectsUnauthorizedCaller` — outsider token rejected.

## Verification

- `go vet ./...` — clean
- `go test -race -count=1 ./...` — all packages pass (`a2abridge`, `bus`, `cmd/october-bus`, `conformance`, `spec`)
- `npm ci && npm run typecheck && npm run build && npm run test:errors` (in `sdk/typescript/`) — pass
- Manual smoke test against a running daemon: sends a message, pulls and acks it on the receiver side, then inspects as the sender and verifies all three timestamps appear in both human and JSON form.

## Docs

Added an "Inspect message delivery state" section to `docs/operations.md`.

Marked draft — happy to iterate on naming, flag shape, or output format before final review.