### PR TITLE
Fix Codex MCP credential forwarding

### DIFF
--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -19,4 +19,6 @@ october-bus agent run \
 
 The wrapper gives Codex only its execution-scoped agent token. It owns heartbeat and marks the execution offline when Codex exits. It does not infer model readiness from the process alone.
 
+Codex filters the environment inherited by stdio MCP servers. Keep the `env_vars` list from the example so the bridge receives the Bus address and execution token. Do not add the scope or admin credential to that list.
+
 The example asks before each October Bus tool call. Change the approval mode only when the agent's permissions and scope are appropriate for unattended Bus actions.

--- a/adapters/codex/config.toml.example
+++ b/adapters/codex/config.toml.example
@@ -1,5 +1,6 @@
 [mcp_servers.october_bus]
 command = "october-bus"
 args = ["mcp", "stdio"]
+env_vars = ["OCTOBER_BUS_ADDRESS", "OCTOBER_BUS_AGENT_TOKEN"]
 required = true
 default_tools_approval_mode = "prompt"

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -5,11 +5,26 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/october-dev/october-bus/bus"
 )
+
+func TestCodexAdapterForwardsOnlyExecutionCredentials(t *testing.T) {
+	configuration, err := os.ReadFile(filepath.Join("..", "adapters", "codex", "config.toml.example"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(configuration)
+	if !strings.Contains(text, `env_vars = ["OCTOBER_BUS_ADDRESS", "OCTOBER_BUS_AGENT_TOKEN"]`) {
+		t.Fatal("Codex adapter must forward the Bus address and execution token")
+	}
+	if strings.Contains(text, "OCTOBER_BUS_SCOPE_TOKEN") || strings.Contains(text, "OCTOBER_BUS_ADMIN_TOKEN") {
+		t.Fatal("Codex adapter must not forward scope or admin credentials")
+	}
+}
 
 func readJSON(t *testing.T, path string) any {
 	t.Helper()


### PR DESCRIPTION
## Summary

- allow Codex to forward the Bus address and execution token to the stdio MCP bridge
- keep scope and admin credentials out of the MCP process
- document Codex's stdio environment filtering
- add a regression check for the credential boundary

Part of #36

## Validation

- completed the full Codex coordination pilot with Codex CLI 0.152.1
- `go test -race -count=1 ./spec`
- `go vet ./...`
