### PR TITLE
Make Agent Card handler cache policy configurable

### DIFF
--- a/a2abridge/card_test.go
+++ b/a2abridge/card_test.go
@@ -269,6 +269,50 @@ func TestAgentCardHandlerIfModifiedSinceInvalidDateTreatedAsMiss(t *testing.T) {
 	}
 }
 
+func TestAgentCardHandlerIfNoneMatchPrecedesIfModifiedSince(t *testing.T) {
+	fixed := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: time.Minute,
+		LastModified:  fixed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil)
+	request.Header.Set("If-None-Match", `"different"`)
+	request.Header.Set("If-Modified-Since", fixed.Format(http.TimeFormat))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("non-matching If-None-Match must ignore matching date: status = %d, want %d", response.Code, http.StatusOK)
+	}
+}
+
+func TestAgentCardHandlerSupportsStandardIfNoneMatchForms(t *testing.T) {
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := httptest.NewRecorder()
+	handler.ServeHTTP(initial, httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil))
+	etag := initial.Header().Get("ETag")
+	for name, value := range map[string]string{
+		"weak":     "W/" + etag,
+		"list":     `"different", ` + etag,
+		"wildcard": "*",
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil)
+			request.Header.Set("If-None-Match", value)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusNotModified {
+				t.Fatalf("If-None-Match %q: status = %d, want %d", value, response.Code, http.StatusNotModified)
+			}
+		})
+	}
+}
+
 func TestAgentCardHandlerCacheHeadersStayConsistent(t *testing.T) {
 	fixed := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
 	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{

--- a/a2abridge/card_test.go
+++ b/a2abridge/card_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
@@ -141,5 +142,162 @@ func TestAgentCardHandlerRejectsUnsupportedMethods(t *testing.T) {
 	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, a2abridge.AgentCardPath, nil))
 	if response.Code != http.StatusMethodNotAllowed || response.Header().Get("Allow") != "GET, HEAD, OPTIONS" {
 		t.Fatalf("unexpected response: %d, %q", response.Code, response.Header().Get("Allow"))
+	}
+}
+
+// makeTestCard returns a small valid card used by the cache-policy tests
+// below. Each test calls it fresh so failures cannot bleed between cases.
+func makeTestCard(t *testing.T) *a2a.AgentCard {
+	t.Helper()
+	card, err := a2abridge.NewAgentCard(bus.Agent{DisplayName: "Reviewer"}, a2abridge.CardOptions{
+		InterfaceURL: "https://agents.example.com/reviewer",
+		Version:      "1.2.3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return card
+}
+
+func TestAgentCardHandlerHonoursCustomCacheLifetime(t *testing.T) {
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil))
+	if got := response.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=300")
+	}
+}
+
+func TestAgentCardHandlerSupportsZeroCacheLifetime(t *testing.T) {
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil))
+	if got := response.Header().Get("Cache-Control"); got != "public, max-age=0" {
+		t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=0")
+	}
+}
+
+func TestAgentCardHandlerRejectsNegativeCacheLifetime(t *testing.T) {
+	_, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: -time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "must not be negative") {
+		t.Fatalf("expected negative-lifetime rejection, got %v", err)
+	}
+}
+
+func TestAgentCardHandlerRejectsExcessiveCacheLifetime(t *testing.T) {
+	_, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: 48 * time.Hour,
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeds the maximum") {
+		t.Fatalf("expected excessive-lifetime rejection, got %v", err)
+	}
+}
+
+func TestAgentCardHandlerHonoursFixedLastModified(t *testing.T) {
+	fixed := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: time.Minute,
+		LastModified:  fixed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil))
+	wantLastModified := fixed.Format(http.TimeFormat)
+	if got := response.Header().Get("Last-Modified"); got != wantLastModified {
+		t.Errorf("Last-Modified = %q, want %q", got, wantLastModified)
+	}
+
+	// Conditional GET against a time matching the card should return 304.
+	conditional := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil)
+	request.Header.Set("If-Modified-Since", wantLastModified)
+	handler.ServeHTTP(conditional, request)
+	if conditional.Code != http.StatusNotModified {
+		t.Errorf("If-Modified-Since match: status = %d, want %d", conditional.Code, http.StatusNotModified)
+	}
+}
+
+func TestAgentCardHandlerIfModifiedSinceMissReturnsFullResponse(t *testing.T) {
+	fixed := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: time.Minute,
+		LastModified:  fixed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The client claims to have a version older than the card's last update.
+	stale := fixed.Add(-time.Hour).Format(http.TimeFormat)
+	request := httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil)
+	request.Header.Set("If-Modified-Since", stale)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Errorf("stale If-Modified-Since: status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if response.Body.Len() == 0 {
+		t.Error("stale If-Modified-Since should return a body, got empty")
+	}
+}
+
+func TestAgentCardHandlerIfModifiedSinceInvalidDateTreatedAsMiss(t *testing.T) {
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil)
+	request.Header.Set("If-Modified-Since", "not-a-valid-http-date")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Errorf("invalid If-Modified-Since: status = %d, want %d (full response)", response.Code, http.StatusOK)
+	}
+}
+
+func TestAgentCardHandlerCacheHeadersStayConsistent(t *testing.T) {
+	fixed := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
+	handler, err := a2abridge.NewAgentCardHandlerWithOptions(makeTestCard(t), a2abridge.HandlerOptions{
+		CacheLifetime: 30 * time.Second,
+		LastModified:  fixed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Issue several requests and confirm the trio (ETag, Cache-Control,
+	// Last-Modified) is byte-identical across them.
+	var firstETag, firstCacheControl, firstLastModified string
+	for i := 0; i < 5; i++ {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, a2abridge.AgentCardPath, nil))
+		if firstETag == "" {
+			firstETag = response.Header().Get("ETag")
+			firstCacheControl = response.Header().Get("Cache-Control")
+			firstLastModified = response.Header().Get("Last-Modified")
+			continue
+		}
+		if got := response.Header().Get("ETag"); got != firstETag {
+			t.Errorf("request %d: ETag drifted to %q (was %q)", i, got, firstETag)
+		}
+		if got := response.Header().Get("Cache-Control"); got != firstCacheControl {
+			t.Errorf("request %d: Cache-Control drifted to %q (was %q)", i, got, firstCacheControl)
+		}
+		if got := response.Header().Get("Last-Modified"); got != firstLastModified {
+			t.Errorf("request %d: Last-Modified drifted to %q (was %q)", i, got, firstLastModified)
+		}
 	}
 }

--- a/a2abridge/handler.go
+++ b/a2abridge/handler.go
@@ -5,17 +5,71 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 )
 
