### PR TITLE
Add MCP adapter conformance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,24 +197,25 @@ If a harness cannot safely wake itself or prove that it is idle, it can implemen
 
 Early Claude Code, Codex, Cursor, and OpenCode configurations live in `adapters/`. They are not yet conformance-verified and are not compatibility claims. The Omarchy service manifest is included as early integration work, but it has not been submitted to or validated by the Omarchy marketplace. The [compatibility registry](compatibility/README.md) starts empty and will list only adapters with current passing evidence.
 
-The local-runtime conformance runner uses only the public HTTP and MCP interfaces. Against a test daemon, run:
+The conformance runner can start an isolated runtime and remove its state when the run finishes:
 
 ```bash
-go run ./cmd/october-bus-conformance
+october-bus-conformance --start-runtime --format text
 ```
 
-Use `--format text` for concise terminal output. JSON is the default and failed runs exit nonzero with the failed check recorded.
+The `mcp-adapter` profile drives an adapter command over stdio while checking results independently through the public Bus API:
 
-It covers authority, registration, discovery, durable delivery, acknowledgements, idempotency, replies, expiry, task dependencies, release and recovery, escalation, isolation, the MCP tool surface, and lifecycle cleanup. Future adapter profiles will also cover:
+```bash
+october-bus-conformance \
+  --profile mcp-adapter \
+  --start-runtime \
+  --adapter-command october-bus \
+  --adapter-arg mcp \
+  --adapter-arg stdio \
+  --format text
+```
 
-- identity, registration, and execution replacement;
-- discovery, capabilities, presence, and reachability;
-- durable messaging, receipts, retries, expiry, and reply linking;
-- task claiming, completion, and dependencies;
-- bounded context exchange;
-- human escalation and permission boundaries;
-- lifecycle reporting and cleanup;
-- every optional wake or completion behavior an adapter declares.
+JSON is the default. Failed runs exit nonzero with the failed check recorded. An adapter command passing this profile does not by itself verify a harness. Harness compatibility also requires a released harness to pass the [verification runbook](compatibility/RUNBOOK.md). See [conformance profiles](docs/conformance.md) for details.
 
 ## Security and trust
 

--- a/cmd/october-bus-conformance/main.go
+++ b/cmd/october-bus-conformance/main.go
@@ -7,25 +7,108 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/october-dev/october-bus/bus"
 	"github.com/october-dev/october-bus/conformance"
 )
 
