### PR TITLE
Add stdio MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ In another terminal, create a collaboration scope:
 go run ./cmd/october-bus scope create my-project
 ```
 
-The command returns a scope token. A harness uses that token once to register an execution and receives a separate, execution-bound agent token. The TypeScript client lives in `sdk/typescript`. MCP clients connect to the daemon's `/mcp` endpoint with the agent token as a Bearer credential.
+The command returns a scope token. A harness uses that token once to register an execution and receives a separate, execution-bound agent token. The TypeScript client lives in `sdk/typescript`. MCP clients can connect to the daemon's `/mcp` endpoint or spawn `october-bus mcp stdio` inside a managed execution.
 
 ## Protocol
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,16 +4,18 @@ This directory contains host-specific configuration for connecting coding harnes
 
 Early configurations are included for Claude Code, Codex, Cursor, and OpenCode. Each adapter directory contains its host configuration, manifest, and setup instructions.
 
-The current adapters are early integrations and are not yet conformance-verified. They use the shared `october-bus agent run` command for registration, credentials, heartbeat, and cleanup.
+The current adapters are early integrations and are not yet conformance-verified. They use the shared `october-bus agent run` command for registration, credentials, heartbeat, and cleanup. Each harness starts `october-bus mcp stdio`, which forwards the daemon's MCP tools over standard input and output.
 
 Each harness receives its own agent token. Scope credentials stay outside the harness process.
 
 The shared launcher proves that the harness process is reachable. It does not claim that the model is ready or idle. Adapters may report stronger lifecycle states only when the host provides reliable evidence.
 
-Start the local daemon on the port used by the example configurations:
+The reusable stdio server entry is in `mcp-stdio.json.example`. The harness-specific examples wrap the same command in each configuration format, so they do not need a fixed daemon port or credential interpolation.
+
+Start the local daemon:
 
 ```sh
-october-bus start --port 4765
+october-bus start
 ```
 
 Create a scope in another terminal, then export the returned scope token only in the terminals that launch managed agents:

--- a/adapters/claude-code/README.md
+++ b/adapters/claude-code/README.md
@@ -2,7 +2,7 @@
 
 Status: early integration, not yet conformance-verified.
 
-Start October Bus on the address used by `mcp.json.example`, then create a scope.
+Start October Bus, then create a scope. The MCP configuration launches the stdio bridge inside the managed agent execution.
 
 Run Claude Code through the managed agent command:
 

--- a/adapters/claude-code/mcp.json.example
+++ b/adapters/claude-code/mcp.json.example
@@ -1,11 +1,9 @@
 {
   "mcpServers": {
     "october_bus": {
-      "type": "http",
-      "url": "http://127.0.0.1:4765/mcp",
-      "headers": {
-        "Authorization": "Bearer ${OCTOBER_BUS_AGENT_TOKEN}"
-      }
+      "type": "stdio",
+      "command": "october-bus",
+      "args": ["mcp", "stdio"]
     }
   }
 }

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -2,7 +2,7 @@
 
 Status: early integration, not yet conformance-verified.
 
-Start October Bus on the address used by `config.toml.example`, then create a scope. Add the example MCP server entry to a trusted project's `.codex/config.toml`.
+Start October Bus, then create a scope. Add the example MCP server entry to a trusted project's `.codex/config.toml`. It launches the stdio bridge inside the managed agent execution.
 
 Run Codex through the managed agent command:
 

--- a/adapters/codex/config.toml.example
+++ b/adapters/codex/config.toml.example
@@ -1,5 +1,5 @@
 [mcp_servers.october_bus]
-url = "http://127.0.0.1:4765/mcp"
-bearer_token_env_var = "OCTOBER_BUS_AGENT_TOKEN"
+command = "october-bus"
+args = ["mcp", "stdio"]
 required = true
 default_tools_approval_mode = "prompt"

--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -2,7 +2,7 @@
 
 Status: early integration, not yet conformance-verified.
 
-Start October Bus on the address used by `mcp.json.example`, then create a scope. Copy or merge the example into `.cursor/mcp.json` in the project where Cursor will run.
+Start October Bus, then create a scope. Copy or merge the example into `.cursor/mcp.json` in the project where Cursor will run. It launches the stdio bridge inside the managed agent execution.
 
 Run Cursor through the managed agent command:
 

--- a/adapters/cursor/mcp.json.example
+++ b/adapters/cursor/mcp.json.example
@@ -1,10 +1,9 @@
 {
   "mcpServers": {
     "october_bus": {
-      "url": "http://127.0.0.1:4765/mcp",
-      "headers": {
-        "Authorization": "Bearer ${env:OCTOBER_BUS_AGENT_TOKEN}"
-      }
+      "type": "stdio",
+      "command": "october-bus",
+      "args": ["mcp", "stdio"]
     }
   }
 }

--- a/adapters/mcp-stdio.json.example
+++ b/adapters/mcp-stdio.json.example
@@ -1,0 +1,5 @@
+{
+  "type": "stdio",
+  "command": "october-bus",
+  "args": ["mcp", "stdio"]
+}

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -2,7 +2,7 @@
 
 Status: early integration, not yet conformance-verified.
 
-Start October Bus on the address used by `opencode.json.example`, then create a scope. Set `OPENCODE_CONFIG` to the example or merge its `mcp` entry into the project's OpenCode configuration.
+Start October Bus, then create a scope. Set `OPENCODE_CONFIG` to the example or merge its `mcp` entry into the project's OpenCode configuration. It launches the stdio bridge inside the managed agent execution.
 
 Run OpenCode through the managed agent command:
 

--- a/adapters/opencode/opencode.json.example
+++ b/adapters/opencode/opencode.json.example
@@ -2,13 +2,9 @@
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "october_bus": {
-      "type": "remote",
-      "url": "http://127.0.0.1:4765/mcp",
-      "enabled": true,
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer {env:OCTOBER_BUS_AGENT_TOKEN}"
-      }
+      "type": "local",
+      "command": ["october-bus", "mcp", "stdio"],
+      "enabled": true
     }
   }
 }

--- a/cmd/october-bus/main.go
+++ b/cmd/october-bus/main.go
@@ -28,6 +28,7 @@ Usage:
   october-bus message receipt <message-id> [--json] [--address <addr>]
   october-bus agent list [--json] [--address <addr>]
   october-bus agent run --id <id> --name <name> [--connect-to <peer>] -- <command> [args...]
+  october-bus mcp stdio
   october-bus demo
   october-bus version
 `
