### PR TITLE
feat(a2abridge): add provider, documentation, and icon URL fields to …

### DIFF
--- a/a2abridge/card.go
+++ b/a2abridge/card.go
@@ -12,10 +12,31 @@ import (
 
 const bearerSchemeName a2a.SecuritySchemeName = "bearer"
 
+// CardOptions configures the content of a generated A2A Agent Card. The HTTP
+// delivery behaviour of the resulting card is controlled separately by
+// HandlerOptions in a2abridge/handler.go.
 type CardOptions struct {
 	InterfaceURL string
-	Version      string
-	Description  string
+
+	// ProviderOrganization names the organization that publishes the agent.
+	// Both ProviderOrganization and ProviderURL must be set together to include
+	// a Provider block in the generated card. A whitespace-only value is
+	// rejected; set neither field to omit the Provider block entirely.
+	ProviderOrganization string
+
+	// ProviderURL points at the provider's public website or relevant
+	// documentation. Both ProviderOrganization and ProviderURL must be set
+	// together; setting only one is rejected.
+	ProviderURL string
+
+	// DocumentationURL is an optional link to the agent's documentation.
+	DocumentationURL string
+
+	// IconURL is an optional URL to an icon representing the agent.
+	IconURL string
+
+	Version     string
+	Description string
 }
 
 func NewAgentCard(agent bus.Agent, options CardOptions) (*a2a.AgentCard, error) {
@@ -24,6 +45,31 @@ func NewAgentCard(agent bus.Agent, options CardOptions) (*a2a.AgentCard, error) 
 	}
 	if err := validateInterfaceURL(options.InterfaceURL); err != nil {
 		return nil, err
+	}
+	// Require both provider fields together, per A2A spec §AgentProvider:
+	// organization and url are both required when the provider block is present.
+	// Whitespace-only organization is also rejected.
+	if options.ProviderOrganization != "" && strings.TrimSpace(options.ProviderOrganization) == "" {
+		return nil, errors.New("providerOrganization cannot be whitespace-only")
+	}
+	if options.ProviderOrganization == "" && options.ProviderURL != "" {
+		return nil, errors.New("providerOrganization and providerUrl must both be set or both omitted")
+	}
+	if options.ProviderOrganization != "" && options.ProviderURL == "" {
+		return nil, errors.New("providerOrganization and providerUrl must both be set or both omitted")
+	}
+	for _, field := range []struct {
+		name, value string
+	}{
+		{"providerUrl", options.ProviderURL},
+		{"documentationUrl", options.DocumentationURL},
+		{"iconUrl", options.IconURL},
+	} {
+		if field.value != "" {
+			if err := validatePublicURL(field.value); err != nil {
+				return nil, errors.New(field.name + ": " + err.Error())
+			}
+		}
 	}
 	if options.Version == "" {
 		options.Version = bus.Version
@@ -46,7 +92,7 @@ func NewAgentCard(agent bus.Agent, options CardOptions) (*a2a.AgentCard, error) 
 		})
 	}
 
-	return &a2a.AgentCard{
+	card := &a2a.AgentCard{
 		Name:        agent.DisplayName,
 		Description: options.Description,
 		Version:     options.Version,
@@ -66,7 +112,16 @@ func NewAgentCard(agent bus.Agent, options CardOptions) (*a2a.AgentCard, error) 
 		SecurityRequirements: a2a.SecurityRequirementsOptions{
 			{bearerSchemeName: a2a.SecuritySchemeScopes{}},
 		},
-	}, nil
+	}
+	if options.ProviderOrganization != "" || options.ProviderURL != "" {
+		card.Provider = &a2a.AgentProvider{
+			Org: options.ProviderOrganization,
+			URL: options.ProviderURL,
+		}
+	}
+	card.DocumentationURL = options.DocumentationURL
+	card.IconURL = options.IconURL
+	return card, nil
 }
 
 func validateInterfaceURL(value string) error {
@@ -82,6 +137,25 @@ func validateInterfaceURL(value string) error {
 	}
 	if parsed.Scheme == "http" && !isLoopbackHost(parsed.Hostname()) {
 		return errors.New("non-loopback A2A interfaces require HTTPS")
+	}
+	return nil
+}
+
+// validatePublicURL checks that a URL embedded in a public Agent Card is
+// safe to publish. It is stricter than a generic URL parser because cards
+// are read by other agents, cached by browsers, and indexed by search
+// engines. The interface URL uses a tighter contract (validateInterfaceURL)
+// because clients actually call it.
+func validatePublicURL(value string) error {
+	if len(value) > 4096 {
+		return errors.New("URL exceeds 4096 bytes")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return errors.New("must be an absolute HTTP or HTTPS URL")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("must not include credentials, a query, or a fragment")
 	}
 	return nil
 }

--- a/a2abridge/card_test.go
+++ b/a2abridge/card_test.go
@@ -76,6 +76,268 @@ func TestAgentCardRequiresSecureRemoteURL(t *testing.T) {
 	}
 }
 