+type stringList []string
+
+func (values *stringList) String() string { return strings.Join(*values, ",") }
+
+func (values *stringList) Set(value string) error {
+	*values = append(*values, value)
+	return nil
+}
+
+type isolatedRuntime struct {
+	daemon *bus.RunningDaemon
+	root   string
+}
+
+func startIsolatedRuntime(ctx context.Context) (*isolatedRuntime, error) {
+	root, err := os.MkdirTemp("", "october-bus-conformance-")
+	if err != nil {
+		return nil, err
+	}
+	paths := bus.DaemonPaths{
+		DataDir: filepath.Join(root, "data"), RuntimeDir: filepath.Join(root, "run"),
+		Database: filepath.Join(root, "data", "bus.db"), RunFile: filepath.Join(root, "run", "bus.json"),
+		LockFile: filepath.Join(root, "run", "bus.lock"),
+	}
+	daemon, err := bus.StartDaemon(ctx, 0, &paths)
+	if err != nil {
+		_ = os.RemoveAll(root)
+		return nil, err
+	}
+	return &isolatedRuntime{daemon: daemon, root: root}, nil
+}
+
+func (runtime *isolatedRuntime) close() error {
+	shutdownContext, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	stopErr := runtime.daemon.Stop(shutdownContext)
+	removeErr := os.RemoveAll(runtime.root)
+	return errors.Join(stopErr, removeErr)
+}
+
 func run() error {
 	flags := flag.NewFlagSet("october-bus-conformance", flag.ContinueOnError)
+	profile := flags.String("profile", conformance.ProfileLocalRuntime, "conformance profile: local-runtime or mcp-adapter")
 	address := flags.String("address", os.Getenv("OCTOBER_BUS_ADDRESS"), "October Bus address")
 	adminTokenEnv := flags.String("admin-token-env", "OCTOBER_BUS_ADMIN_TOKEN", "environment variable containing the admin token")
+	startRuntime := flags.Bool("start-runtime", false, "start an isolated runtime for this run")
+	adapterCommand := flags.String("adapter-command", "", "executable for the mcp-adapter profile")
+	var adapterArgs stringList
+	flags.Var(&adapterArgs, "adapter-arg", "adapter argument, repeatable")
 	timeout := flags.Duration("timeout", 2*time.Minute, "conformance timeout")
 	format := flags.String("format", "json", "output format: json or text")
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
+	addressSet := false
+	flags.Visit(func(value *flag.Flag) {
+		if value.Name == "address" {
+			addressSet = true
+		}
+	})
 	if *format != "json" && *format != "text" {
 		return errors.New("format must be json or text")
 	}
+	if *profile != conformance.ProfileLocalRuntime && *profile != conformance.ProfileMCPAdapter {
+		return errors.New("profile must be local-runtime or mcp-adapter")
+	}
+	if *profile == conformance.ProfileMCPAdapter && *adapterCommand == "" {
+		return errors.New("adapter-command is required for the mcp-adapter profile")
+	}
+	if *profile == conformance.ProfileLocalRuntime && (*adapterCommand != "" || len(adapterArgs) != 0) {
+		return errors.New("adapter-command and adapter-arg require the mcp-adapter profile")
+	}
+	if *startRuntime && addressSet {
+		return errors.New("address cannot be combined with start-runtime")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	var temporaryRuntime *isolatedRuntime
+	if *startRuntime {
+		var err error
+		*address = ""
+		temporaryRuntime, err = startIsolatedRuntime(ctx)
+		if err != nil {
+			return err
+		}
+		*address = temporaryRuntime.daemon.RunFile.Address
+		defer temporaryRuntime.close()
+	}
+
 	adminToken := os.Getenv(*adminTokenEnv)
+	if temporaryRuntime != nil {
+		adminToken = temporaryRuntime.daemon.RunFile.AdminToken
+	}
 	if *address == "" || adminToken == "" {
 		paths, err := bus.DefaultDaemonPaths()
 		if err != nil {
@@ -45,9 +128,15 @@ func run() error {
 	if *address == "" || adminToken == "" {
 		return errors.New("address and admin token are required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
-	defer cancel()
-	result, runErr := conformance.Run(ctx, conformance.Options{Address: *address, AdminToken: adminToken})
+	var result conformance.Result
+	var runErr error
+	if *profile == conformance.ProfileMCPAdapter {
+		result, runErr = conformance.RunMCPAdapter(ctx, conformance.MCPAdapterOptions{
+			Address: *address, AdminToken: adminToken, Command: *adapterCommand, Args: adapterArgs,
+		})
+	} else {
+		result, runErr = conformance.Run(ctx, conformance.Options{Address: *address, AdminToken: adminToken})
+	}
 	if *format == "text" {
 		fmt.Printf("October Bus %s conformance\n", result.Profile)
 		for _, name := range result.Passed {

--- a/cmd/october-bus-conformance/main_test.go
+++ b/cmd/october-bus-conformance/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/october-dev/october-bus/bus"
+)
+
+func TestIsolatedRuntimeCleanup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	runtimeValue, err := startIsolatedRuntime(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := runtimeValue.root
+	if _, err := (bus.Client{Address: runtimeValue.daemon.RunFile.Address}).Health(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtimeValue.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary runtime directory still exists: %v", err)
+	}
+}

--- a/compatibility/README.md
+++ b/compatibility/README.md
@@ -10,6 +10,8 @@ Each evidence record must validate against [`compatibility-evidence.schema.json`
 
 Use the [harness verification runbook](RUNBOOK.md) to produce a reproducible evidence record.
 
+The automated `mcp-adapter` runner verifies an adapter executable without asking a model to perform the checks. This establishes the transport and coordination behavior of the adapter. It does not establish compatibility for a named harness. A harness enters this registry only after its released version also completes the runbook through that adapter.
+
 ## Support levels
 
 | Level | Meaning |

--- a/conformance/mcp_adapter.go
+++ b/conformance/mcp_adapter.go
@@ -1,0 +1,631 @@
+package conformance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/october-dev/october-bus/bus"
+)
+
+const ProfileMCPAdapter = "mcp-adapter"
+
+// MCPAdapterOptions describes one executable MCP adapter verification run.
+type MCPAdapterOptions struct {
+	Address     string
+	AdminToken  string
+	Command     string
+	Args        []string
+	Environment []string
+}
+
+type adapterConnection struct {
+	session *mcp.ClientSession
+	stderr  *bytes.Buffer
+}
+
+func (connection *adapterConnection) close() error {
+	if connection == nil || connection.session == nil {
+		return nil
+	}
+	return connection.session.Close()
+}
+
+func removeEnvironment(base []string, names ...string) []string {
+	removed := make(map[string]bool, len(names))
+	for _, name := range names {
+		removed[strings.ToUpper(name)] = true
+	}
+	result := make([]string, 0, len(base))
+	for _, entry := range base {
+		name, _, _ := strings.Cut(entry, "=")
+		if !removed[strings.ToUpper(name)] {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func setEnvironment(base []string, values ...string) []string {
+	replaced := make([]string, 0, len(values)/2)
+	for index := 0; index < len(values); index += 2 {
+		replaced = append(replaced, values[index])
+	}
+	result := removeEnvironment(base, replaced...)
+	for index := 0; index < len(values); index += 2 {
+		result = append(result, values[index]+"="+values[index+1])
+	}
+	return result
+}
+
+func removeEnvironmentValues(base []string, values ...string) []string {
+	protected := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value != "" {
+			protected[value] = true
+		}
+	}
+	result := make([]string, 0, len(base))
+	for _, entry := range base {
+		_, value, _ := strings.Cut(entry, "=")
+		if !protected[value] {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+func connectAdapter(ctx context.Context, options MCPAdapterOptions, scopeToken string, registration bus.RegisterAgentResult) (*adapterConnection, error) {
+	command := exec.CommandContext(ctx, options.Command, options.Args...)
+	baseEnvironment := options.Environment
+	if baseEnvironment == nil {
+		baseEnvironment = os.Environ()
+	}
+	command.Env = setEnvironment(
+		removeEnvironmentValues(
+			removeEnvironment(baseEnvironment, "OCTOBER_BUS_ADMIN_TOKEN", "OCTOBER_BUS_SCOPE_TOKEN"),
+			options.AdminToken, scopeToken,
+		),
+		"OCTOBER_BUS_ADDRESS", options.Address,
+		"OCTOBER_BUS_AGENT_ID", registration.AgentID,
+		"OCTOBER_BUS_EXECUTION_ID", registration.ExecutionID,
+		"OCTOBER_BUS_AGENT_TOKEN", registration.AgentToken,
+	)
+	stderr := &bytes.Buffer{}
+	command.Stderr = stderr
+	client := mcp.NewClient(&mcp.Implementation{Name: "october-bus-conformance", Version: bus.Version}, nil)
+	session, err := client.Connect(ctx, &mcp.CommandTransport{Command: command}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not start MCP adapter: %w", err)
+	}
+	return &adapterConnection{session: session, stderr: stderr}, nil
+}
+
+func decodeToolResult[T any](result *mcp.CallToolResult, err error) (T, error) {
+	var zero T
+	if err != nil {
+		return zero, err
+	}
+	if result == nil {
+		return zero, errors.New("tool returned no result")
+	}
+	if result.IsError {
+		return zero, fmt.Errorf("tool returned an error: %s", toolResultText(result))
+	}
+	encoded, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		return zero, err
+	}
+	var decoded T
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return zero, fmt.Errorf("could not decode tool result: %w", err)
+	}
+	return decoded, nil
+}
+
+func toolResultText(result *mcp.CallToolResult) string {
+	parts := make([]string, 0, len(result.Content))
+	for _, content := range result.Content {
+		if textContent, ok := content.(*mcp.TextContent); ok {
+			parts = append(parts, textContent.Text)
+		}
+	}
+	if len(parts) == 0 {
+		return "unspecified error"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func callTool[T any](ctx context.Context, session *mcp.ClientSession, name string, arguments map[string]any) (T, error) {
+	return decodeToolResult[T](session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: arguments}))
+}
+
+func requireToolError(ctx context.Context, session *mcp.ClientSession, name string, arguments map[string]any) error {
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: arguments})
+	if err != nil {
+		return nil
+	}
+	if result != nil && result.IsError {
+		return nil
+	}
+	return fmt.Errorf("expected %s to fail", name)
+}
+
+func findAgent(agents []bus.Agent, id string) (bus.Agent, error) {
+	for _, agent := range agents {
+		if agent.ID == id {
+			return agent, nil
+		}
+	}
+	return bus.Agent{}, fmt.Errorf("agent %s was not found", id)
+}
+
+func checkNoCredentials(logs []*bytes.Buffer, credentials ...string) error {
+	for _, log := range logs {
+		text := log.String()
+		for _, credential := range credentials {
+			if credential != "" && strings.Contains(text, credential) {
+				return errors.New("adapter diagnostics contained a protected credential")
+			}
+		}
+	}
+	return nil
+}
+
+// RunMCPAdapter verifies an executable adapter over stdio MCP. It verifies the
+// adapter contract, not the behavior of a particular AI model or harness.
+func RunMCPAdapter(ctx context.Context, options MCPAdapterOptions) (result Result, runErr error) {
+	result = Result{
+		Profile: ProfileMCPAdapter, StartedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Passed: []string{}, Failed: []Failure{},
+	}
+	defer func() { result.CompletedAt = time.Now().UTC().Format(time.RFC3339Nano) }()
+	record := recorder{result: &result}
+	if strings.TrimSpace(options.Command) == "" {
+		return result, errors.New("adapter command is required")
+	}
+
+	admin := bus.Client{Address: options.Address, Token: options.AdminToken}
+	var health bus.Health
+	if err := record.check("health-and-version", func() error {
+		var err error
+		health, err = admin.Health(ctx)
+		if err != nil {
+			return err
+		}
+		if health.ProtocolVersion != bus.ProtocolVersion || health.Status != "ready" {
+			return fmt.Errorf("unexpected health response: %#v", health)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+	result.ProtocolVersion = health.ProtocolVersion
+	result.RuntimeVersion = health.RuntimeVersion
+
+	scopeID := fmt.Sprintf("mcp-adapter-%d", time.Now().UnixNano())
+	scope, err := admin.CreateScope(ctx, bus.CreateScopeInput{ID: scopeID})
+	if err != nil {
+		return result, err
+	}
+	owner := bus.Client{Address: options.Address, Token: scope.ScopeToken}
+	controllerSession, err := bus.StartAgentSession(ctx, bus.AgentSessionOptions{
+		Address: options.Address, ScopeToken: scope.ScopeToken,
+		Registration:      bus.RegisterAgentInput{ID: "controller", DisplayName: "Controller", LeaseMS: 30000},
+		HeartbeatInterval: 100 * time.Millisecond, InitialLifecycle: bus.LifecycleReady, InitialReady: true,
+	})
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		closeContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = controllerSession.Close(closeContext)
+	}()
+	controller := controllerSession.Client
+
+	workerContext, stopWorker := context.WithCancel(ctx)
+	workerSession, err := bus.StartAgentSession(workerContext, bus.AgentSessionOptions{
+		Address: options.Address, ScopeToken: scope.ScopeToken,
+		Registration: bus.RegisterAgentInput{
+			ID: "worker", DisplayName: "Worker", ConnectTo: []string{"controller"}, LeaseMS: 30000,
+			Capabilities: []bus.AgentCapability{{Name: "verification"}},
+		},
+		HeartbeatInterval: 100 * time.Millisecond, InitialLifecycle: bus.LifecycleReady, InitialReady: true,
+	})
+	if err != nil {
+		stopWorker()
+		return result, err
+	}
+	workerClosed := false
+	defer func() {
+		if !workerClosed {
+			stopWorker()
+		}
+	}()
+	var adapter *adapterConnection
+	if err := record.check("adapter-start-and-execution-identity", func() error {
+		var err error
+		adapter, err = connectAdapter(ctx, options, scope.ScopeToken, workerSession.Registration)
+		if err != nil {
+			return err
+		}
+		status, err := callTool[bus.NodeStatus](ctx, adapter.session, "get_node_status", map[string]any{})
+		if err != nil {
+			return err
+		}
+		if status.Identity.AgentID != "worker" || status.Identity.ExecutionID != workerSession.Registration.ExecutionID {
+			return fmt.Errorf("unexpected adapter identity: %#v", status.Identity)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+	adapterClosed := false
+	logs := []*bytes.Buffer{adapter.stderr}
+	defer func() {
+		if !adapterClosed {
+			_ = adapter.close()
+		}
+	}()
+
+	if err := record.check("external-heartbeat", func() error {
+		agents, err := owner.ListAgents(ctx)
+		if err != nil {
+			return err
+		}
+		before, err := findAgent(agents, "worker")
+		if err != nil {
+			return err
+		}
+		time.Sleep(250 * time.Millisecond)
+		agents, err = owner.ListAgents(ctx)
+		if err != nil {
+			return err
+		}
+		after, err := findAgent(agents, "worker")
+		if err != nil {
+			return err
+		}
+		if !after.Ready || !after.Reachable || after.UpdatedAt == before.UpdatedAt {
+			return fmt.Errorf("heartbeat did not renew the ready execution: %#v", after)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("exact-peer-discovery", func() error {
+		peers, err := callTool[struct {
+			Peers []bus.Agent `json:"peers"`
+		}](ctx, adapter.session, "list_peers", map[string]any{})
+		if err != nil {
+			return err
+		}
+		if len(peers.Peers) != 1 || peers.Peers[0].ID != "controller" {
+			return fmt.Errorf("unexpected peers: %#v", peers.Peers)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("durable-messaging-and-acknowledgement", func() error {
+		inbound, err := controller.SendMessage(ctx, bus.SendMessageInput{To: "worker", Body: "controller notification"})
+		if err != nil {
+			return err
+		}
+		inbox, err := callTool[struct {
+			Messages []bus.Message `json:"messages"`
+		}](ctx, adapter.session, "check_inbox", map[string]any{"limit": 10})
+		if err != nil || len(inbox.Messages) != 1 || inbox.Messages[0].ID != inbound.MessageID {
+			return fmt.Errorf("unexpected adapter inbox: %#v, %v", inbox.Messages, err)
+		}
+		acknowledged, err := callTool[map[string]int64](ctx, adapter.session, "acknowledge_messages", map[string]any{"messageIds": []string{inbound.MessageID}})
+		if err != nil || acknowledged["acknowledged"] != 1 {
+			return fmt.Errorf("unexpected acknowledgement: %#v, %v", acknowledged, err)
+		}
+		outbound, err := callTool[bus.DeliveryReceipt](ctx, adapter.session, "message_peer", map[string]any{
+			"peer": "controller", "message": "worker notification", "mode": "notify",
+		})
+		if err != nil {
+			return err
+		}
+		messages, err := controller.PullInbox(ctx, 10, 0)
+		if err != nil || len(messages) != 1 || messages[0].ID != outbound.MessageID {
+			return fmt.Errorf("unexpected controller inbox: %#v, %v", messages, err)
+		}
+		_, err = controller.AcknowledgeMessages(ctx, []string{outbound.MessageID})
+		return err
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("correlated-request-and-response", func() error {
+		request, err := controller.SendMessage(ctx, bus.SendMessageInput{To: "worker", Body: "review", Mode: bus.MessageRequest})
+		if err != nil {
+			return err
+		}
+		inbox, err := callTool[struct {
+			Messages []bus.Message `json:"messages"`
+		}](ctx, adapter.session, "check_inbox", map[string]any{"limit": 10})
+		if err != nil || len(inbox.Messages) != 1 || inbox.Messages[0].ID != request.MessageID {
+			return fmt.Errorf("unexpected request inbox: %#v, %v", inbox.Messages, err)
+		}
+		if _, err := callTool[map[string]int64](ctx, adapter.session, "acknowledge_messages", map[string]any{"messageIds": []string{request.MessageID}}); err != nil {
+			return err
+		}
+		response, err := callTool[bus.DeliveryReceipt](ctx, adapter.session, "message_peer", map[string]any{
+			"peer": "controller", "message": "reviewed", "mode": "response", "responseTo": request.MessageID,
+		})
+		if err != nil {
+			return err
+		}
+		messages, err := controller.PullInbox(ctx, 10, 0)
+		if err != nil || len(messages) != 1 || messages[0].ID != response.MessageID {
+			return fmt.Errorf("unexpected response inbox: %#v, %v", messages, err)
+		}
+		if _, err := controller.AcknowledgeMessages(ctx, []string{response.MessageID}); err != nil {
+			return err
+		}
+		receipt, err := controller.Receipt(ctx, request.MessageID)
+		if err != nil || receipt.ResponseMessageID != response.MessageID {
+			return fmt.Errorf("request did not link response: %#v, %v", receipt, err)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("idempotent-send", func() error {
+		arguments := map[string]any{
+			"peer": "controller", "message": "retry once", "mode": "request", "idempotencyKey": "adapter-conformance-retry",
+		}
+		first, err := callTool[bus.DeliveryReceipt](ctx, adapter.session, "message_peer", arguments)
+		if err != nil {
+			return err
+		}
+		second, err := callTool[bus.DeliveryReceipt](ctx, adapter.session, "message_peer", arguments)
+		if err != nil || first.MessageID != second.MessageID {
+			return fmt.Errorf("retry created a duplicate: %#v, %#v, %v", first, second, err)
+		}
+		messages, err := controller.PullInbox(ctx, 10, 0)
+		if err != nil || len(messages) != 1 || messages[0].ID != first.MessageID {
+			return fmt.Errorf("unexpected retry delivery: %#v, %v", messages, err)
+		}
+		if _, err := controller.AcknowledgeMessages(ctx, []string{first.MessageID}); err != nil {
+			return err
+		}
+		_, err = controller.SendMessage(ctx, bus.SendMessageInput{
+			To: "worker", Body: "accepted", Mode: bus.MessageResponse, ResponseTo: first.MessageID,
+		})
+		if err != nil {
+			return err
+		}
+		inbox, err := callTool[struct {
+			Messages []bus.Message `json:"messages"`
+		}](ctx, adapter.session, "check_inbox", map[string]any{"limit": 10})
+		if err != nil || len(inbox.Messages) != 1 {
+			return fmt.Errorf("unexpected retry response: %#v, %v", inbox.Messages, err)
+		}
+		_, err = callTool[map[string]int64](ctx, adapter.session, "acknowledge_messages", map[string]any{"messageIds": []string{inbox.Messages[0].ID}})
+		return err
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("bounded-context", func() error {
+		receipt, err := callTool[bus.DeliveryReceipt](ctx, adapter.session, "message_peer", map[string]any{
+			"peer": "controller", "message": "bounded context", "context": []map[string]any{{
+				"kind": "text", "title": "Relevant finding", "text": "Only this finding is shared.",
+			}},
+		})
+		if err != nil {
+			return err
+		}
+		messages, err := controller.PullInbox(ctx, 10, 0)
+		if err != nil || len(messages) != 1 || messages[0].ID != receipt.MessageID || len(messages[0].Context) != 1 || messages[0].Context[0].Title != "Relevant finding" {
+			return fmt.Errorf("unexpected bounded context: %#v, %v", messages, err)
+		}
+		_, err = controller.AcknowledgeMessages(ctx, []string{receipt.MessageID})
+		return err
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("shared-task-lifecycle", func() error {
+		first, err := callTool[bus.Task](ctx, adapter.session, "add_task", map[string]any{"description": "First task"})
+		if err != nil {
+			return err
+		}
+		blocked, err := callTool[bus.Task](ctx, adapter.session, "add_task", map[string]any{
+			"description": "Dependent task", "dependencies": []string{first.ID},
+		})
+		if err != nil {
+			return err
+		}
+		if err := requireToolError(ctx, adapter.session, "claim_task", map[string]any{"taskId": blocked.ID}); err != nil {
+			return err
+		}
+		for _, call := range []struct {
+			name string
+			args map[string]any
+		}{
+			{"claim_task", map[string]any{"taskId": first.ID}},
+			{"release_task", map[string]any{"taskId": first.ID}},
+			{"claim_task", map[string]any{"taskId": first.ID}},
+			{"complete_task", map[string]any{"taskId": first.ID, "note": "Complete"}},
+		} {
+			if _, err := callTool[bus.Task](ctx, adapter.session, call.name, call.args); err != nil {
+				return err
+			}
+		}
+		if _, err := controller.ClaimTask(ctx, blocked.ID); err != nil {
+			return err
+		}
+		_, err = controller.CompleteTask(ctx, blocked.ID, "Complete")
+		return err
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("human-escalation-boundary", func() error {
+		escalation, err := callTool[bus.HumanEscalation](ctx, adapter.session, "ask_user", map[string]any{
+			"question": "Continue?", "options": []string{"yes", "no"},
+		})
+		if err != nil {
+			return err
+		}
+		if _, err := workerSession.Client.ResolveEscalation(ctx, escalation.ID, "yes"); requireCode(err, bus.CodeUnauthenticated) != nil {
+			return fmt.Errorf("agent resolved its own escalation: %v", err)
+		}
+		resolved, err := owner.ResolveEscalation(ctx, escalation.ID, "yes")
+		if err != nil || resolved.Status != "resolved" {
+			return fmt.Errorf("owner could not resolve escalation: %#v, %v", resolved, err)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("execution-replacement", func() error {
+		replacement, err := owner.RegisterAgent(ctx, bus.RegisterAgentInput{ID: "worker", DisplayName: "Worker", LeaseMS: 30000})
+		if err != nil {
+			return err
+		}
+		if replacement.ExecutionID == workerSession.Registration.ExecutionID {
+			return errors.New("replacement reused the previous execution id")
+		}
+		if err := requireToolError(ctx, adapter.session, "list_tasks", map[string]any{}); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
+	if err := adapter.close(); err != nil {
+		return result, err
+	}
+	adapterClosed = true
+	stopWorker()
+	<-workerSession.Done()
+	workerClosed = true
+
+	if err := record.check("clean-and-expired-lifecycle", func() error {
+		cleanContext, stopClean := context.WithCancel(ctx)
+		cleanSession, err := bus.StartAgentSession(cleanContext, bus.AgentSessionOptions{
+			Address: options.Address, ScopeToken: scope.ScopeToken,
+			Registration:      bus.RegisterAgentInput{ID: "clean-worker", DisplayName: "Clean Worker", LeaseMS: 30000},
+			HeartbeatInterval: 100 * time.Millisecond, InitialLifecycle: bus.LifecycleReady, InitialReady: true,
+		})
+		if err != nil {
+			stopClean()
+			return err
+		}
+		cleanAdapter, err := connectAdapter(ctx, options, scope.ScopeToken, cleanSession.Registration)
+		if err != nil {
+			stopClean()
+			return err
+		}
+		logs = append(logs, cleanAdapter.stderr)
+		if err := cleanAdapter.close(); err != nil {
+			stopClean()
+			return err
+		}
+		closeContext, cancelClose := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelClose()
+		if err := cleanSession.Close(closeContext); err != nil {
+			stopClean()
+			return err
+		}
+		stopClean()
+		agents, err := owner.ListAgents(ctx)
+		if err != nil {
+			return err
+		}
+		cleanAgent, err := findAgent(agents, "clean-worker")
+		if err != nil || cleanAgent.Lifecycle != bus.LifecycleOffline || cleanAgent.Reachable {
+			return fmt.Errorf("clean worker did not go offline: %#v, %v", cleanAgent, err)
+		}
+
+		crashContext, stopCrash := context.WithCancel(ctx)
+		crashSession, err := bus.StartAgentSession(crashContext, bus.AgentSessionOptions{
+			Address: options.Address, ScopeToken: scope.ScopeToken,
+			Registration:      bus.RegisterAgentInput{ID: "crash-worker", DisplayName: "Crash Worker", LeaseMS: 30000},
+			HeartbeatInterval: 100 * time.Millisecond, InitialLifecycle: bus.LifecycleReady, InitialReady: true,
+		})
+		if err != nil {
+			stopCrash()
+			return err
+		}
+		crashAdapter, err := connectAdapter(ctx, options, scope.ScopeToken, crashSession.Registration)
+		if err != nil {
+			stopCrash()
+			return err
+		}
+		logs = append(logs, crashAdapter.stderr)
+		task, err := callTool[bus.Task](ctx, crashAdapter.session, "add_task", map[string]any{"description": "Recover after expiry"})
+		if err != nil {
+			_ = crashAdapter.close()
+			stopCrash()
+			return err
+		}
+		if _, err := callTool[bus.Task](ctx, crashAdapter.session, "claim_task", map[string]any{"taskId": task.ID}); err != nil {
+			_ = crashAdapter.close()
+			stopCrash()
+			return err
+		}
+		stopCrash()
+		<-crashSession.Done()
+		if err := crashAdapter.close(); err != nil {
+			return err
+		}
+		expiryDeadline := time.Now().Add(33 * time.Second)
+		for {
+			agents, err = owner.ListAgents(ctx)
+			if err != nil {
+				return err
+			}
+			crashed, findErr := findAgent(agents, "crash-worker")
+			if findErr != nil {
+				return findErr
+			}
+			if !crashed.Reachable {
+				break
+			}
+			if time.Now().After(expiryDeadline) {
+				return fmt.Errorf("expired worker remained reachable: %#v", crashed)
+			}
+			timer := time.NewTimer(100 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		if _, err := controller.ClaimTask(ctx, task.ID); err != nil {
+			return fmt.Errorf("expired execution claim was not recovered: %w", err)
+		}
+		_, err = controller.CompleteTask(ctx, task.ID, "Recovered")
+		return err
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("credential-isolation", func() error {
+		return checkNoCredentials(logs, options.AdminToken, scope.ScopeToken)
+	}); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/conformance/mcp_adapter_internal_test.go
+++ b/conformance/mcp_adapter_internal_test.go
@@ -1,0 +1,16 @@
+package conformance
+
+import "testing"
+
+func TestRemoveEnvironmentValues(t *testing.T) {
+	environment := []string{
+		"PATH=/usr/bin",
+		"CUSTOM_ADMIN=admin-secret",
+		"CUSTOM_SCOPE=scope-secret",
+		"OTHER=value",
+	}
+	filtered := removeEnvironmentValues(environment, "admin-secret", "scope-secret")
+	if len(filtered) != 2 || filtered[0] != "PATH=/usr/bin" || filtered[1] != "OTHER=value" {
+		t.Fatalf("unexpected filtered environment: %#v", filtered)
+	}
+}

--- a/conformance/runner_test.go
+++ b/conformance/runner_test.go
@@ -2,12 +2,29 @@ package conformance_test
 
 import (
 	"context"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/october-dev/october-bus/bus"
 	"github.com/october-dev/october-bus/conformance"
 )
+
+func buildRuntimeCommand(t *testing.T) string {
+	t.Helper()
+	name := "october-bus"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(t.TempDir(), name)
+	command := exec.Command("go", "build", "-o", path, "../cmd/october-bus")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build runtime command: %v\n%s", err, output)
+	}
+	return path
+}
 
 func TestLocalRuntimeProfile(t *testing.T) {
 	runtimeValue, err := bus.Open(":memory:")
@@ -44,6 +61,50 @@ func TestFailureResultNamesTheFailedCheck(t *testing.T) {
 	defer server.Stop(context.Background())
 	result, err := conformance.Run(context.Background(), conformance.Options{Address: address, AdminToken: "wrong-token"})
 	if err == nil || len(result.Failed) != 1 || result.Failed[0].Check != "scope-authority" || result.CompletedAt == "" {
+		t.Fatalf("unexpected failure result: %#v, %v", result, err)
+	}
+}
+
+func TestMCPAdapterProfile(t *testing.T) {
+	runtimeValue, err := bus.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := bus.NewServer(runtimeValue, bus.ServerOptions{AdminToken: "conformance-admin-token"})
+	address, err := server.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop(context.Background())
+	binary := buildRuntimeCommand(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Second)
+	defer cancel()
+	result, err := conformance.RunMCPAdapter(ctx, conformance.MCPAdapterOptions{
+		Address: address, AdminToken: "conformance-admin-token", Command: binary, Args: []string{"mcp", "stdio"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Profile != conformance.ProfileMCPAdapter || result.ProtocolVersion != bus.ProtocolVersion || len(result.Passed) != 13 || len(result.Failed) != 0 || result.CompletedAt == "" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestMCPAdapterFailureNamesStartupCheck(t *testing.T) {
+	runtimeValue, err := bus.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := bus.NewServer(runtimeValue, bus.ServerOptions{AdminToken: "conformance-admin-token"})
+	address, err := server.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop(context.Background())
+	result, err := conformance.RunMCPAdapter(context.Background(), conformance.MCPAdapterOptions{
+		Address: address, AdminToken: "conformance-admin-token", Command: buildRuntimeCommand(t), Args: []string{"version"},
+	})
+	if err == nil || len(result.Failed) != 1 || result.Failed[0].Check != "adapter-start-and-execution-identity" || result.CompletedAt == "" {
 		t.Fatalf("unexpected failure result: %#v, %v", result, err)
 	}
 }

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,41 @@
+# Conformance profiles
+
+The conformance runner checks October Bus implementations and adapters through public interfaces. It emits JSON by default and exits nonzero after recording the first failed check. Use `--format text` for terminal output.
+
+## Local runtime
+
+Run the local runtime profile against the current daemon:
+
+```bash
+october-bus-conformance --format text
+```
+
+Use `--address` with `OCTOBER_BUS_ADMIN_TOKEN` to target another daemon. Use `--admin-token-env` when the admin credential is stored under a different environment variable.
+
+For an isolated run, let the runner start a daemon on a free loopback port:
+
+```bash
+october-bus-conformance --start-runtime --format text
+```
+
+The runner uses a temporary data directory and removes it after stopping the daemon.
+
+## MCP adapter
+
+The MCP adapter profile starts an executable directly, without a shell. Each adapter argument is passed separately:
+
+```bash
+october-bus-conformance \
+  --profile mcp-adapter \
+  --start-runtime \
+  --adapter-command october-bus \
+  --adapter-arg mcp \
+  --adapter-arg stdio \
+  --format text
+```
+
+The runner gives the adapter an execution-bound agent credential and keeps registration and heartbeat outside the MCP process. Admin and scope credentials are removed from the adapter environment. The profile checks identity, heartbeat, exact peer discovery, durable messaging, acknowledgements, requests, replies, idempotency, bounded context, shared tasks, human escalation, execution replacement, clean shutdown, and lease-expiry recovery.
+
+The lease-expiry check takes about 30 seconds. Increase `--timeout` if the host is slow.
+
+Passing this automated profile verifies the adapter command. It does not verify a named AI harness. Use the [harness verification runbook](../compatibility/RUNBOOK.md) with a released harness before adding compatibility evidence to the public registry.

--- a/spec/0.1/adapters.md
+++ b/spec/0.1/adapters.md
@@ -41,7 +41,9 @@ An `experimental` manifest describes integration work but is never compatibility
 
 ## MCP adapter profile
 
-An MCP adapter passes the required profile when a released harness version can:
+The automated MCP adapter profile verifies the executable adapter separately from a harness. A passing adapter run is necessary, but is not compatibility evidence for a named harness. Harness evidence additionally requires a released harness version to complete the verification runbook through that adapter.
+
+The complete MCP adapter profile requires that the adapter and released harness can:
 
 1. start through the adapter with an execution-bound agent credential;
 2. remain leased through heartbeat owned outside the model loop;


### PR DESCRIPTION
## Summary

- add an executable `mcp-adapter` conformance profile with 13 named checks
- add isolated runtime startup and cleanup to the conformance CLI
- verify stdio identity, heartbeat, coordination primitives, authority replacement, lifecycle recovery, and credential isolation
- document the boundary between adapter conformance and harness compatibility evidence

Closes #69

## Validation

- `go test -race -count=1 ./...`
- `go vet ./...`
- local-runtime conformance: 15/15
- MCP adapter conformance: 13/13
- TypeScript typecheck, build, error tests, and dependency audit
- Linux and Windows cross-builds
- two-agent demo