@@ -596,6 +597,12 @@ func run() error {
 		}
 		if len(args) >= 2 && args[1] == "list" {
 			return listAgents(args[2:])
+		}
+	case "mcp":
+		if len(args) == 2 && args[1] == "stdio" {
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+			return runMCPStdio(ctx)
 		}
 	case "demo":
 		return bus.RunDemo(context.Background())

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -5,15 +5,144 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/october-dev/october-bus/bus"
 )
+
+func TestMCPStdioHelper(t *testing.T) {
+	if os.Getenv("OCTOBER_BUS_MCP_STDIO_TEST_HELPER") != "1" {
+		return
+	}
+	if err := runMCPStdio(context.Background()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func mcpBridgeCommand(address, token string, stderr io.Writer) *exec.Cmd {
+	command := exec.Command(os.Args[0], "-test.run=^TestMCPStdioHelper$")
+	command.Env = setEnvironment(removeEnvironment(os.Environ(),
+		"OCTOBER_BUS_ADDRESS",
+		"OCTOBER_BUS_AGENT_TOKEN",
+		"OCTOBER_BUS_SCOPE_TOKEN",
+		"OCTOBER_BUS_ADMIN_TOKEN",
+	),
+		"OCTOBER_BUS_MCP_STDIO_TEST_HELPER", "1",
+		"OCTOBER_BUS_ADDRESS", address,
+		"OCTOBER_BUS_AGENT_TOKEN", token,
+	)
+	command.Stderr = stderr
+	return command
+}
+
+func connectMCPBridge(t *testing.T, ctx context.Context, address, token string) (*mcp.ClientSession, *bytes.Buffer) {
+	t.Helper()
+	stderr := new(bytes.Buffer)
+	client := mcp.NewClient(&mcp.Implementation{Name: "bridge-test", Version: "1"}, nil)
+	session, err := client.Connect(ctx, &mcp.CommandTransport{Command: mcpBridgeCommand(address, token, stderr)}, nil)
+	if err != nil {
+		t.Fatalf("connect to stdio bridge: %v; stderr: %s", err, stderr.String())
+	}
+	return session, stderr
+}
+
+func callMCPBridgeTool(t *testing.T, ctx context.Context, session *mcp.ClientSession, name string, arguments map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: arguments})
+	if err != nil || result.IsError {
+		t.Fatalf("call %s: %#v, %v", name, result, err)
+	}
+	return result
+}
+
+func TestMCPStdioBridgeForwardsDaemonTools(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address, _, senderToken, receiverToken, cleanup := startTestServer(t, ctx, "stdio-forwarding")
+	defer cleanup()
+	session, stderr := connectMCPBridge(t, ctx, address, senderToken)
+	defer session.Close()
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil || len(tools.Tools) != 11 {
+		t.Fatalf("unexpected forwarded tools: %d, %v; stderr: %s", len(tools.Tools), err, stderr.String())
+	}
+	directClient := mcp.NewClient(&mcp.Implementation{Name: "direct-test", Version: "1"}, nil)
+	directSession, err := directClient.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint: address + "/mcp",
+		HTTPClient: &http.Client{Transport: agentTokenTransport{
+			token: senderToken,
+			base:  http.DefaultTransport,
+		}},
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer directSession.Close()
+	directTools, err := directSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forwardedJSON, err := json.Marshal(tools.Tools)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directJSON, err := json.Marshal(directTools.Tools)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(forwardedJSON, directJSON) {
+		t.Fatalf("stdio bridge changed the daemon tool definitions\nforwarded: %s\ndirect: %s", forwardedJSON, directJSON)
+	}
+	callMCPBridgeTool(t, ctx, session, "list_peers", map[string]any{})
+	callMCPBridgeTool(t, ctx, session, "message_peer", map[string]any{"peer": "receiver", "message": "Forwarded over stdio"})
+	messages, err := (bus.Client{Address: address, Token: receiverToken}).PullInbox(ctx, 10, 0)
+	if err != nil || len(messages) != 1 || messages[0].Body != "Forwarded over stdio" {
+		t.Fatalf("unexpected forwarded message: %#v, %v", messages, err)
+	}
+	callMCPBridgeTool(t, ctx, session, "add_task", map[string]any{"description": "Forward a task"})
+	callMCPBridgeTool(t, ctx, session, "ask_user", map[string]any{"question": "Continue?"})
+}
+
+func TestMCPStdioBridgeStartsWithoutRuntimeIdentity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	session, stderr := connectMCPBridge(t, ctx, "http://127.0.0.1:1", "")
+	initial := session.InitializeResult()
+	if initial == nil || !strings.Contains(initial.Instructions, "not running inside a managed agent execution") {
+		t.Fatalf("unexpected bridge instructions: %#v", initial)
+	}
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil || len(tools.Tools) != 0 {
+		t.Fatalf("unexpected tools without identity: %#v, %v; stderr: %s", tools, err, stderr.String())
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("stdio bridge did not stop cleanly when input closed: %v", err)
+	}
+}
+
+func TestMCPStdioBridgeRejectsUnavailableDaemon(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stderr := new(bytes.Buffer)
+	client := mcp.NewClient(&mcp.Implementation{Name: "bridge-test", Version: "1"}, nil)
+	_, err := client.Connect(ctx, &mcp.CommandTransport{Command: mcpBridgeCommand("http://127.0.0.1:1", "agent-token", stderr)}, nil)
+	if err == nil || !strings.Contains(stderr.String(), "could not connect to October Bus") {
+		t.Fatalf("expected unavailable daemon error, got %v; stderr: %s", err, stderr.String())
+	}
+}
 
 func TestAgentRunHelper(t *testing.T) {
 	if os.Getenv("OCTOBER_BUS_TEST_HELPER") != "1" {

--- a/cmd/october-bus/mcp_stdio.go
+++ b/cmd/october-bus/mcp_stdio.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/october-dev/october-bus/bus"
+)
+
+const (
+	mcpBridgeInstructions = "This server forwards October Bus tools from the current agent execution."
+	mcpBridgeNoIdentity   = "October Bus tools are unavailable because this process is not running inside a managed agent execution."
+)
+
+type agentTokenTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (transport agentTokenTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	clone := request.Clone(request.Context())
+	clone.Header = request.Header.Clone()
+	clone.Header.Set("Authorization", "Bearer "+transport.token)
+	return transport.base.RoundTrip(clone)
+}
+
+func runMCPStdio(ctx context.Context) error {
+	address := strings.TrimRight(strings.TrimSpace(os.Getenv("OCTOBER_BUS_ADDRESS")), "/")
+	token := strings.TrimSpace(os.Getenv("OCTOBER_BUS_AGENT_TOKEN"))
+	if address == "" || token == "" {
+		server := newMCPBridgeServer(mcpBridgeNoIdentity)
+		return server.Run(ctx, &mcp.StdioTransport{})
+	}
+
+	connectContext, cancelConnect := context.WithTimeout(ctx, 10*time.Second)
+	httpClient := &http.Client{Transport: agentTokenTransport{token: token, base: http.DefaultTransport}}
+	client := mcp.NewClient(&mcp.Implementation{Name: "october-bus-stdio-bridge", Version: bus.Version}, nil)
+	upstream, err := client.Connect(connectContext, &mcp.StreamableClientTransport{
+		Endpoint:             address + "/mcp",
+		HTTPClient:           httpClient,
+		MaxRetries:           -1,
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		cancelConnect()
+		return fmt.Errorf("could not connect to October Bus at %s: %w", address, err)
+	}
+	defer upstream.Close()
+
+	server := newMCPBridgeServer(mcpBridgeInstructions)
+	for cursor := ""; ; {
+		result, err := upstream.ListTools(connectContext, &mcp.ListToolsParams{Cursor: cursor})
+		if err != nil {
+			cancelConnect()
+			return fmt.Errorf("could not discover October Bus tools: %w", err)
+		}
+		for _, upstreamTool := range result.Tools {
+			tool := *upstreamTool
+			toolName := tool.Name
+			server.AddTool(&tool, func(callContext context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				params := request.Params
+				return upstream.CallTool(callContext, &mcp.CallToolParams{
+					Meta:           params.Meta,
+					Name:           toolName,
+					Arguments:      params.Arguments,
+					InputResponses: params.InputResponses,
+					RequestState:   params.RequestState,
+				})
+			})
+		}
+		if result.NextCursor == "" {
+			break
+		}
+		if result.NextCursor == cursor {
+			cancelConnect()
+			return errors.New("October Bus returned a repeated tool cursor")
+		}
+		cursor = result.NextCursor
+	}
+	cancelConnect()
+	return server.Run(ctx, &mcp.StdioTransport{})
+}
+
+func newMCPBridgeServer(instructions string) *mcp.Server {
+	return mcp.NewServer(&mcp.Implementation{Name: "october-bus", Version: bus.Version}, &mcp.ServerOptions{
+		Instructions: instructions,
+		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
+	})
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,6 +15,16 @@ october-bus stop
 
 Use `october-bus doctor --json` for machine-readable diagnostics. It reports versions, paths, process state, and endpoint health. It does not print credentials or message content.
 
+## MCP over stdio
+
+Harnesses that need a local stdio MCP server can run:
+
+```bash
+october-bus mcp stdio
+```
+
+The bridge reads `OCTOBER_BUS_ADDRESS` and `OCTOBER_BUS_AGENT_TOKEN`, discovers the daemon's MCP tools, and forwards calls without keeping its own state. `october-bus agent run` supplies both values to the managed harness process. If either value is absent, the bridge starts without tools and does not contact a daemon.
+
 ## Inspect message delivery state
 
 Agents can inspect the durable delivery state of a message they sent or

--- a/spec/0.1/mcp.md
+++ b/spec/0.1/mcp.md
@@ -4,6 +4,8 @@ October Bus uses MCP Streamable HTTP as an agent-facing integration surface. MCP
 
 The endpoint is `/mcp` and requires an execution-bound agent Bearer token. An MCP session does not register an agent or renew its lease. A launcher or native adapter MUST own registration, credential handoff, heartbeat, execution replacement, and cleanup outside the model loop.
 
+The reference CLI can forward this same MCP surface over stdio with `october-bus mcp stdio`. The bridge does not add authority or keep separate Bus state.
+
 ## Required tools
 
 | Tool | Protocol operation |


### PR DESCRIPTION
Closes #15.

Adds a stateless stdio bridge that forwards the daemon's MCP tools through execution-bound agent authority. Updates the Claude Code, Codex, Cursor, and OpenCode examples to use one local command.

Validation:

- `go test -race -count=1 ./...`
- `go vet ./...`
- Linux and Windows cross-builds
- TypeScript typecheck and build
- local demo