-const AgentCardPath = "/.well-known/agent-card.json"
+const (
+	AgentCardPath = "/.well-known/agent-card.json"
 
+	// DefaultAgentCardCacheLifetime is the Cache-Control max-age applied by
+	// NewAgentCardHandler when the caller does not specify a value. It
+	// matches the conservative lifetime the A2A bridge shipped with before
+	// the policy became configurable.
+	DefaultAgentCardCacheLifetime = 60 * time.Second
+
+	// MaxAgentCardCacheLifetime caps the cache lifetime a caller can
+	// request. Twenty-four hours is generous for any realistic agent card
+	// and prevents a misconfigured caller from effectively pinning a card
+	// forever.
+	MaxAgentCardCacheLifetime = 24 * time.Hour
+)
+
+// HandlerOptions controls HTTP delivery behaviour for the Agent Card handler.
+// Card *content* lives on CardOptions; these options only shape caching and
+// conditional request handling.
+type HandlerOptions struct {
+	// CacheLifetime is the max-age value emitted in the Cache-Control
+	// response header. Zero means "revalidate every time." Negative values
+	// and values greater than MaxAgentCardCacheLifetime are rejected at
+	// construction time.
+	CacheLifetime time.Duration
+
+	// LastModified overrides the Last-Modified response header. When zero,
+	// the handler uses the current time truncated to one second, matching
+	// the original bridge behaviour. Setting a fixed time is useful for
+	// cards that are pinned to a known release.
+	LastModified time.Time
+}
+
+// NewAgentCardHandler returns an http.Handler that serves the given Agent
+// Card with the default cache policy (60-second max-age, the current time
+// as Last-Modified). Use NewAgentCardHandlerWithOptions to override either
+// value.
 func NewAgentCardHandler(card *a2a.AgentCard) (http.Handler, error) {
+	return NewAgentCardHandlerWithOptions(card, HandlerOptions{CacheLifetime: DefaultAgentCardCacheLifetime})
+}
+
+// NewAgentCardHandlerWithOptions returns an http.Handler that serves the
+// given Agent Card with a configurable cache policy. The ETag, Cache-Control
+// and Last-Modified headers are computed once at construction time and stay
+// consistent for every request handled by the returned http.Handler.
+//
+// The handler honours both If-None-Match (compared against the ETag) and
+// If-Modified-Since (compared against Last-Modified), returning 304 Not
+// Modified when either matches.
+func NewAgentCardHandlerWithOptions(card *a2a.AgentCard, options HandlerOptions) (http.Handler, error) {
 	if card == nil {
 		return nil, errors.New("agent card is required")
+	}
+	if options.CacheLifetime < 0 {
+		return nil, fmt.Errorf("agent card cache lifetime must not be negative, got %s", options.CacheLifetime)
+	}
+	if options.CacheLifetime > MaxAgentCardCacheLifetime {
+		return nil, fmt.Errorf("agent card cache lifetime %s exceeds the maximum of %s", options.CacheLifetime, MaxAgentCardCacheLifetime)
 	}
 	body, err := json.Marshal(card)
 	if err != nil {
@@ -23,22 +77,27 @@ func NewAgentCardHandler(card *a2a.AgentCard) (http.Handler, error) {
 	}
 	digest := sha256.Sum256(body)
 	etag := `"` + hex.EncodeToString(digest[:]) + `"`
-	lastModified := time.Now().UTC().Truncate(time.Second).Format(http.TimeFormat)
+	cacheControl := fmt.Sprintf("public, max-age=%d", int(options.CacheLifetime.Seconds()))
+	lastModified := options.LastModified
+	if lastModified.IsZero() {
+		lastModified = time.Now().UTC()
+	}
+	lastModifiedHeader := lastModified.UTC().Truncate(time.Second).Format(http.TimeFormat)
 
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.Header().Set("Allow", "GET, HEAD, OPTIONS")
 		response.Header().Set("Access-Control-Allow-Origin", "*")
 		response.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
-		response.Header().Set("Cache-Control", "public, max-age=60")
+		response.Header().Set("Cache-Control", cacheControl)
 		response.Header().Set("Content-Type", "application/json")
 		response.Header().Set("ETag", etag)
-		response.Header().Set("Last-Modified", lastModified)
+		response.Header().Set("Last-Modified", lastModifiedHeader)
 
 		switch request.Method {
 		case http.MethodOptions:
 			response.WriteHeader(http.StatusNoContent)
 		case http.MethodGet, http.MethodHead:
-			if request.Header.Get("If-None-Match") == etag {
+			if requestMatchesCache(request, etag, lastModified) {
 				response.WriteHeader(http.StatusNotModified)
 				return
 			}
@@ -50,4 +109,29 @@ func NewAgentCardHandler(card *a2a.AgentCard) (http.Handler, error) {
 			response.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	}), nil
+}
+
+// requestMatchesCache returns true when the request carries either an
+// If-None-Match value equal to etag or an If-Modified-Since value equal to
+// or later than lastModified.
+func requestMatchesCache(request *http.Request, etag string, lastModified time.Time) bool {
+	if header := request.Header.Get("If-None-Match"); header != "" && header == etag {
+		return true
+	}
+	header := request.Header.Get("If-Modified-Since")
+	if header == "" {
+		return false
+	}
+	since, err := http.ParseTime(header)
+	if err != nil {
+		// Per RFC 7232 an invalid date is treated as "never matches" so the
+		// caller receives the full response rather than a misleading 304.
+		return false
+	}
+	// Compare at second precision: Last-Modified is truncated to one second
+	// and If-Modified-Since has only second precision in HTTP. Per RFC 7232
+	// §3.3 the condition matches when the resource's last modification date
+	// is earlier than or equal to the client-supplied date — that is, when
+	// the client's copy is at least as new as the resource.
+	return !since.Truncate(time.Second).Before(lastModified.Truncate(time.Second))
 }

--- a/a2abridge/handler.go
+++ b/a2abridge/handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -111,12 +112,12 @@ func NewAgentCardHandlerWithOptions(card *a2a.AgentCard, options HandlerOptions)
 	}), nil
 }
 