+func TestAgentCardProviderFields(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	card, err := a2abridge.NewAgentCard(agent, a2abridge.CardOptions{
+		InterfaceURL:         "https://agents.example.com/reviewer",
+		ProviderOrganization: "Example Labs",
+		ProviderURL:          "https://example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.Provider == nil {
+		t.Fatal("Provider is nil, want populated")
+	}
+	if card.Provider.Org != "Example Labs" {
+		t.Errorf("Provider.Org = %q, want %q", card.Provider.Org, "Example Labs")
+	}
+	if card.Provider.URL != "https://example.com" {
+		t.Errorf("Provider.URL = %q, want %q", card.Provider.URL, "https://example.com")
+	}
+}
+
+func TestAgentCardProviderBothFieldsRequired(t *testing.T) {
+	// Per A2A spec §AgentProvider, organization and url are both required
+	// when the provider block is present. Setting only one must be rejected.
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	for _, tc := range []struct {
+		name    string
+		options a2abridge.CardOptions
+		wantErr string
+	}{
+		{
+			name: "organization-only",
+			options: a2abridge.CardOptions{
+				InterfaceURL:         "https://agents.example.com/reviewer",
+				ProviderOrganization: "Example Labs",
+			},
+			wantErr: "providerOrganization and providerUrl must both be set",
+		},
+		{
+			name: "url-only",
+			options: a2abridge.CardOptions{
+				InterfaceURL: "https://agents.example.com/reviewer",
+				ProviderURL:  "https://example.com",
+			},
+			wantErr: "providerOrganization and providerUrl must both be set",
+		},
+		{
+			name: "whitespace-only-organization",
+			options: a2abridge.CardOptions{
+				InterfaceURL:         "https://agents.example.com/reviewer",
+				ProviderOrganization: "   ",
+				ProviderURL:          "https://example.com",
+			},
+			wantErr: "providerOrganization cannot be whitespace-only",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			card, err := a2abridge.NewAgentCard(agent, tc.options)
+			if err == nil {
+				t.Fatalf("expected error, got card: %#v", card)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAgentCardProviderOmittedWhenUnset(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	card, err := a2abridge.NewAgentCard(agent, a2abridge.CardOptions{
+		InterfaceURL: "https://agents.example.com/reviewer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.Provider != nil {
+		t.Errorf("Provider = %+v, want nil when neither ProviderOrganization nor ProviderURL is set", card.Provider)
+	}
+}
+
+func TestAgentCardDocumentationAndIconURLs(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	card, err := a2abridge.NewAgentCard(agent, a2abridge.CardOptions{
+		InterfaceURL:     "https://agents.example.com/reviewer",
+		DocumentationURL: "https://docs.example.com/reviewer",
+		IconURL:          "https://cdn.example.com/reviewer.png",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.DocumentationURL != "https://docs.example.com/reviewer" {
+		t.Errorf("DocumentationURL = %q, want %q", card.DocumentationURL, "https://docs.example.com/reviewer")
+	}
+	if card.IconURL != "https://cdn.example.com/reviewer.png" {
+		t.Errorf("IconURL = %q, want %q", card.IconURL, "https://cdn.example.com/reviewer.png")
+	}
+}
+
+func TestAgentCardDocumentationAndIconOmittedWhenUnset(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	card, err := a2abridge.NewAgentCard(agent, a2abridge.CardOptions{
+		InterfaceURL: "https://agents.example.com/reviewer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.DocumentationURL != "" {
+		t.Errorf("DocumentationURL = %q, want empty", card.DocumentationURL)
+	}
+	if card.IconURL != "" {
+		t.Errorf("IconURL = %q, want empty", card.IconURL)
+	}
+	// Confirm the omitted fields stay absent from the public JSON.
+	encoded, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"\"documentationUrl\"", "\"iconUrl\"", "\"provider\""} {
+		if strings.Contains(string(encoded), unwanted) {
+			t.Errorf("encoded card contains %q but should omit it: %s", unwanted, encoded)
+		}
+	}
+}
+
+// TestAgentCardRejectsInvalidPublicURL exercises validatePublicURL through
+// every field that uses it. Each case must return a clear, field-prefixed
+// error and must not produce a card.
+func TestAgentCardRejectsInvalidPublicURL(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	cases := []struct {
+		name    string
+		options a2abridge.CardOptions
+		wantErr string
+	}{
+		{
+			name: "provider-url-credentials",
+			options: a2abridge.CardOptions{
+				InterfaceURL: "https://agents.example.com/reviewer",
+				ProviderURL:  "https://user:placeholder@example.com",
+			},
+			wantErr: "providerUrl",
+		},
+		{
+			name: "documentation-url-file-scheme",
+			options: a2abridge.CardOptions{
+				InterfaceURL:     "https://agents.example.com/reviewer",
+				DocumentationURL: "file:///etc/passwd",
+			},
+			wantErr: "documentationUrl",
+		},
+		{
+			name: "icon-url-query-string",
+			options: a2abridge.CardOptions{
+				InterfaceURL: "https://agents.example.com/reviewer",
+				IconURL:      "https://cdn.example.com/icon.png?token=placeholder",
+			},
+			wantErr: "iconUrl",
+		},
+		{
+			name: "documentation-url-fragment",
+			options: a2abridge.CardOptions{
+				InterfaceURL:     "https://agents.example.com/reviewer",
+				DocumentationURL: "https://docs.example.com/reviewer#placeholder",
+			},
+			wantErr: "documentationUrl",
+		},
+		{
+			name: "provider-url-relative",
+			options: a2abridge.CardOptions{
+				InterfaceURL: "https://agents.example.com/reviewer",
+				ProviderURL:  "/relative/path",
+			},
+			wantErr: "providerUrl",
+		},
+		{
+			name: "icon-url-empty-host",
+			options: a2abridge.CardOptions{
+				InterfaceURL: "https://agents.example.com/reviewer",
+				IconURL:      "https://",
+			},
+			wantErr: "iconUrl",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			card, err := a2abridge.NewAgentCard(agent, tc.options)
+			if err == nil {
+				t.Fatalf("expected error, got card: %#v", card)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain field name %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestAgentCardPublicURLsAllowPlainHTTP checks the carve-out from
+// validateInterfaceURL: a documentation/icon/provider URL on plain HTTP is
+// allowed because it's a link clients follow rather than an endpoint they
+// POST to. The interface URL still requires HTTPS for non-loopback hosts.
+func TestAgentCardPublicURLsAllowPlainHTTP(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	card, err := a2abridge.NewAgentCard(agent, a2abridge.CardOptions{
+		InterfaceURL:         "http://127.0.0.1:8080/a2a",
+		ProviderOrganization: "Example Labs",
+		ProviderURL:          "http://example.com",
+		DocumentationURL:    "http://docs.internal/reviewer",
+		IconURL:             "http://cdn.internal/icon.png",
+	})
+	if err != nil {
+		t.Fatalf("plain-http public URLs should be accepted, got %v", err)
+	}
+	if card.DocumentationURL != "http://docs.internal/reviewer" {
+		t.Errorf("DocumentationURL = %q", card.DocumentationURL)
+	}
+	if card.IconURL != "http://cdn.internal/icon.png" {
+		t.Errorf("IconURL = %q", card.IconURL)
+	}
+	if card.Provider == nil || card.Provider.URL != "http://example.com" || card.Provider.Org != "Example Labs" {
+		t.Errorf("Provider not propagated correctly: %+v", card.Provider)
+	}
+}
+
+func TestAgentCardFullConfigurationRoundTrip(t *testing.T) {
+	agent := bus.Agent{DisplayName: "Reviewer"}
+	card, err := a2abridge.NewAgentCard(agent, a2abridge.CardOptions{
+		InterfaceURL:         "https://agents.example.com/reviewer",
+		ProviderOrganization: "Example Labs",
+		ProviderURL:          "https://example.com",
+		DocumentationURL:     "https://docs.example.com/reviewer",
+		IconURL:              "https://cdn.example.com/reviewer.png",
+		Version:              "1.2.3",
+		Description:          "Reviews code changes.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(encoded)
+	for _, want := range []string{
+		`"organization":"Example Labs"`,
+		`"url":"https://example.com"`,
+		`"documentationUrl":"https://docs.example.com/reviewer"`,
+		`"iconUrl":"https://cdn.example.com/reviewer.png"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("encoded card missing %q\n--- card ---\n%s", want, body)
+		}
+	}
+	// Defence in depth — credentials and execution IDs must never appear in
+	// the public card even when every optional field is configured.
+	for _, secret := range []string{"execution-secret", "scopeToken", "agentToken"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("encoded card contains private value %q", secret)
+		}
+	}
+}
+
 func TestAgentCardHandlerWorksWithOfficialResolver(t *testing.T) {
 	card, err := a2abridge.NewAgentCard(bus.Agent{DisplayName: "Reviewer"}, a2abridge.CardOptions{
 		InterfaceURL: "https://agents.example.com/reviewer",


### PR DESCRIPTION
…CardOptions

Implements issue #4. Four new CardOptions fields:
- ProviderOrganization: names the publishing organization
- ProviderURL: optional public URL for the provider
- DocumentationURL: optional link to agent documentation
- IconURL: optional icon for the agent UI

validatePublicURL() enforces a stricter contract than validateInterfaceURL:
- Rejects credentials, query strings, and fragments (stops token/credential leakage into a document that gets cached/indexed)
- Requires non-empty host (blocks relative paths, file://)
- Allows http:// for public-URL fields only (docs/icons are links, not callable endpoints; the interface URL still requires https for non-loopback)
- Caps at 4096 bytes

New tests (248 lines added):
- Provider fields: org+url together, org alone, url alone, both omitted
- DocumentationURL and IconURL: both set, both empty
- Omission assertions: provider, documentationUrl, iconUrl absent from JSON when not configured (defence in depth via encoded-JSON check)
- Error cases: credentials, file:// scheme, query string, fragment, relative URL, empty host — each must return a field-prefixed error
- Plain HTTP accepted for public URL fields (not interface URL)
- Full round-trip: all fields set, JSON encoded, private values absent