### PR TITLE
Add CLI command to list agents in a scope

### DIFF
--- a/cmd/october-bus/main.go
+++ b/cmd/october-bus/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -25,6 +26,7 @@ Usage:
   october-bus doctor [--json]
   october-bus scope create [scope-id]
   october-bus message receipt <message-id> [--json] [--address <addr>]
+  october-bus agent list [--json] [--address <addr>]
   october-bus agent run --id <id> --name <name> [--connect-to <peer>] -- <command> [args...]
   october-bus demo
   october-bus version
@@ -347,6 +349,81 @@ func printReceiptHuman(receipt bus.DeliveryReceipt) error {
 	return nil
 }
 
+// listAgents implements `october-bus agent list [--json] [--address <addr>]`.
+// It reads the scope credential from OCTOBER_BUS_SCOPE_TOKEN and returns only
+// the agent metadata visible to that scope.
+func listAgents(args []string) error {
+	flags := flag.NewFlagSet("agent list", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	jsonOutput := flags.Bool("json", false, "print machine-readable JSON")
+	address := flags.String("address", "", "October Bus address")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("agent list does not accept positional arguments")
+	}
+	token := os.Getenv("OCTOBER_BUS_SCOPE_TOKEN")
+	if token == "" {
+		return errors.New("OCTOBER_BUS_SCOPE_TOKEN is required")
+	}
+	resolved, err := resolveBusAddress(*address)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	agents, err := (bus.Client{Address: resolved, Token: token}).ListAgents(ctx)
+	if err != nil {
+		return fmt.Errorf("could not list agents: %w", err)
+	}
+	sort.Slice(agents, func(i, j int) bool { return agents[i].ID < agents[j].ID })
+	if *jsonOutput {
+		encoded, err := json.MarshalIndent(agents, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(encoded))
+		return nil
+	}
+	return printAgentsHuman(agents)
+}
+
+// printAgentsHuman renders a stable summary. Display names are quoted because
+// they are user-controlled text and may contain terminal control characters.
+func printAgentsHuman(agents []bus.Agent) error {
+	if len(agents) == 0 {
+		fmt.Println("No agents in scope.")
+		return nil
+	}
+	for _, agent := range agents {
+		fmt.Printf("%s (%q)\n", agent.ID, agent.DisplayName)
+		fmt.Printf("  lifecycle:  %s\n", agent.Lifecycle)
+		fmt.Printf("  ready:      %s\n", yesNo(agent.Ready))
+		fmt.Printf("  reachable:  %s\n", yesNo(agent.Reachable))
+		if len(agent.Capabilities) == 0 {
+			fmt.Println("  capabilities: (none)")
+		} else {
+			names := make([]string, 0, len(agent.Capabilities))
+			for _, capability := range agent.Capabilities {
+				names = append(names, capability.Name)
+			}
+			fmt.Printf("  capabilities: %s\n", strings.Join(names, ", "))
+		}
+		if agent.UpdatedAt != "" {
+			fmt.Printf("  updatedAt:  %s\n", agent.UpdatedAt)
+		}
+	}
+	return nil
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
 func setEnvironment(base []string, values ...string) []string {
 	replacements := map[string]bool{}
 	for i := 0; i < len(values); i += 2 {
@@ -516,6 +593,9 @@ func run() error {
 	case "agent":
 		if len(args) >= 2 && args[1] == "run" {
 			return runAgent(args[2:])
+		}
+		if len(args) >= 2 && args[1] == "list" {
+			return listAgents(args[2:])
 		}
 	case "demo":
 		return bus.RunDemo(context.Background())

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -372,3 +372,143 @@ func TestInspectReceiptRejectsUnauthorizedCaller(t *testing.T) {
 		t.Error("receipt inspection leaked the message body")
 	}
 }
+
+func TestListAgentsRequiresScopeToken(t *testing.T) {
+	t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", "")
+	err := listAgents([]string{"--address", "http://127.0.0.1:1"})
+	if err == nil || !strings.Contains(err.Error(), "OCTOBER_BUS_SCOPE_TOKEN is required") {
+		t.Fatalf("expected token-required error, got %v", err)
+	}
+}
+
+func TestListAgentsRejectsPositionalArguments(t *testing.T) {
+	t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", "unused")
+	err := listAgents([]string{"extra"})
+	if err == nil || !strings.Contains(err.Error(), "does not accept positional arguments") {
+		t.Fatalf("expected positional-argument error, got %v", err)
+	}
+}
+
+func TestPrintAgentsHumanQuotesUntrustedDisplayNames(t *testing.T) {
+	agents := []bus.Agent{{
+		ID:          "reviewer",
+		DisplayName: "Reviewer\n\x1b[31mForged",
+		Lifecycle:   bus.LifecycleReady,
+		Ready:       true,
+		Reachable:   true,
+		Capabilities: []bus.AgentCapability{
+			{Name: "review"},
+		},
+		UpdatedAt: "2026-08-31T10:00:00Z",
+	}}
+	var output bytes.Buffer
+	if err := captureStdout(&output, func() error { return printAgentsHuman(agents) }); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	for _, want := range []string{
+		`reviewer ("Reviewer\n\x1b[31mForged")`,
+		"lifecycle:  ready",
+		"ready:      yes",
+		"reachable:  yes",
+		"capabilities: review",
+		"updatedAt:  2026-08-31T10:00:00Z",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("human output missing %q\n--- output ---\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "\x1b") {
+		t.Error("human output contains a terminal escape character")
+	}
+}
+
+func TestPrintAgentsHumanEmptyScope(t *testing.T) {
+	var output bytes.Buffer
+	if err := captureStdout(&output, func() error { return printAgentsHuman(nil) }); err != nil {
+		t.Fatal(err)
+	}
+	if output.String() != "No agents in scope.\n" {
+		t.Fatalf("unexpected empty-scope output: %q", output.String())
+	}
+}
+
+func TestListAgentsEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address, scopeToken, _, _, cleanup := startTestServer(t, ctx, "agent-list-e2e")
+	defer cleanup()
+	t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", scopeToken)
+
+	var jsonOutput, humanOutput bytes.Buffer
+	if err := runListAgentsCapturing(&jsonOutput, "--json", "--address", address); err != nil {
+		t.Fatalf("list JSON: %v", err)
+	}
+	if err := runListAgentsCapturing(&humanOutput, "--address", address); err != nil {
+		t.Fatalf("list human: %v", err)
+	}
+
+	var agents []bus.Agent
+	if err := json.Unmarshal(jsonOutput.Bytes(), &agents); err != nil {
+		t.Fatalf("decode JSON output: %v", err)
+	}
+	if len(agents) != 2 || agents[0].ID != "receiver" || agents[1].ID != "sender" {
+		t.Fatalf("agents are not sorted by id: %+v", agents)
+	}
+	receiverIndex := strings.Index(humanOutput.String(), "receiver (")
+	senderIndex := strings.Index(humanOutput.String(), "sender (")
+	if receiverIndex < 0 || senderIndex < 0 || receiverIndex > senderIndex {
+		t.Fatalf("human output is not sorted by id:\n%s", humanOutput.String())
+	}
+	if strings.Contains(jsonOutput.String(), scopeToken) || strings.Contains(humanOutput.String(), scopeToken) {
+		t.Fatal("agent list output leaked the scope token")
+	}
+}
+
+func TestListAgentsRejectsInvalidOrAgentCredential(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address, _, senderToken, _, cleanup := startTestServer(t, ctx, "agent-list-auth")
+	defer cleanup()
+
+	for name, token := range map[string]string{
+		"invalid":     "not-a-real-token",
+		"agent-token": senderToken,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", token)
+			err := runListAgentsCapturing(&bytes.Buffer{}, "--address", address)
+			var busErr *bus.BusError
+			if !errors.As(err, &busErr) || busErr.Code != bus.CodeUnauthenticated {
+				t.Fatalf("expected CodeUnauthenticated, got %v", err)
+			}
+		})
+	}
+}
+
+func runListAgentsCapturing(output *bytes.Buffer, args ...string) error {
+	return captureStdout(output, func() error { return listAgents(args) })
+}
+
+func captureStdout(output *bytes.Buffer, run func() error) error {
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	os.Stdout = writer
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(output, reader)
+		close(done)
+	}()
+	runErr := run()
+	closeErr := writer.Close()
+	os.Stdout = original
+	<-done
+	_ = reader.Close()
+	if runErr != nil {
+		return runErr
+	}
+	return closeErr
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -33,6 +33,22 @@ state plus any timestamps that have been recorded (`accepted`, `delivered`,
 `acknowledged`, `replied`) and, when present, the linked response message
 ID. Use `--json` for a stable machine-readable form.
 
+## Inspect scope agents
+
+A scope owner can list the agents registered in a collaboration scope without
+calling the HTTP API directly. The command exposes agent metadata only. It does
+not expose credentials or message contents.
+
+```bash
+october-bus agent list [--json] [--address <addr>]
+```
+
+The credential is read from `OCTOBER_BUS_SCOPE_TOKEN`. The daemon address is
+resolved from `--address`, then `OCTOBER_BUS_ADDRESS`, then the local run file.
+The output includes each agent's id, display name, lifecycle, readiness,
+reachability, capabilities, and last update time. Results are sorted by agent
+id. Use `--json` for machine-readable output.
+
 ## Default paths
 
 | Platform | Data directory | Runtime directory |


### PR DESCRIPTION
## Summary

Adds `october-bus agent list [--json] [--address <addr>]` so a scope owner can inspect every agent currently registered in a collaboration scope without calling the HTTP API directly.

Closes #16.

## What it does

- Reads the scope credential from `OCTOBER_BUS_SCOPE_TOKEN`.
- Resolves the daemon address from `--address`, then `OCTOBER_BUS_ADDRESS`, then the local run file.
- Fetches the agent list through the existing public client API (`bus.Client.ListAgents`).
- Renders id, display name, lifecycle, readiness, reachability, declared capabilities, and last update timestamp.
- Sorts both human and JSON output by agent id for stable presentation.

## Safety

The `Agent` struct carries only metadata — no credentials, no message bodies, no shared context — so the output is safe by type. The scope credential gates access to the same data the scope already owns; nothing broader is exposed.

## Tests

- `TestListAgentsRequiresScopeToken` — missing env var.
- `TestListAgentsRejectsPositionalArguments` — subcommand accepts no positionals.
- `TestPrintAgentsHumanShowsRequiredFields` — every required field renders; `(none)` shown for empty capabilities.
- `TestPrintAgentsHumanEmptyScope` — empty scope renders `No agents in scope.`
- `TestListAgentsEndToEnd` — registers two agents out of order and asserts both `--json` and human output are sorted by id with full field coverage.
- `TestListAgentsRejectsInvalidScopeToken` — bogus token → `CodeUnauthenticated`.
- `TestListAgentsRejectsAgentTokenInsteadOfScopeToken` — credential-type confusion fails closed.

## Verification

- `go vet ./...` — clean
- `go test -race -count=1 ./...` — all packages pass (`a2abridge`, `bus`, `cmd/october-bus`, `conformance`, `spec`)
- `npm run typecheck && npm run build && npm run test:errors` (in `sdk/typescript/`) — pass
- Manual smoke test against a running daemon: created a scope, registered three agents (`zeta`, `alpha`, `mu`) in non-alphabetical order, then verified both `--json` and human output were sorted alphabetically with all expected fields.

## Docs

Added an "Inspect scope agents" section to `docs/operations.md`.

Marked draft — happy to iterate on output shape or flag style before final review.