-// requestMatchesCache returns true when the request carries either an
-// If-None-Match value equal to etag or an If-Modified-Since value equal to
-// or later than lastModified.
+// requestMatchesCache evaluates If-None-Match before If-Modified-Since, as
+// required by HTTP. If-Modified-Since is ignored whenever If-None-Match is
+// present, including when none of its entity tags match.
 func requestMatchesCache(request *http.Request, etag string, lastModified time.Time) bool {
-	if header := request.Header.Get("If-None-Match"); header != "" && header == etag {
-		return true
+	if values := request.Header.Values("If-None-Match"); len(values) > 0 {
+		return ifNoneMatchMatches(values, etag)
 	}
 	header := request.Header.Get("If-Modified-Since")
 	if header == "" {
@@ -134,4 +135,23 @@ func requestMatchesCache(request *http.Request, etag string, lastModified time.T
 	// is earlier than or equal to the client-supplied date — that is, when
 	// the client's copy is at least as new as the resource.
 	return !since.Truncate(time.Second).Before(lastModified.Truncate(time.Second))
+}
+
+// ifNoneMatchMatches uses weak entity-tag comparison for GET and HEAD cache
+// validation. It accepts multiple header lines, comma-separated lists, weak
+// tags, and the wildcard form.
+func ifNoneMatchMatches(values []string, etag string) bool {
+	target := strings.TrimPrefix(strings.TrimSpace(etag), "W/")
+	for _, value := range values {
+		for _, candidate := range strings.Split(value, ",") {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "*" {
+				return true
+			}
+			if strings.TrimPrefix(candidate, "W/") == target {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/docs/architecture/a2a-bridge.md
+++ b/docs/architecture/a2a-bridge.md
@@ -38,12 +38,11 @@ to override either value via `HandlerOptions.CacheLifetime` and
 `HandlerOptions.LastModified`. The cache lifetime must be non-negative
 and at most 24 hours; the constructor rejects other values.
 
-The handler honours both `If-None-Match` (compared against the `ETag`)
-and `If-Modified-Since` (compared against `Last-Modified` at second
-precision), returning `304 Not Modified` when either matches. The three
-headers (`ETag`, `Cache-Control`, `Last-Modified`) are computed once at
-construction time and stay consistent for every request served by a
-given handler instance.
+The handler honours both `If-None-Match` and `If-Modified-Since`. It supports
+weak tags, tag lists, and wildcard cache validation. `If-None-Match` takes
+precedence when both headers are present. The `ETag`, `Cache-Control`, and
+`Last-Modified` headers are computed once and remain consistent for every
+request served by a handler instance.
 
 ## Extensions
 

--- a/docs/architecture/a2a-bridge.md
+++ b/docs/architecture/a2a-bridge.md
@@ -29,6 +29,22 @@ SDK versions and A2A protocol versions are independent. The bridge records both.
 
 The initial package generates and serves read-only Agent Cards. It does not implement A2A message or task operations yet.
 
+### Handler caching and conditional requests
+
+The handler returned by `a2abridge.NewAgentCardHandler` defaults to a
+60-second `Cache-Control: public, max-age=60` policy with the current
+time as `Last-Modified`. Use `a2abridge.NewAgentCardHandlerWithOptions`
+to override either value via `HandlerOptions.CacheLifetime` and
+`HandlerOptions.LastModified`. The cache lifetime must be non-negative
+and at most 24 hours; the constructor rejects other values.
+
+The handler honours both `If-None-Match` (compared against the `ETag`)
+and `If-Modified-Since` (compared against `Last-Modified` at second
+precision), returning `304 Not Modified` when either matches. The three
+headers (`ETag`, `Cache-Control`, `Last-Modified`) are computed once at
+construction time and stay consistent for every request served by a
+given handler instance.
+
 ## Extensions
 
 Core A2A behavior is implemented before any October-specific extension. Extension identifiers are not published until their domain and lifecycle are established. Extension support will have separate conformance evidence from core A2A support.


### PR DESCRIPTION
## Summary

Adds `a2abridge.NewAgentCardHandlerWithOptions(card, HandlerOptions)` so deployments can override the `Cache-Control` max-age and `Last-Modified` header that the Agent Card HTTP handler emits. The original `NewAgentCardHandler(card)` constructor is preserved as a thin wrapper that pins the cache lifetime to a new `DefaultAgentCardCacheLifetime` constant (60 seconds), so existing callers see no behaviour change.

Closes #6.

## What it does

- Adds `HandlerOptions{CacheLifetime, LastModified}` and the new constructor.
- Validates `CacheLifetime`: rejects negative values and values greater than `MaxAgentCardCacheLifetime` (24 hours) at construction time.
- Honours `If-None-Match` (already present) and `If-Modified-Since` (new), returning `304 Not Modified` when either matches.
- Treats an unparseable `If-Modified-Since` as a miss and yields a full response, per RFC 7232 §3.3.
- Computes the `ETag`, `Cache-Control`, and `Last-Modified` headers once at construction time and keeps them byte-identical across every request served by a given handler instance.

## Bug found and fixed

While writing the `If-Modified-Since` tests I caught an inverted comparison that would have shipped broken conditional-request semantics — the original (pre-PR) handler didn't implement `If-Modified-Since` at all, so this was net-new behaviour, but the first draft of my implementation had the comparison backwards. The new tests pin the correct RFC 7232 §3.3 semantics: 304 is returned only when the resource's last modification date is *earlier than or equal to* the client-supplied date, i.e. the client's copy is at least as new as the resource. Both directions are tested.

## Tests

- `TestAgentCardHandlerHonoursCustomCacheLifetime` — custom duration surfaces in `Cache-Control`.
- `TestAgentCardHandlerSupportsZeroCacheLifetime` — `0` is valid and emits `max-age=0` (revalidate every time).
- `TestAgentCardHandlerRejectsNegativeCacheLifetime` — negative durations rejected.
- `TestAgentCardHandlerRejectsExcessiveCacheLifetime` — over 24 h rejected.
- `TestAgentCardHandlerHonoursFixedLastModified` — fixed `Last-Modified` and `If-Modified-Since` matching returns 304.
- `TestAgentCardHandlerIfModifiedSinceMissReturnsFullResponse` — stale `If-Modified-Since` returns 200 + body.
- `TestAgentCardHandlerIfModifiedSinceInvalidDateTreatedAsMiss` — unparseable dates fall back to full response.
- `TestAgentCardHandlerCacheHeadersStayConsistent` — `ETag`, `Cache-Control`, `Last-Modified` byte-identical across 5 sequential requests.

The four pre-existing `a2abridge` tests continue to pass unchanged.

## Verification

- `go vet ./...` — clean
- `go test -race -count=1 ./...` — all packages pass (`a2abridge`, `bus`, `cmd/october-bus`, `conformance`, `spec`)
- `npm run typecheck && npm run build && npm run test:errors` (in `sdk/typescript/`) — pass

## Docs

Added a "Handler caching and conditional requests" subsection to `docs/architecture/a2a-bridge.md`.

Marked draft — happy to iterate on the lifetime bounds, the option-name conventions, or whether to add a `s-maxage` field before final review.
