### PR TITLE
Verify Codex adapter on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ People increasingly run several coding agents at once. The human often becomes t
 Agents should be able to coordinate directly while keeping their own tools, permissions, and context. October Bus provides the shared language for that coordination. It does not decide which agents to run or how to manage the overall operation.
 
 > [!WARNING]
-> **Project status:** October Bus is a new standalone project extracted from the coordination layer built for October. It is under active development and is not yet stable. The native Go daemon, TypeScript client, MCP tools, durable SQLite store, draft 0.1 specification, and local-runtime conformance profile are runnable. Early Claude Code, Codex, Cursor, and OpenCode configurations are included. Protocol and package interfaces may change before the first stable release, and no harness integration is conformance-verified yet.
+> **Project status:** October Bus is a new standalone project extracted from the coordination layer built for October. It is under active development and is not yet stable. The native Go daemon, TypeScript client, MCP tools, durable SQLite store, draft 0.1 specification, and conformance profiles are runnable. Codex CLI 0.152.1 is verified on macOS arm64. Early Claude Code, Cursor, and OpenCode configurations are included. Protocol and package interfaces may change before the first stable release.
 
 ## What agents can do
 
@@ -195,7 +195,7 @@ If a harness cannot safely wake itself or prove that it is idle, it can implemen
 
 ## Compatibility
 
-Early Claude Code, Codex, Cursor, and OpenCode configurations live in `adapters/`. They are not yet conformance-verified and are not compatibility claims. The Omarchy service manifest is included as early integration work, but it has not been submitted to or validated by the Omarchy marketplace. The [compatibility registry](compatibility/README.md) starts empty and will list only adapters with current passing evidence.
+Codex CLI 0.152.1 is verified on macOS arm64. Early Claude Code, Cursor, and OpenCode configurations live in `adapters/`, but are not compatibility claims. The Omarchy service manifest is included as early integration work, but it has not been submitted to or validated by the Omarchy marketplace. The [compatibility registry](compatibility/README.md) lists only adapters with current passing evidence.
 
 The conformance runner can start an isolated runtime and remove its state when the run finishes:
 

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,6 +1,6 @@
 # Codex adapter
 
-Status: early integration, not yet conformance-verified.
+Status: verified with Codex CLI 0.152.1 on macOS arm64. Other versions and platforms remain unverified.
 
 Start October Bus, then create a scope. Add the example MCP server entry to a trusted project's `.codex/config.toml`. It launches the stdio bridge inside the managed agent execution.
 

--- a/adapters/codex/adapter.json
+++ b/adapters/codex/adapter.json
@@ -3,19 +3,20 @@
   "id": "codex-mcp",
   "adapterVersion": "0.1.0",
   "harnessFamily": "Codex",
-  "status": "experimental",
+  "status": "verified",
   "protocolVersions": ["0.1"],
   "transport": "mcp",
   "delivery": "pull",
   "lifecycleEvidence": "process",
   "capabilities": ["discovery", "messaging", "requests", "tasks", "escalation", "bounded-context"],
-  "testedVersions": [],
-  "platforms": ["macos", "linux", "windows"],
+  "testedVersions": ["0.152.1"],
+  "platforms": ["macos"],
   "maintainer": "October",
   "repository": "https://github.com/october-dev/october-bus",
   "limitations": [
-    "Not yet conformance-verified",
     "Pull-only delivery",
-    "Process reachability does not prove model readiness"
-  ]
+    "Process reachability does not prove model readiness",
+    "Verified only on macOS arm64"
+  ],
+  "conformanceCommand": "october-bus-conformance --profile mcp-adapter --start-runtime --adapter-command october-bus --adapter-arg mcp --adapter-arg stdio"
 }

--- a/compatibility/evidence/codex-0.152.1-macos-arm64.json
+++ b/compatibility/evidence/codex-0.152.1-macos-arm64.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "harnessFamily": "Codex",
+  "harnessVersion": "0.152.1",
+  "adapterId": "codex-mcp",
+  "adapterVersion": "0.1.0",
+  "protocolVersion": "0.1",
+  "runtimeVersion": "0.1.0-rc.4",
+  "operatingSystem": "macos",
+  "architecture": "arm64",
+  "profile": "mcp-adapter",
+  "result": "passed",
+  "resultDigest": "sha256:bd980ccca1aeb7598f3f29fa56be0c4fc0a122a481ed07a01718a6e352edfa27",
+  "verifiedAt": "2026-09-02T13:05:48Z",
+  "repositoryCommit": "a8c2793ffc3925421f8782ac08985dfa88d2fcc0",
+  "verificationMode": "assisted",
+  "limitations": [
+    "Pull-only delivery",
+    "Process reachability does not prove model readiness",
+    "Verified only on macOS arm64"
+  ]
+}

--- a/compatibility/registry.json
+++ b/compatibility/registry.json
@@ -1,4 +1,6 @@
 {
   "schemaVersion": 1,
-  "verified": []
+  "verified": [
+    "evidence/codex-0.152.1-macos-arm64.json"
+  ]
 }


### PR DESCRIPTION
## Summary

- add passing Codex CLI 0.152.1 compatibility evidence for macOS arm64
- register the verified Codex adapter and narrow its platform claim
- link the result to the released `v0.1.0-rc.4` runtime and exact repository commit
- retain explicit pull-delivery and lifecycle limitations

Closes #36

## Verification

- verified the release archive checksum
- ran the full assisted harness scenario through the released daemon, launcher, and stdio bridge
- verified discovery, bidirectional delivery, acknowledgements, request/reply correlation, idempotency, bounded context, dependent shared tasks, escalation, and clean shutdown
- `go test -race -count=1 ./spec`
- `go vet ./...`
