### PR TITLE
Add bounded long-poll inbox delivery

### DIFF
--- a/bus/client.go
+++ b/bus/client.go
@@ -128,8 +128,12 @@ func (c Client) Receipt(ctx context.Context, messageID string) (DeliveryReceipt,
 	return request[DeliveryReceipt](ctx, c, http.MethodGet, "/v1/messages/"+url.PathEscape(messageID), nil)
 }
 
-func (c Client) ReserveInbox(ctx context.Context, limit int) (*InboxReservation, error) {
-	return request[*InboxReservation](ctx, c, http.MethodPost, "/v1/inbox/reserve", map[string]int{"limit": limit})
+func (c Client) ReserveInbox(ctx context.Context, limit int, wait time.Duration) (*InboxReservation, error) {
+	waitMS := wait.Milliseconds()
+	if wait > 0 && waitMS == 0 {
+		waitMS = 1
+	}
+	return request[*InboxReservation](ctx, c, http.MethodPost, "/v1/inbox/reserve", map[string]any{"limit": limit, "waitMs": waitMS})
 }
 
 func (c Client) CommitInbox(ctx context.Context, reservationID string) ([]Message, error) {
@@ -141,8 +145,8 @@ func (c Client) ReleaseInbox(ctx context.Context, reservationID string) error {
 	return err
 }
 
-func (c Client) PullInbox(ctx context.Context, limit int) ([]Message, error) {
-	reservation, err := c.ReserveInbox(ctx, limit)
+func (c Client) PullInbox(ctx context.Context, limit int, wait time.Duration) ([]Message, error) {
+	reservation, err := c.ReserveInbox(ctx, limit, wait)
 	if err != nil || reservation == nil {
 		return nil, err
 	}

--- a/bus/demo.go
+++ b/bus/demo.go
@@ -64,7 +64,7 @@ func RunDemo(ctx context.Context) error {
 	if _, err := reviewer.ClaimTask(ctx, task.ID); err != nil {
 		return err
 	}
-	messages, err := reviewer.PullInbox(ctx, 10)
+	messages, err := reviewer.PullInbox(ctx, 10, 0)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func RunDemo(ctx context.Context) error {
 	if _, err := reviewer.CompleteTask(ctx, task.ID, "done"); err != nil {
 		return err
 	}
-	replies, err := planner.PullInbox(ctx, 10)
+	replies, err := planner.PullInbox(ctx, 10, 0)
 	if err != nil {
 		return err
 	}

--- a/bus/inbox_wait.go
+++ b/bus/inbox_wait.go
@@ -1,0 +1,57 @@
+package bus
+
+import "sync"
+
+type inboxSignalKey struct {
+	scopeID string
+	agentID string
+}
+
+type inboxSignal struct {
+	channel chan struct{}
+	waiters int
+}
+
+type inboxSignals struct {
+	mu       sync.Mutex
+	channels map[inboxSignalKey]*inboxSignal
+}
+
+func newInboxSignals() *inboxSignals {
+	return &inboxSignals{channels: make(map[inboxSignalKey]*inboxSignal)}
+}
+
+func (signals *inboxSignals) subscribe(key inboxSignalKey) (<-chan struct{}, func()) {
+	signals.mu.Lock()
+	signal := signals.channels[key]
+	if signal == nil {
+		signal = &inboxSignal{channel: make(chan struct{})}
+		signals.channels[key] = signal
+	}
+	signal.waiters++
+	signals.mu.Unlock()
+
+	var once sync.Once
+	return signal.channel, func() {
+		once.Do(func() {
+			signals.mu.Lock()
+			defer signals.mu.Unlock()
+			if signals.channels[key] != signal {
+				return
+			}
+			signal.waiters--
+			if signal.waiters == 0 {
+				delete(signals.channels, key)
+			}
+		})
+	}
+}
+
+func (signals *inboxSignals) notify(key inboxSignalKey) {
+	signals.mu.Lock()
+	defer signals.mu.Unlock()
+	if signal := signals.channels[key]; signal != nil {
+		close(signal.channel)
+		delete(signals.channels, key)
+	}
+}

--- a/bus/inbox_wait_test.go
+++ b/bus/inbox_wait_test.go
@@ -1,0 +1,290 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInboxSignalsWakeCurrentWaitersWithoutRetainingIdleAgents(t *testing.T) {
+	signals := newInboxSignals()
+	key := inboxSignalKey{scopeID: "scope", agentID: "agent"}
+	signals.notify(key)
+	if len(signals.channels) != 0 {
+		t.Fatal("notification without waiters retained an idle agent")
+	}
+	current, unsubscribe := signals.subscribe(key)
+	defer unsubscribe()
+	signals.notify(key)
+	select {
+	case <-current:
+	default:
+		t.Fatal("notification did not wake the current waiter")
+	}
+	if len(signals.channels) != 0 {
+		t.Fatal("completed notification retained an idle agent")
+	}
+}
+
+func TestReserveInboxWakesForDurableMessage(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result := make(chan *InboxReservation, 1)
+	failure := make(chan error, 1)
+	go func() {
+		reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 1000)
+		if err != nil {
+			failure <- err
+			return
+		}
+		result <- reservation
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	receipt, err := agents.runtime.SendMessage(ctx, agents.plannerToken, SendMessageInput{To: "reviewer", Body: "Wake up"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-failure:
+		t.Fatal(err)
+	case reservation := <-result:
+		if reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != receipt.MessageID {
+			t.Fatalf("unexpected reservation: %#v", reservation)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}
+
+func TestInboxWaitDoesNotMissConcurrentSend(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	for index := 0; index < 25; index++ {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		result := make(chan *InboxReservation, 1)
+		failure := make(chan error, 1)
+		go func() {
+			reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 1, 500)
+			if err != nil {
+				failure <- err
+				return
+			}
+			result <- reservation
+		}()
+		receipt, err := agents.runtime.SendMessage(ctx, agents.plannerToken, SendMessageInput{To: "reviewer", Body: "Concurrent wake"})
+		if err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+		select {
+		case err := <-failure:
+			cancel()
+			t.Fatal(err)
+		case reservation := <-result:
+			if reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != receipt.MessageID {
+				cancel()
+				t.Fatalf("unexpected concurrent reservation: %#v", reservation)
+			}
+			messages, err := agents.runtime.CommitInbox(ctx, agents.reviewerToken, reservation.ID)
+			if err != nil || len(messages) != 1 {
+				cancel()
+				t.Fatalf("unexpected concurrent commit: %#v, %v", messages, err)
+			}
+			if _, err := agents.runtime.AcknowledgeMessages(ctx, agents.reviewerToken, []string{receipt.MessageID}); err != nil {
+				cancel()
+				t.Fatal(err)
+			}
+		case <-ctx.Done():
+			cancel()
+			t.Fatal(ctx.Err())
+		}
+		cancel()
+	}
+}
+
+func TestCommitInboxDoesNotWakeConcurrentWaiter(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	if _, err := agents.runtime.SendMessage(context.Background(), agents.plannerToken, SendMessageInput{To: "reviewer", Body: "Process once"}); err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 0)
+	if err != nil || reservation == nil {
+		t.Fatalf("unexpected initial reservation: %#v, %v", reservation, err)
+	}
+
+	waitContext, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	waitDone := make(chan error, 1)
+	go func() {
+		_, err := agents.runtime.ReserveInbox(waitContext, agents.reviewerToken, 10, 2000)
+		waitDone <- err
+	}()
+	time.Sleep(40 * time.Millisecond)
+	if _, err := agents.runtime.CommitInbox(context.Background(), agents.reviewerToken, reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-waitDone:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("commit woke concurrent waiter: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("concurrent waiter did not honor cancellation")
+	}
+}
+
+func TestReserveInboxTimesOutWithoutReservation(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	started := time.Now()
+	reservation, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 40)
+	if err != nil || reservation != nil {
+		t.Fatalf("unexpected wait result: %#v, %v", reservation, err)
+	}
+	if elapsed := time.Since(started); elapsed < 25*time.Millisecond || elapsed > time.Second {
+		t.Fatalf("unexpected wait duration: %s", elapsed)
+	}
+	if len(agents.runtime.inboxSignals.channels) != 0 {
+		t.Fatal("timed-out wait retained an inbox subscription")
+	}
+}
+
+func TestCanceledInboxWaitDoesNotConsumeLaterMessage(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	failure := make(chan error, 1)
+	go func() {
+		_, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 2000)
+		failure <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-failure:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("inbox wait did not stop after cancellation")
+	}
+	if len(agents.runtime.inboxSignals.channels) != 0 {
+		t.Fatal("canceled wait retained an inbox subscription")
+	}
+
+	receipt, err := agents.runtime.SendMessage(context.Background(), agents.plannerToken, SendMessageInput{To: "reviewer", Body: "Still available"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 0)
+	if err != nil || reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != receipt.MessageID {
+		t.Fatalf("canceled wait consumed work: %#v, %v", reservation, err)
+	}
+}
+
+func TestInboxWaitStopsWhenExecutionIsReplaced(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	failure := make(chan error, 1)
+	go func() {
+		_, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 2000)
+		failure <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	if _, err := agents.runtime.RegisterAgent(context.Background(), agents.scope.ScopeToken, RegisterAgentInput{
+		ID: "reviewer", DisplayName: "Replacement", LeaseMS: 30000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-failure:
+		requireCode(t, err, CodeUnauthenticated)
+	case <-time.After(time.Second):
+		t.Fatal("inbox wait did not stop after execution replacement")
+	}
+}
+
+func TestInboxWaitRechecksAtLeaseExpiry(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	expiresAt := nowMillis() + 60
+	if _, err := agents.runtime.store.db.Exec(`UPDATE agents SET lease_expires_at=? WHERE scope_id=? AND agent_id=?`, expiresAt, agents.scope.ScopeID, agents.reviewer.AgentID); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 2000)
+	requireCode(t, err, CodeUnauthenticated)
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("lease expiry took too long to stop wait: %s", elapsed)
+	}
+}
+
+func TestInboxWaitRechecksWhenReservationExpires(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	receipt, err := agents.runtime.SendMessage(context.Background(), agents.plannerToken, SendMessageInput{To: "reviewer", Body: "Redeliver"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 0)
+	if err != nil || first == nil {
+		t.Fatalf("unexpected initial reservation: %#v, %v", first, err)
+	}
+	if _, err := agents.runtime.store.db.Exec(`UPDATE reservations SET expires_at=? WHERE reservation_id=?`, nowMillis()+60, first.ID); err != nil {
+		t.Fatal(err)
+	}
+	redelivery, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 2000)
+	if err != nil || redelivery == nil || len(redelivery.Messages) != 1 || redelivery.Messages[0].ID != receipt.MessageID {
+		t.Fatalf("expired reservation did not wake delivery: %#v, %v", redelivery, err)
+	}
+}
+
+func TestInboxWaitBoundsAreValidated(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	_, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, -1)
+	requireCode(t, err, CodeInvalidArgument)
+	_, err = agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, maxInboxWaitMS+1)
+	requireCode(t, err, CodeInvalidArgument)
+}
+
+func TestServerStopCancelsInboxWait(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	server := NewServer(agents.runtime, ServerOptions{AdminToken: "inbox-wait-admin"})
+	address, err := server.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitDone := make(chan struct {
+		reservation *InboxReservation
+		err         error
+	}, 1)
+	go func() {
+		reservation, err := (Client{Address: address, Token: agents.reviewerToken}).ReserveInbox(context.Background(), 10, 25*time.Second)
+		waitDone <- struct {
+			reservation *InboxReservation
+			err         error
+		}{reservation: reservation, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	stopContext, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := server.Stop(stopContext); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case result := <-waitDone:
+		if result.err != nil || result.reservation != nil {
+			t.Fatalf("stopped server returned an unexpected inbox result: %#v, %v", result.reservation, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server stop did not cancel inbox wait")
+	}
+}

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -336,12 +336,20 @@ func (s *Server) reserveInbox(response http.ResponseWriter, request *http.Reques
 		return err
 	}
 	var input struct {
-		Limit int `json:"limit,omitempty"`
+		Limit  int   `json:"limit,omitempty"`
+		WaitMS int64 `json:"waitMs,omitempty"`
 	}
 	if err := decodeBody(response, request, &input); err != nil {
 		return err
 	}
-	result, err := s.runtime.ReserveInbox(request.Context(), token, input.Limit)
+	parentContext := request.Context()
+	waitContext, cancel := s.inboxWaitContext(parentContext)
+	defer cancel()
+	result, err := s.runtime.ReserveInbox(waitContext, token, input.Limit, input.WaitMS)
+	if s.inboxWaitStopped(parentContext, err) {
+		writeResult(response, http.StatusOK, nil)
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -1,11 +1,19 @@
 package bus
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
-const maxExpiryMS int64 = 30 * 24 * 60 * 60 * 1000
+const (
+	maxExpiryMS int64 = 30 * 24 * 60 * 60 * 1000
+	// Inbox waits stay below the server and default client timeout of 30 seconds.
+	maxInboxWaitMS int64 = 25 * 1000
+)
 
 type Runtime struct {
-	store *Store
+	store        *Store
+	inboxSignals *inboxSignals
 }
 
 func Open(source string) (*Runtime, error) {
@@ -13,7 +21,7 @@ func Open(source string) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Runtime{store: store}, nil
+	return &Runtime{store: store, inboxSignals: newInboxSignals()}, nil
 }
 
 func (r *Runtime) Close() error { return r.store.Close() }
@@ -54,7 +62,11 @@ func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input Re
 	if input.Capabilities == nil {
 		input.Capabilities = []AgentCapability{}
 	}
-	return r.store.RegisterAgent(ctx, scopeID, input)
+	result, err := r.store.RegisterAgent(ctx, scopeID, input)
+	if err == nil {
+		r.inboxSignals.notify(inboxSignalKey{scopeID: result.ScopeID, agentID: result.AgentID})
+	}
+	return result, err
 }
 
 func (r *Runtime) ListAgents(ctx context.Context, scopeToken string) ([]Agent, error) {
@@ -138,7 +150,11 @@ func (r *Runtime) SendMessage(ctx context.Context, agentToken string, input Send
 	if input.Context == nil {
 		input.Context = []ContextItem{}
 	}
-	return r.store.SendMessage(ctx, principal, input)
+	result, err := r.store.SendMessage(ctx, principal, input)
+	if err == nil {
+		r.inboxSignals.notify(inboxSignalKey{scopeID: principal.ScopeID, agentID: input.To})
+	}
+	return result, err
 }
 
 func (r *Runtime) Receipt(ctx context.Context, agentToken, messageID string) (DeliveryReceipt, error) {
@@ -152,18 +168,96 @@ func (r *Runtime) Receipt(ctx context.Context, agentToken, messageID string) (De
 	return r.store.Receipt(ctx, principal, messageID)
 }
 
-func (r *Runtime) ReserveInbox(ctx context.Context, agentToken string, limit int) (*InboxReservation, error) {
-	principal, err := r.Principal(ctx, agentToken)
-	if err != nil {
-		return nil, err
-	}
+func normalizedInboxLimit(limit int) (int, error) {
 	if limit == 0 {
 		limit = 50
 	}
 	if limit < 1 || limit > 100 {
-		return nil, Errorf(CodeInvalidArgument, "limit must be between 1 and 100")
+		return 0, Errorf(CodeInvalidArgument, "limit must be between 1 and 100")
 	}
-	return r.store.ReserveInbox(ctx, principal, limit)
+	return limit, nil
+}
+
+// ReserveInbox reserves available messages, waiting for up to waitMS when the
+// inbox is empty. A zero wait returns immediately. Callers embedding Runtime
+// directly should cancel ctx before closing the Runtime.
+func (r *Runtime) ReserveInbox(ctx context.Context, agentToken string, limit int, waitMS int64) (*InboxReservation, error) {
+	principal, err := r.Principal(ctx, agentToken)
+	if err != nil {
+		return nil, err
+	}
+	limit, err = normalizedInboxLimit(limit)
+	if err != nil {
+		return nil, err
+	}
+	if waitMS < 0 || waitMS > maxInboxWaitMS {
+		return nil, Errorf(CodeInvalidArgument, "waitMs must be between 0 and 25000")
+	}
+	if waitMS == 0 {
+		return r.store.ReserveInbox(ctx, principal, limit)
+	}
+	deadline := time.Now().Add(time.Duration(waitMS) * time.Millisecond)
+	key := inboxSignalKey{scopeID: principal.ScopeID, agentID: principal.AgentID}
+	for {
+		signal, unsubscribe := r.inboxSignals.subscribe(key)
+		principal, err = r.Principal(ctx, agentToken)
+		if err != nil {
+			unsubscribe()
+			return nil, err
+		}
+		reservation, err := r.store.ReserveInbox(ctx, principal, limit)
+		if err != nil || reservation != nil {
+			unsubscribe()
+			return reservation, err
+		}
+
+		now := time.Now()
+		if !now.Before(deadline) {
+			unsubscribe()
+			return nil, nil
+		}
+		wakeAt := deadline
+		leaseExpiresAt := time.UnixMilli(principal.LeaseExpiresAt)
+		if leaseExpiresAt.Before(wakeAt) {
+			wakeAt = leaseExpiresAt
+		}
+		reservationExpiresAt, err := r.store.NextInboxReservationExpiry(ctx, principal)
+		if err != nil {
+			unsubscribe()
+			return nil, err
+		}
+		if reservationExpiresAt > 0 {
+			expiresAt := time.UnixMilli(reservationExpiresAt)
+			if expiresAt.Before(wakeAt) {
+				wakeAt = expiresAt
+			}
+		}
+		wait := time.Until(wakeAt)
+		if wait <= 0 {
+			unsubscribe()
+			continue
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			unsubscribe()
+			return nil, ctx.Err()
+		case <-signal:
+			stopTimer(timer)
+		case <-timer.C:
+		}
+		unsubscribe()
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }
 
 func (r *Runtime) CommitInbox(ctx context.Context, agentToken, reservationID string) ([]Message, error) {
@@ -185,7 +279,11 @@ func (r *Runtime) ReleaseInbox(ctx context.Context, agentToken, reservationID st
 	if err := validateIdentity(reservationID, "reservationId", false); err != nil {
 		return err
 	}
-	return r.store.ReleaseInbox(ctx, principal, reservationID)
+	err = r.store.ReleaseInbox(ctx, principal, reservationID)
+	if err == nil {
+		r.inboxSignals.notify(inboxSignalKey{scopeID: principal.ScopeID, agentID: principal.AgentID})
+	}
+	return err
 }
 
 func (r *Runtime) AcknowledgeMessages(ctx context.Context, agentToken string, messageIDs []string) (int64, error) {

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -66,7 +66,7 @@ func TestDurableRequestRedeliveryAcknowledgementAndReply(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil || len(reservation.Messages) != 1 {
 		t.Fatalf("unexpected reservation: %#v, %v", reservation, err)
 	}
@@ -74,7 +74,7 @@ func TestDurableRequestRedeliveryAcknowledgementAndReply(t *testing.T) {
 	if err != nil || first[0].State != DeliveryDelivered {
 		t.Fatalf("unexpected delivery: %#v, %v", first, err)
 	}
-	redelivery, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	redelivery, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || redelivery == nil || redelivery.Messages[0].ID != receipt.MessageID {
 		t.Fatalf("unexpected redelivery: %#v, %v", redelivery, err)
 	}
@@ -117,7 +117,7 @@ func TestMessageIdempotencyRejectsPayloadChanges(t *testing.T) {
 	input.Body = "Review something else"
 	_, err = agents.runtime.SendMessage(ctx, agents.plannerToken, input)
 	requireCode(t, err, CodeConflict)
-	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil || len(reservation.Messages) != 1 {
 		t.Fatalf("idempotent retry created duplicate work: %#v, %v", reservation, err)
 	}
@@ -146,7 +146,7 @@ func TestResponsesRequireDeliveryButMayFinishAfterExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil {
 		t.Fatalf("unexpected reservation: %#v, %v", reservation, err)
 	}
@@ -176,7 +176,7 @@ func TestExpiredReservationCannotDeliverOrResurrectMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil {
 		t.Fatalf("unexpected reservation: %#v, %v", reservation, err)
 	}
@@ -194,7 +194,7 @@ func TestExpiredReservationCannotDeliverOrResurrectMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reservation, err = agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err = agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil {
 		t.Fatalf("unexpected second reservation: %#v, %v", reservation, err)
 	}
@@ -213,7 +213,7 @@ func TestExpiredReservationCannotDeliverOrResurrectMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reservation, err = agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err = agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil {
 		t.Fatalf("unexpected third reservation: %#v, %v", reservation, err)
 	}
@@ -401,7 +401,7 @@ func TestSQLitePreservesAcceptedWorkAcrossRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer restarted.Close()
-	reservation, err := restarted.ReserveInbox(ctx, agents.reviewerToken, 10)
+	reservation, err := restarted.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation == nil || reservation.Messages[0].ID != receipt.MessageID {
 		t.Fatalf("message did not survive restart: %#v, %v", reservation, err)
 	}
@@ -631,16 +631,23 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reservation, err := reviewerClient.ReserveInbox(ctx, 10)
+	reservation, err := reviewerClient.ReserveInbox(ctx, 10, 0)
 	if err != nil || reservation == nil {
 		t.Fatalf("unexpected HTTP reservation: %#v, %v", reservation, err)
 	}
 	if err := reviewerClient.ReleaseInbox(ctx, reservation.ID); err != nil {
 		t.Fatal(err)
 	}
-	reservation, err = reviewerClient.ReserveInbox(ctx, 10)
+	reservation, err = reviewerClient.ReserveInbox(ctx, 10, 0)
 	if err != nil || reservation == nil || reservation.Messages[0].ID != receipt.MessageID {
 		t.Fatalf("released inbox was not available again: %#v, %v", reservation, err)
+	}
+	delivered, err := reviewerClient.CommitInbox(ctx, reservation.ID)
+	if err != nil || len(delivered) != 1 {
+		t.Fatalf("unexpected committed inbox: %#v, %v", delivered, err)
+	}
+	if _, err := reviewerClient.AcknowledgeMessages(ctx, []string{receipt.MessageID}); err != nil {
+		t.Fatal(err)
 	}
 	httpClient := &http.Client{Transport: bearerTransport{token: agents.plannerToken, base: http.DefaultTransport}, Timeout: 10 * time.Second}
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1"}, nil)
@@ -674,6 +681,39 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 	}
 	if _, ok := structured["tasks"].([]any); !ok {
 		t.Fatalf("MCP list_tasks must return a tasks array: %#v", result.StructuredContent)
+	}
+	type callResult struct {
+		result *mcp.CallToolResult
+		err    error
+	}
+	waiting := make(chan callResult, 1)
+	go func() {
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "check_inbox", Arguments: map[string]any{"waitMs": 2000}})
+		waiting <- callResult{result: result, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	wakeReceipt, err := reviewerClient.SendMessage(ctx, SendMessageInput{To: "planner", Body: "Wake MCP"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case call := <-waiting:
+		if call.err != nil || call.result.IsError {
+			t.Fatalf("MCP check_inbox failed: %#v, %v", call.result, call.err)
+		}
+		structured, ok := call.result.StructuredContent.(map[string]any)
+		if !ok {
+			t.Fatalf("MCP check_inbox structured content must be an object: %#v", call.result.StructuredContent)
+		}
+		messages, ok := structured["messages"].([]any)
+		if !ok || len(messages) != 1 {
+			t.Fatalf("MCP check_inbox must return one message: %#v", call.result.StructuredContent)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	if _, err := plannerClient.AcknowledgeMessages(ctx, []string{wakeReceipt.MessageID}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/bus/server.go
+++ b/bus/server.go
@@ -27,6 +27,8 @@ type ServerOptions struct {
 type Server struct {
 	runtime      *Runtime
 	options      ServerOptions
+	waitContext  context.Context
+	cancelWaits  context.CancelFunc
 	httpServer   *http.Server
 	listener     net.Listener
 	mcpHandler   http.Handler
@@ -47,8 +49,10 @@ func NewServer(runtime *Runtime, options ServerOptions) *Server {
 	if options.StartedAt == "" {
 		options.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	}
+	waitContext, cancelWaits := context.WithCancel(context.Background())
 	server := &Server{
 		runtime: runtime, options: options,
+		waitContext: waitContext, cancelWaits: cancelWaits,
 		serveDone: make(chan error, 1), shutdown: make(chan struct{}),
 	}
 	server.mcpHandler = mcp.NewStreamableHTTPHandler(func(request *http.Request) *mcp.Server {
@@ -105,6 +109,7 @@ func (s *Server) requestShutdown() {
 func (s *Server) Stop(ctx context.Context) error {
 	var stopErr error
 	s.closeOnce.Do(func() {
+		s.cancelWaits()
 		if s.listener != nil {
 			stopErr = s.httpServer.Shutdown(ctx)
 		}
@@ -114,6 +119,19 @@ func (s *Server) Stop(ctx context.Context) error {
 		s.address = ""
 	})
 	return stopErr
+}
+
+func (s *Server) inboxWaitContext(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	stop := context.AfterFunc(s.waitContext, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
+
+func (s *Server) inboxWaitStopped(parent context.Context, err error) bool {
+	return errors.Is(err, context.Canceled) && parent.Err() == nil && s.waitContext.Err() != nil
 }
 
 func bearer(request *http.Request) (string, error) {
@@ -207,11 +225,17 @@ func (s *Server) newMCPServer(token string) *mcp.Server {
 			return nil, result, err
 		})
 	type inboxInput struct {
-		Limit int `json:"limit,omitempty"`
+		Limit  int   `json:"limit,omitempty"`
+		WaitMS int64 `json:"waitMs,omitempty" jsonschema:"wait for messages for up to 25000 milliseconds"`
 	}
-	mcp.AddTool(server, &mcp.Tool{Name: "check_inbox", Description: "Receive durable messages waiting for this agent."},
+	mcp.AddTool(server, &mcp.Tool{Name: "check_inbox", Description: "Receive durable messages waiting for this agent. Pass waitMs up to 25000 to wait for new messages instead of polling."},
 		func(ctx context.Context, _ *mcp.CallToolRequest, input inboxInput) (*mcp.CallToolResult, any, error) {
-			reservation, err := s.runtime.ReserveInbox(ctx, token, input.Limit)
+			waitContext, cancel := s.inboxWaitContext(ctx)
+			defer cancel()
+			reservation, err := s.runtime.ReserveInbox(waitContext, token, input.Limit, input.WaitMS)
+			if s.inboxWaitStopped(ctx, err) {
+				return nil, map[string]any{"messages": []Message{}}, nil
+			}
 			if err != nil || reservation == nil {
 				if reservation == nil && err == nil {
 					return nil, map[string]any{"messages": []Message{}}, nil

--- a/bus/store.go
+++ b/bus/store.go
@@ -677,6 +677,16 @@ func releaseReservation(ctx context.Context, tx *sql.Tx, scopeID, agentID, reser
 	return err
 }
 
+func requireCurrentExecution(ctx context.Context, tx *sql.Tx, principal Principal, now int64) error {
+	var executionID string
+	var leaseExpiresAt int64
+	err := tx.QueryRowContext(ctx, `SELECT execution_id,lease_expires_at FROM agents WHERE scope_id=? AND agent_id=?`, principal.ScopeID, principal.AgentID).Scan(&executionID, &leaseExpiresAt)
+	if errors.Is(err, sql.ErrNoRows) || (err == nil && (executionID != principal.ExecutionID || leaseExpiresAt <= now)) {
+		return Errorf(CodeUnauthenticated, "Agent execution is no longer current")
+	}
+	return err
+}
+
 func (s *Store) ReserveInbox(ctx context.Context, principal Principal, limit int) (*InboxReservation, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -684,6 +694,9 @@ func (s *Store) ReserveInbox(ctx context.Context, principal Principal, limit int
 	}
 	defer tx.Rollback()
 	now := nowMillis()
+	if err := requireCurrentExecution(ctx, tx, principal, now); err != nil {
+		return nil, err
+	}
 	if err := expireMessages(ctx, tx, principal.ScopeID, now); err != nil {
 		return nil, err
 	}
@@ -751,6 +764,15 @@ func (s *Store) ReserveInbox(ctx context.Context, principal Principal, limit int
 		return nil, err
 	}
 	return &InboxReservation{ID: reservationID, ExpiresAt: instant(expiresAt), Messages: messages}, nil
+}
+
+func (s *Store) NextInboxReservationExpiry(ctx context.Context, principal Principal) (int64, error) {
+	var expiresAt sql.NullInt64
+	err := s.db.QueryRowContext(ctx, `SELECT MIN(expires_at) FROM reservations WHERE scope_id=? AND agent_id=?`, principal.ScopeID, principal.AgentID).Scan(&expiresAt)
+	if err != nil {
+		return 0, err
+	}
+	return expiresAt.Int64, nil
 }
 
 func (s *Store) CommitInbox(ctx context.Context, principal Principal, reservationID string) ([]Message, error) {

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -239,7 +239,7 @@ func TestInspectReceiptEndToEnd(t *testing.T) {
 	if initial.State != bus.DeliveryQueued {
 		t.Fatalf("expected initial state queued, got %q", initial.State)
 	}
-	inbox, err := receiver.PullInbox(ctx, 10)
+	inbox, err := receiver.PullInbox(ctx, 10, 0)
 	if err != nil {
 		t.Fatalf("pull: %v", err)
 	}

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -187,7 +187,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 	}
 
 	if err := record.check("reservation-delivery-and-acknowledgement", func() error {
-		reservation, err := reviewer.ReserveInbox(ctx, 10)
+		reservation, err := reviewer.ReserveInbox(ctx, 10, 0)
 		if err != nil || reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != request.MessageID {
 			return fmt.Errorf("unexpected reservation: %#v, %v", reservation, err)
 		}
@@ -212,7 +212,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		if err != nil {
 			return err
 		}
-		messages, err := planner.PullInbox(ctx, 10)
+		messages, err := planner.PullInbox(ctx, 10, 0)
 		if err != nil || len(messages) != 1 || messages[0].ID != response.MessageID {
 			return fmt.Errorf("unexpected response inbox: %#v, %v", messages, err)
 		}
@@ -237,13 +237,45 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return err
 		}
 		time.Sleep(50 * time.Millisecond)
-		messages, err := reviewer.PullInbox(ctx, 10)
+		messages, err := reviewer.PullInbox(ctx, 10, 0)
 		if err != nil || len(messages) != 0 {
 			return fmt.Errorf("expired message was delivered: %#v, %v", messages, err)
 		}
 		state, err := planner.Receipt(ctx, receipt.MessageID)
 		if err != nil || state.State != bus.DeliveryExpired {
 			return fmt.Errorf("unexpected expiry receipt: %#v, %v", state, err)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("bounded-inbox-wait", func() error {
+		type waitResult struct {
+			messages []bus.Message
+			err      error
+		}
+		waiting := make(chan waitResult, 1)
+		go func() {
+			messages, err := reviewer.PullInbox(ctx, 10, 2*time.Second)
+			waiting <- waitResult{messages: messages, err: err}
+		}()
+		time.Sleep(50 * time.Millisecond)
+		receipt, err := planner.SendMessage(ctx, bus.SendMessageInput{To: "reviewer", Body: "Wake waiting inbox"})
+		if err != nil {
+			return err
+		}
+		select {
+		case waited := <-waiting:
+			if waited.err != nil || len(waited.messages) != 1 || waited.messages[0].ID != receipt.MessageID {
+				return fmt.Errorf("unexpected waited inbox: %#v, %v", waited.messages, waited.err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		count, err := reviewer.AcknowledgeMessages(ctx, []string{receipt.MessageID})
+		if err != nil || count != 1 {
+			return fmt.Errorf("unexpected waited acknowledgement: %d, %v", count, err)
 		}
 		return nil
 	}); err != nil {

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -15,7 +15,7 @@ Keep admin and scope tokens outside model context. A managed session gives the h
 ## Go
 
 ```go
-ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
 
 owner := bus.Client{Address: address, Token: scopeToken}
@@ -30,6 +30,7 @@ if err != nil {
 
 agent := bus.Client{Address: address, Token: registration.AgentToken}
 peers, err := agent.ListPeers(ctx)
+messages, err := agent.PullInbox(ctx, 50, 25*time.Second)
 ```
 
 Every Go call accepts a context. The default HTTP client has a 30-second timeout. Supply `Client.HTTP` to set a different transport or timeout.
@@ -59,11 +60,12 @@ const session = await OctoberBusAgentSession.start({
 
 await session.setState('ready', true)
 const peers = await session.client.listPeers({ timeoutMs: 10_000 })
+const messages = await session.client.pullInbox(50, { waitMs: 25_000 })
 ```
 
-Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argument. The default timeout is 30 seconds.
+Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argument. Inbox reservation and pull operations also accept `waitMs` up to 25 seconds. The default request timeout is 30 seconds.
 
-Use `pollInbox` for abortable pull delivery with bounded backoff. Use `withClaimedTask` to release a task if work or completion fails. Keep the managed session alive while holding a claim.
+Prefer bounded inbox waiting for efficient pull delivery. `pollInbox` provides an async iterator over repeated bounded waits. Use `withClaimedTask` to release a task if work or completion fails. Keep the managed session alive while holding a claim.
 
 ## Errors
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -49,6 +49,14 @@ await reviewer.acknowledgeMessages(messages.map((message) => message.id))
 console.log(receipt.messageId, messages)
 ```
 
+An idle agent can wait for new work without a polling loop:
+
+```ts
+const messages = await reviewer.pullInbox(50, { waitMs: 25_000 })
+```
+
+The server caps each wait at 25 seconds. Cancellation through `AbortSignal` does not reserve or lose a message.
+
 Scope credentials create agents and handle human escalations. Agent credentials discover peers, exchange messages, coordinate tasks, and ask for human input.
 
 Operations time out after 30 seconds by default. Pass `{ timeoutMs, signal }` as the final method argument to set a shorter deadline or cancel a request.
@@ -57,4 +65,4 @@ Generate a new idempotency key for each logical send. Keys remain bound to their
 
 `OctoberBusAgentSession` manages registration, conservative lifecycle state, heartbeat, execution replacement, and shutdown cleanup for adapters that use the TypeScript client.
 
-`pollInbox` provides abortable polling with bounded backoff. `withClaimedTask` releases a claim when work or completion fails. Use both with a live agent session so the execution lease remains current while work is claimed.
+`pollInbox` provides an abortable async iterator over repeated bounded inbox waits. `withClaimedTask` releases a claim when work or completion fails. Use both with a live agent session so the execution lease remains current while work is claimed.

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.2",
+  "version": "0.1.0-next.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.2",
+      "version": "0.1.0-next.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.2",
+  "version": "0.1.0-next.3",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -32,6 +32,10 @@ export interface OperationOptions {
   timeoutMs?: number
 }
 
+export interface InboxReservationOptions extends OperationOptions {
+  waitMs?: number
+}
+
 async function request<T>(
   address: string,
   token: string | undefined,
@@ -176,8 +180,16 @@ export class OctoberBusClient {
     return request(this.address, this.agentToken, 'GET', `/v1/messages/${encodeURIComponent(messageId)}`, undefined, options)
   }
 
-  reserveInbox(limit = 50, options?: OperationOptions): Promise<InboxReservation | null> {
-    return request(this.address, this.agentToken, 'POST', '/v1/inbox/reserve', { limit }, options)
+  reserveInbox(limit = 50, options: InboxReservationOptions = {}): Promise<InboxReservation | null> {
+    const { waitMs, ...operationOptions } = options
+    return request(
+      this.address,
+      this.agentToken,
+      'POST',
+      '/v1/inbox/reserve',
+      { limit, ...(waitMs === undefined ? {} : { waitMs }) },
+      operationOptions
+    )
   }
 
   commitInbox(reservationId: string, options?: OperationOptions): Promise<BusMessage[]> {
@@ -202,7 +214,7 @@ export class OctoberBusClient {
     )
   }
 
-  async pullInbox(limit = 50, options?: OperationOptions): Promise<BusMessage[]> {
+  async pullInbox(limit = 50, options?: InboxReservationOptions): Promise<BusMessage[]> {
     const reservation = await this.reserveInbox(limit, options)
     return reservation ? this.commitInbox(reservation.id, options) : []
   }

--- a/sdk/typescript/src/session.ts
+++ b/sdk/typescript/src/session.ts
@@ -20,33 +20,13 @@ export interface AgentSessionOptions {
 
 export interface InboxPollingOptions {
   limit?: number
-  intervalMs?: number
-  maxIntervalMs?: number
-  backoffFactor?: number
+  waitMs?: number
   signal?: AbortSignal
 }
 
 export interface ClaimedTaskResult<T> {
   task: BusTask
   value: T
-}
-
-function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(signal.reason ?? new Error('Operation aborted'))
-      return
-    }
-    const onAbort = () => {
-      clearTimeout(timer)
-      reject(signal?.reason ?? new Error('Operation aborted'))
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort)
-      resolve()
-    }, milliseconds)
-    signal?.addEventListener('abort', onAbort, { once: true })
-  })
 }
 
 export function requiredEnvironmentValue(
@@ -172,25 +152,23 @@ export async function* pollInbox(
   options: InboxPollingOptions = {}
 ): AsyncGenerator<BusMessage[]> {
   const limit = options.limit ?? 50
-  const intervalMs = options.intervalMs ?? 1_000
-  const maxIntervalMs = options.maxIntervalMs ?? 10_000
-  const backoffFactor = options.backoffFactor ?? 1.5
+  const waitMs = options.waitMs ?? 25_000
   if (limit < 1 || limit > 100) throw new Error('limit must be between 1 and 100')
-  if (intervalMs < 1) throw new Error('intervalMs must be positive')
-  if (maxIntervalMs < intervalMs) throw new Error('maxIntervalMs must not be shorter than intervalMs')
-  if (backoffFactor < 1 || !Number.isFinite(backoffFactor)) {
-    throw new Error('backoffFactor must be a finite number of at least 1')
+  if (!Number.isInteger(waitMs) || waitMs < 1 || waitMs > 25_000) {
+    throw new Error('waitMs must be an integer between 1 and 25000')
   }
-  let nextIntervalMs = intervalMs
   while (!options.signal?.aborted) {
-    const messages = await client.pullInbox(limit, options.signal ? { signal: options.signal } : undefined)
-    if (messages.length > 0) {
-      nextIntervalMs = intervalMs
-      yield messages
-    } else {
-      nextIntervalMs = Math.min(maxIntervalMs, Math.ceil(nextIntervalMs * backoffFactor))
+    let messages: BusMessage[]
+    try {
+      messages = await client.pullInbox(limit, {
+        waitMs,
+        ...(options.signal === undefined ? {} : { signal: options.signal })
+      })
+    } catch (error) {
+      if (options.signal?.aborted) return
+      throw error
     }
-    if (!options.signal?.aborted) await delay(nextIntervalMs, options.signal)
+    if (messages.length > 0) yield messages
   }
 }
 

--- a/sdk/typescript/test/errors.mjs
+++ b/sdk/typescript/test/errors.mjs
@@ -74,17 +74,19 @@ assert.equal(releasedTask, 'task_failure')
 
 let inboxPolls = 0
 const pollingClient = {
-  async pullInbox() {
+  async pullInbox(limit, options) {
+    assert.equal(limit, 50)
+    assert.equal(options.waitMs, 25_000)
     inboxPolls += 1
     return inboxPolls === 1 ? [] : [{ id: 'message_1' }]
   }
 }
-const inbox = pollInbox(pollingClient, { intervalMs: 1, maxIntervalMs: 2, backoffFactor: 2 })
+const inbox = pollInbox(pollingClient)
 const polled = await inbox.next()
 assert.equal(polled.done, false)
 assert.equal(polled.value[0].id, 'message_1')
 await inbox.return()
-await assert.rejects(() => pollInbox(pollingClient, { intervalMs: 0 }).next(), /intervalMs must be positive/)
+await assert.rejects(() => pollInbox(pollingClient, { waitMs: 0 }).next(), /waitMs must be an integer between 1 and 25000/)
 
 const server = createServer((_request, response) => {
   response.writeHead(502, { 'content-type': 'text/plain' })

--- a/sdk/typescript/test/integration.mjs
+++ b/sdk/typescript/test/integration.mjs
@@ -85,6 +85,17 @@ try {
   assert.equal(messages.length, 1)
   assert.equal(messages[0].id, receipt.messageId)
   assert.equal(await reviewer.acknowledgeMessages([messages[0].id]), 1)
+  const waitingInbox = reviewer.pullInbox(50, { waitMs: 2_000, timeoutMs: 3_000 })
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const waitingReceipt = await planner.sendMessage({
+    to: 'reviewer',
+    body: 'Wake the waiting reviewer',
+    idempotencyKey: newIdempotencyKey()
+  })
+  const waitingMessages = await waitingInbox
+  assert.equal(waitingMessages.length, 1)
+  assert.equal(waitingMessages[0].id, waitingReceipt.messageId)
+  assert.equal(await reviewer.acknowledgeMessages([waitingMessages[0].id]), 1)
   const task = await planner.addTask('Review integration')
   const completed = await withClaimedTask(reviewer, task.id, async () => 'reviewed', (value) => value)
   assert.equal(completed.task.status, 'done')

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -82,6 +82,8 @@ queued -> reserved -> delivered -> acknowledged
 
 Reservations prevent two concurrent delivery attempts from consuming the same inbox item. A reservation expires after 30 seconds in the reference runtime. Releasing or expiring a reservation makes an undelivered message available again. Delivered but unacknowledged messages MAY be redelivered.
 
+An inbox reservation request MAY wait for work with `waitMs`. The reference profile allows values from 0 through 25000. The wait ends when work becomes reservable, its deadline passes, the caller cancels, the server stops, or the execution loses authority. A timeout returns no reservation and does not consume work.
+
 Acknowledgement means the recipient reports that it processed the message. Clients SHOULD acknowledge only after processing succeeds.
 
 ### Idempotency

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -61,6 +61,8 @@ Failures use:
 | `POST` | `/v1/scope/escalations/{escalationId}/resolve` | Scope | Resolved escalation |
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
 
+`POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
+
 Request and result shapes are defined in [protocol.schema.json](schemas/protocol.schema.json). Consumers can reference individual definitions with a fragment such as:
 
 ```text

--- a/spec/0.1/mcp.md
+++ b/spec/0.1/mcp.md
@@ -22,7 +22,7 @@ The endpoint is `/mcp` and requires an execution-bound agent Bearer token. An MC
 
 `message_peer.peer` SHOULD be an exact agent ID. The reference MCP server also accepts a unique case-insensitive exact display name, using the addressing rules in the main specification.
 
-`check_inbox` commits a short reservation and returns delivered messages. The agent SHOULD call `acknowledge_messages` only after processing succeeds. A host that cannot wake an idle agent MUST document that it is pull-only.
+`check_inbox` accepts an optional `waitMs` value from 0 through 25000. It commits a short reservation and returns delivered messages. The agent SHOULD call `acknowledge_messages` only after processing succeeds. A host that cannot wake an idle agent MUST document that it is pull-only.
 
 Every tool returns an object as structured content. Collection tools place their array under a named field, including `peers`, `messages`, and `tasks`.
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -222,6 +222,14 @@
         "responseMessageId": { "$ref": "#/$defs/identifier" }
       }
     },
+    "reserveInboxInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limit": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "waitMs": { "type": "integer", "minimum": 0, "maximum": 25000 }
+      }
+    },
     "inboxReservation": {
       "type": "object",
       "additionalProperties": false,

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -96,6 +96,13 @@ func TestProtocolSchemas(t *testing.T) {
 		"to": "planner", "body": "Unexpected correlation", "mode": "notify", "responseTo": "msg_123",
 	})
 
+	reserve := resolvedSchema(t, path, "reserveInboxInput")
+	requireValid(t, reserve, map[string]any{"limit": float64(50), "waitMs": float64(25000)})
+	requireValid(t, reserve, map[string]any{})
+	requireValid(t, reserve, map[string]any{"limit": float64(0), "waitMs": float64(0)})
+	requireInvalid(t, reserve, map[string]any{"waitMs": float64(25001)})
+	requireInvalid(t, reserve, map[string]any{"waitMs": float64(1.5)})
+
 	task := resolvedSchema(t, path, "task")
 	requireValid(t, task, map[string]any{
 		"id": "task_123", "scopeId": "scope", "description": "Review",
@@ -126,7 +133,7 @@ func TestAdapterManifestsMatchSchema(t *testing.T) {
 	requireInvalid(t, schema, map[string]any{
 		"schemaVersion": float64(1), "id": "unproven", "harnessFamily": "Unknown",
 		"adapterVersion": "0.1.0",
-		"status": "verified", "protocolVersions": []any{"0.1"}, "transport": "mcp",
+		"status":         "verified", "protocolVersions": []any{"0.1"}, "transport": "mcp",
 		"delivery": "pull", "lifecycleEvidence": "process", "capabilities": []any{},
 		"testedVersions": []any{}, "platforms": []any{"linux"}, "maintainer": "October",
 		"repository": "https://github.com/october-dev/october-bus",
@@ -221,7 +228,7 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	requireValid(t, resolvedSchema(t, path, "deliveryReceipt"), jsonValue(t, receipt))
-	messages, err := reviewer.PullInbox(ctx, 10)
+	messages, err := reviewer.PullInbox(ctx, 10, 0)
 	if err != nil || len(messages) != 1 {
 		t.Fatalf("unexpected messages: %#v, %v", messages, err)
 	}


### PR DESCRIPTION
## Summary

- add bounded long-poll delivery to inbox reservations
- wake waiting agents after durable sends and reservation changes
- stop waits when requests are canceled, the daemon stops, leases expire, or executions are replaced
- expose the option through HTTP, MCP, Go, TypeScript, schemas, and client documentation
- preserve immediate reservation behavior when `waitMs` is omitted

## Validation

- `go test -race -count=1 ./...`
- `go vet ./...`
- TypeScript typecheck, build, error tests, and Go interoperability test
- 15 public-interface conformance checks
- Linux and Windows cross-builds
- two-agent demo

Closes #14