### PR TITLE
Add resumable scope event streams

### DIFF
--- a/bus/client.go
+++ b/bus/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"net/url"
 	"time"
@@ -176,6 +177,44 @@ func (c Client) StorageSummary(ctx context.Context) (StorageSummary, error) {
 
 func (c Client) PruneScope(ctx context.Context, input PruneScopeInput) (PruneScopeResult, error) {
 	return request[PruneScopeResult](ctx, c, http.MethodPost, "/v1/scope/storage/prune", input)
+}
+
+func (c Client) Events(ctx context.Context, after int64, limit int, wait time.Duration) (EventBatch, error) {
+	if limit == 0 {
+		limit = defaultEventLimit
+	}
+	waitMS := wait.Milliseconds()
+	if wait > 0 && waitMS == 0 {
+		waitMS = 1
+	}
+	query := url.Values{}
+	query.Set("after", fmt.Sprintf("%d", after))
+	query.Set("limit", fmt.Sprintf("%d", limit))
+	query.Set("waitMs", fmt.Sprintf("%d", waitMS))
+	return request[EventBatch](ctx, c, http.MethodGet, "/v1/events?"+query.Encode(), nil)
+}
+
+func (c Client) WatchEvents(ctx context.Context, after int64, limit int) iter.Seq2[EventBatch, error] {
+	return func(yield func(EventBatch, error) bool) {
+		for ctx.Err() == nil {
+			batch, err := c.Events(ctx, after, limit, 25*time.Second)
+			if err != nil {
+				yield(EventBatch{}, err)
+				return
+			}
+			if batch.ResyncRequired {
+				yield(batch, nil)
+				return
+			}
+			after = batch.NextRevision
+			if len(batch.Events) == 0 {
+				continue
+			}
+			if !yield(batch, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (c Client) ClaimTask(ctx context.Context, taskID string) (Task, error) {

--- a/bus/events.go
+++ b/bus/events.go
@@ -1,0 +1,181 @@
+package bus
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+const (
+	defaultEventLimit    = 50
+	maxEventLimit        = 100
+	maxScopeEventWaiters = 128
+)
+
+func eventAttributes(values ...string) map[string]string {
+	attributes := make(map[string]string, len(values)/2)
+	for index := 0; index+1 < len(values); index += 2 {
+		if values[index+1] != "" {
+			attributes[values[index]] = values[index+1]
+		}
+	}
+	return attributes
+}
+
+func appendEvent(ctx context.Context, tx *sql.Tx, scopeID, eventType, subjectID string, attributes map[string]string, createdAt int64) error {
+	var revision int64
+	if err := tx.QueryRowContext(ctx, `UPDATE scopes SET event_revision=event_revision+1 WHERE scope_id=? RETURNING event_revision`, scopeID).Scan(&revision); err != nil {
+		return err
+	}
+	eventID, err := randomID("evt_")
+	if err != nil {
+		return err
+	}
+	if attributes == nil {
+		attributes = map[string]string{}
+	}
+	data, err := json.Marshal(attributes)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `INSERT INTO events(event_id,scope_id,revision,event_type,subject_id,attributes_json,created_at) VALUES(?,?,?,?,?,?,?)`,
+		eventID, scopeID, revision, eventType, subjectID, string(data), createdAt)
+	return err
+}
+
+func scanEvent(row rowScanner) (BusEvent, error) {
+	var event BusEvent
+	var attributes string
+	var createdAt int64
+	if err := row.Scan(&event.ID, &event.ScopeID, &event.Revision, &event.Type, &event.SubjectID, &attributes, &createdAt); err != nil {
+		return BusEvent{}, err
+	}
+	if err := json.Unmarshal([]byte(attributes), &event.Attributes); err != nil {
+		return BusEvent{}, err
+	}
+	if event.Attributes == nil {
+		event.Attributes = map[string]string{}
+	}
+	event.CreatedAt = instant(createdAt)
+	return event, nil
+}
+
+func (s *Store) Events(ctx context.Context, scopeID string, after int64, limit int) (EventBatch, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return EventBatch{}, err
+	}
+	defer tx.Rollback()
+	batch := EventBatch{ScopeID: scopeID, Events: []BusEvent{}, NextRevision: after}
+	if err := tx.QueryRowContext(ctx, `SELECT event_revision,event_floor_revision FROM scopes WHERE scope_id=?`, scopeID).
+		Scan(&batch.CurrentRevision, &batch.MinimumCursor); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return EventBatch{}, Errorf(CodeNotFound, "Scope "+scopeID+" was not found")
+		}
+		return EventBatch{}, err
+	}
+	if after > batch.CurrentRevision {
+		return EventBatch{}, Errorf(CodeInvalidArgument, "after exceeds the current event revision")
+	}
+	if after < batch.MinimumCursor {
+		batch.ResyncRequired = true
+		batch.NextRevision = batch.CurrentRevision
+		if err := tx.Commit(); err != nil {
+			return EventBatch{}, err
+		}
+		return batch, nil
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT event_id,scope_id,revision,event_type,subject_id,attributes_json,created_at FROM events WHERE scope_id=? AND revision>? ORDER BY revision LIMIT ?`, scopeID, after, limit)
+	if err != nil {
+		return EventBatch{}, err
+	}
+	for rows.Next() {
+		event, err := scanEvent(rows)
+		if err != nil {
+			rows.Close()
+			return EventBatch{}, err
+		}
+		batch.Events = append(batch.Events, event)
+		batch.NextRevision = event.Revision
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return EventBatch{}, err
+	}
+	rows.Close()
+	if err := tx.Commit(); err != nil {
+		return EventBatch{}, err
+	}
+	return batch, nil
+}
+
+func normalizedEventLimit(limit int) (int, error) {
+	if limit == 0 {
+		return defaultEventLimit, nil
+	}
+	if limit < 1 || limit > maxEventLimit {
+		return 0, Errorf(CodeInvalidArgument, "limit must be between 1 and 100")
+	}
+	return limit, nil
+}
+
+func (r *Runtime) notifyScope(scopeID string) {
+	r.signals.notify(signalKey{scopeID: scopeID})
+}
+
+func (r *Runtime) Events(ctx context.Context, scopeToken string, after int64, limit int, wait time.Duration) (EventBatch, error) {
+	if after < 0 {
+		return EventBatch{}, Errorf(CodeInvalidArgument, "after must not be negative")
+	}
+	limit, err := normalizedEventLimit(limit)
+	if err != nil {
+		return EventBatch{}, err
+	}
+	if wait < 0 {
+		return EventBatch{}, Errorf(CodeInvalidArgument, "wait must be between 0 and 25 seconds")
+	}
+	waitMS := wait.Milliseconds()
+	if wait > 0 && waitMS == 0 {
+		waitMS = 1
+	}
+	if waitMS < 0 || waitMS > maxEventWaitMS {
+		return EventBatch{}, Errorf(CodeInvalidArgument, "wait must be between 0 and 25 seconds")
+	}
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return EventBatch{}, err
+	}
+	if waitMS == 0 {
+		return r.store.Events(ctx, scopeID, after, limit)
+	}
+	deadline := time.Now().Add(time.Duration(waitMS) * time.Millisecond)
+	key := signalKey{scopeID: scopeID}
+	for {
+		signal, unsubscribe, subscribed := r.signals.subscribeLimited(key, maxScopeEventWaiters)
+		if !subscribed {
+			return EventBatch{}, Errorf(CodeBackpressure, "Scope event wait limit is full")
+		}
+		if _, err := r.store.AuthenticateScope(ctx, scopeToken); err != nil {
+			unsubscribe()
+			return EventBatch{}, err
+		}
+		batch, err := r.store.Events(ctx, scopeID, after, limit)
+		if err != nil || batch.ResyncRequired || len(batch.Events) > 0 || !time.Now().Before(deadline) {
+			unsubscribe()
+			return batch, err
+		}
+		timer := time.NewTimer(time.Until(deadline))
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			unsubscribe()
+			return EventBatch{}, ctx.Err()
+		case <-signal:
+			stopTimer(timer)
+		case <-timer.C:
+		}
+		unsubscribe()
+	}
+}

--- a/bus/events_test.go
+++ b/bus/events_test.go
@@ -1,0 +1,235 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScopeEventsAreOrderedAndDoNotContainRecordBodies(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+
+	message, err := agents.runtime.SendMessage(ctx, agents.plannerToken, SendMessageInput{
+		To: "reviewer", Mode: MessageRequest, Body: "private message body", Context: []ContextItem{{Kind: "text", Title: "private context", Text: "secret"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := agents.runtime.AddTask(ctx, agents.plannerToken, AddTaskInput{Title: "private task title", Description: "private task description"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	escalation, err := agents.runtime.AskHuman(ctx, agents.reviewerToken, AskHumanInput{Question: "private question"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
+	if err != nil || reservation == nil {
+		t.Fatalf("unexpected reservation: %#v, %v", reservation, err)
+	}
+	if err := agents.runtime.ReleaseInbox(ctx, agents.reviewerToken, reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+	reservation, err = agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
+	if err != nil || reservation == nil {
+		t.Fatalf("unexpected second reservation: %#v, %v", reservation, err)
+	}
+	if _, err := agents.runtime.CommitInbox(ctx, agents.reviewerToken, reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.AcknowledgeMessages(ctx, agents.reviewerToken, []string{message.MessageID}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.SendMessage(ctx, agents.reviewerToken, SendMessageInput{
+		To: "planner", Mode: MessageResponse, ResponseTo: message.MessageID, Body: "private reply",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	expiring, err := agents.runtime.SendMessage(ctx, agents.plannerToken, SendMessageInput{To: "reviewer", Body: "private expiring message", ExpiresInMS: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(30 * time.Millisecond)
+	if _, err := agents.runtime.Receipt(ctx, agents.plannerToken, expiring.MessageID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.ClaimTask(ctx, agents.plannerToken, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.AddTaskProgress(ctx, agents.plannerToken, task.ID, AddTaskProgressInput{Kind: "progress", Text: "private progress"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.ReleaseTask(ctx, agents.plannerToken, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.ClaimTask(ctx, agents.plannerToken, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.CompleteTask(ctx, agents.plannerToken, task.ID, "private completion"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.ResolveEscalation(ctx, agents.scope.ScopeToken, escalation.ID, "private answer"); err != nil {
+		t.Fatal(err)
+	}
+
+	batch, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, 0, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.ResyncRequired || len(batch.Events) < 6 || batch.NextRevision != batch.CurrentRevision {
+		t.Fatalf("unexpected event batch: %#v", batch)
+	}
+	for index, event := range batch.Events {
+		if event.Revision != int64(index+1) || event.ScopeID != agents.scope.ScopeID || event.ID == "" || event.CreatedAt == "" {
+			t.Fatalf("invalid event at %d: %#v", index, event)
+		}
+		encoded := event.Type + event.SubjectID
+		for key, value := range event.Attributes {
+			encoded += key + value
+		}
+		for _, private := range []string{"private message body", "private reply", "private expiring message", "private context", "secret", "private task title", "private task description", "private question", "private progress", "private completion", "private answer"} {
+			if strings.Contains(encoded, private) {
+				t.Fatalf("event exposed record content %q: %#v", private, event)
+			}
+		}
+	}
+	subjects := map[string]bool{}
+	for _, event := range batch.Events {
+		subjects[event.SubjectID] = true
+	}
+	for _, subject := range []string{message.MessageID, task.ID, escalation.ID} {
+		if !subjects[subject] {
+			t.Fatalf("event batch omitted subject %s", subject)
+		}
+	}
+	types := map[string]bool{}
+	for _, event := range batch.Events {
+		types[event.Type] = true
+	}
+	for _, eventType := range []string{
+		"agent.registered", "link.created", "message.accepted", "message.replied", "message.reserved", "message.released",
+		"message.delivered", "message.acknowledged", "message.expired", "task.created", "task.claimed", "task.progress_added",
+		"task.released", "task.completed", "escalation.created", "escalation.resolved",
+	} {
+		if !types[eventType] {
+			t.Fatalf("event batch omitted type %s", eventType)
+		}
+	}
+
+	resumed, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, batch.NextRevision, 100, 0)
+	if err != nil || len(resumed.Events) != 0 || resumed.NextRevision != batch.NextRevision {
+		t.Fatalf("unexpected resumed batch: %#v, %v", resumed, err)
+	}
+	if _, err := agents.runtime.Events(ctx, agents.plannerToken, 0, 50, 0); err == nil {
+		t.Fatal("agent token read the scope event stream")
+	} else {
+		requireCode(t, err, CodeUnauthenticated)
+	}
+}
+
+func TestScopeEventWaitWakesAndCanBeCanceled(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	current, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, 0, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan EventBatch, 1)
+	failure := make(chan error, 1)
+	go func() {
+		batch, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, current.NextRevision, 100, time.Second)
+		if err != nil {
+			failure <- err
+			return
+		}
+		result <- batch
+	}()
+	time.Sleep(40 * time.Millisecond)
+	if _, err := agents.runtime.Heartbeat(ctx, agents.plannerToken, HeartbeatInput{Lifecycle: LifecycleWorking, Ready: true, LeaseMS: 30000}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-failure:
+		t.Fatal(err)
+	case batch := <-result:
+		if len(batch.Events) != 1 || batch.Events[0].Type != "agent.lifecycle_changed" {
+			t.Fatalf("unexpected wake batch: %#v", batch)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	canceled, stop := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := agents.runtime.Events(canceled, agents.scope.ScopeToken, current.NextRevision+1, 100, time.Second)
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	stop()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation, got %v", err)
+	}
+}
+
+func TestIdempotentRetryDoesNotAppendAnotherEvent(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	input := SendMessageInput{To: "reviewer", Body: "retry once", IdempotencyKey: "event-retry"}
+	first, err := agents.runtime.SendMessage(ctx, agents.plannerToken, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retry, err := agents.runtime.SendMessage(ctx, agents.plannerToken, input)
+	if err != nil || retry.MessageID != first.MessageID {
+		t.Fatalf("unexpected retry: %#v, %v", retry, err)
+	}
+	batch, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, 0, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := 0
+	for _, event := range batch.Events {
+		if event.Type == "message.accepted" && event.SubjectID == first.MessageID {
+			accepted++
+		}
+	}
+	if accepted != 1 {
+		t.Fatalf("idempotent send appended %d accepted events", accepted)
+	}
+}
+
+func TestPrunedEventCursorRequiresResync(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	old := time.Now().Add(-2 * time.Hour).UnixMilli()
+	cutoff := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	if _, err := agents.runtime.store.db.Exec(`UPDATE events SET created_at=? WHERE scope_id=?`, old, agents.scope.ScopeID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.Heartbeat(ctx, agents.plannerToken, HeartbeatInput{Lifecycle: LifecycleReady, Ready: true, LeaseMS: 30000}); err != nil {
+		t.Fatal(err)
+	}
+	pruned, err := agents.runtime.PruneScope(ctx, agents.scope.ScopeToken, PruneScopeInput{Before: cutoff, Execute: true})
+	if err != nil || pruned.Records.Events == 0 {
+		t.Fatalf("unexpected event retention: %#v, %v", pruned, err)
+	}
+	stale, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, 0, 100, 0)
+	if err != nil || !stale.ResyncRequired || len(stale.Events) != 0 || stale.MinimumCursor == 0 {
+		t.Fatalf("stale cursor did not require resync: %#v, %v", stale, err)
+	}
+	resumed, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, stale.MinimumCursor, 100, 0)
+	if err != nil || resumed.ResyncRequired || len(resumed.Events) != 1 || resumed.Events[0].Type != "agent.lifecycle_changed" {
+		t.Fatalf("unexpected retained events: %#v, %v", resumed, err)
+	}
+	_, err = agents.runtime.Events(ctx, agents.scope.ScopeToken, resumed.CurrentRevision+1, 100, 0)
+	requireCode(t, err, CodeInvalidArgument)
+}

--- a/bus/inbox_wait.go
+++ b/bus/inbox_wait.go
@@ -2,31 +2,43 @@ package bus
 
 import "sync"
 
-type inboxSignalKey struct {
-	scopeID string
-	agentID string
+type signalKey struct {
+	scopeID    string
+	consumerID string
 }
 
-type inboxSignal struct {
+type runtimeSignal struct {
 	channel chan struct{}
 	waiters int
 }
 
-type inboxSignals struct {
+type runtimeSignals struct {
 	mu       sync.Mutex
-	channels map[inboxSignalKey]*inboxSignal
+	channels map[signalKey]*runtimeSignal
 }
 
-func newInboxSignals() *inboxSignals {
-	return &inboxSignals{channels: make(map[inboxSignalKey]*inboxSignal)}
+func newRuntimeSignals() *runtimeSignals {
+	return &runtimeSignals{channels: make(map[signalKey]*runtimeSignal)}
 }
 
-func (signals *inboxSignals) subscribe(key inboxSignalKey) (<-chan struct{}, func()) {
+func (signals *runtimeSignals) subscribe(key signalKey) (<-chan struct{}, func()) {
+	channel, unsubscribe, _ := signals.subscribeLimited(key, 0)
+	return channel, unsubscribe
+}
+
+func (signals *runtimeSignals) subscribeLimited(key signalKey, limit int) (<-chan struct{}, func(), bool) {
 	signals.mu.Lock()
 	signal := signals.channels[key]
 	if signal == nil {
-		signal = &inboxSignal{channel: make(chan struct{})}
+		signal = &runtimeSignal{channel: make(chan struct{})}
 		signals.channels[key] = signal
+	}
+	if limit > 0 && signal.waiters >= limit {
+		if signal.waiters == 0 {
+			delete(signals.channels, key)
+		}
+		signals.mu.Unlock()
+		return nil, func() {}, false
 	}
 	signal.waiters++
 	signals.mu.Unlock()
@@ -44,10 +56,10 @@ func (signals *inboxSignals) subscribe(key inboxSignalKey) (<-chan struct{}, fun
 				delete(signals.channels, key)
 			}
 		})
-	}
+	}, true
 }
 
-func (signals *inboxSignals) notify(key inboxSignalKey) {
+func (signals *runtimeSignals) notify(key signalKey) {
 	signals.mu.Lock()
 	defer signals.mu.Unlock()
 	if signal := signals.channels[key]; signal != nil {

--- a/bus/inbox_wait_test.go
+++ b/bus/inbox_wait_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestInboxSignalsWakeCurrentWaitersWithoutRetainingIdleAgents(t *testing.T) {
-	signals := newInboxSignals()
-	key := inboxSignalKey{scopeID: "scope", agentID: "agent"}
+	signals := newRuntimeSignals()
+	key := signalKey{scopeID: "scope", consumerID: "agent"}
 	signals.notify(key)
 	if len(signals.channels) != 0 {
 		t.Fatal("notification without waiters retained an idle agent")
@@ -24,6 +24,28 @@ func TestInboxSignalsWakeCurrentWaitersWithoutRetainingIdleAgents(t *testing.T) 
 	}
 	if len(signals.channels) != 0 {
 		t.Fatal("completed notification retained an idle agent")
+	}
+}
+
+func TestRuntimeSignalsEnforceWaiterLimit(t *testing.T) {
+	signals := newRuntimeSignals()
+	key := signalKey{scopeID: "scope"}
+	unsubscribes := make([]func(), 0, 2)
+	for range 2 {
+		_, unsubscribe, ok := signals.subscribeLimited(key, 2)
+		if !ok {
+			t.Fatal("waiter was rejected before the limit")
+		}
+		unsubscribes = append(unsubscribes, unsubscribe)
+	}
+	if _, _, ok := signals.subscribeLimited(key, 2); ok {
+		t.Fatal("waiter above the limit was accepted")
+	}
+	for _, unsubscribe := range unsubscribes {
+		unsubscribe()
+	}
+	if len(signals.channels) != 0 {
+		t.Fatal("released waiters retained a signal")
 	}
 }
 
@@ -151,7 +173,7 @@ func TestReserveInboxTimesOutWithoutReservation(t *testing.T) {
 	if elapsed := time.Since(started); elapsed < 25*time.Millisecond || elapsed > time.Second {
 		t.Fatalf("unexpected wait duration: %s", elapsed)
 	}
-	if len(agents.runtime.inboxSignals.channels) != 0 {
+	if len(agents.runtime.signals.channels) != 0 {
 		t.Fatal("timed-out wait retained an inbox subscription")
 	}
 }
@@ -175,7 +197,7 @@ func TestCanceledInboxWaitDoesNotConsumeLaterMessage(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("inbox wait did not stop after cancellation")
 	}
-	if len(agents.runtime.inboxSignals.channels) != 0 {
+	if len(agents.runtime.signals.channels) != 0 {
 		t.Fatal("canceled wait retained an inbox subscription")
 	}
 

--- a/bus/protocol.go
+++ b/bus/protocol.go
@@ -124,6 +124,25 @@ type TaskProgress struct {
 	CreatedAt   string `json:"createdAt"`
 }
 
+type BusEvent struct {
+	ID         string            `json:"id"`
+	ScopeID    string            `json:"scopeId"`
+	Type       string            `json:"type"`
+	SubjectID  string            `json:"subjectId"`
+	Revision   int64             `json:"revision"`
+	Attributes map[string]string `json:"attributes"`
+	CreatedAt  string            `json:"createdAt"`
+}
+
+type EventBatch struct {
+	ScopeID         string     `json:"scopeId"`
+	Events          []BusEvent `json:"events"`
+	NextRevision    int64      `json:"nextRevision"`
+	CurrentRevision int64      `json:"currentRevision"`
+	MinimumCursor   int64      `json:"minimumCursor"`
+	ResyncRequired  bool       `json:"resyncRequired"`
+}
+
 type StorageRecordSummary struct {
 	RecordType     string `json:"recordType"`
 	State          string `json:"state"`
@@ -149,6 +168,7 @@ type RetentionCounts struct {
 	Tasks        int64 `json:"tasks"`
 	TaskProgress int64 `json:"taskProgress"`
 	Escalations  int64 `json:"escalations"`
+	Events       int64 `json:"events"`
 }
 
 type PruneScopeResult struct {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -3,7 +3,9 @@ package bus
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type routeHandler func(http.ResponseWriter, *http.Request) error
@@ -127,6 +129,9 @@ func (s *Server) newRouter() http.Handler {
 	)
 	registerRoute(router, "/v1/scope/storage/prune",
 		routeMethod{http.MethodPost, s.pruneScope},
+	)
+	registerRoute(router, "/v1/events",
+		routeMethod{http.MethodGet, s.events},
 	)
 	return router
 }
@@ -522,6 +527,55 @@ func (s *Server) pruneScope(response http.ResponseWriter, request *http.Request)
 		return err
 	}
 	result, err := s.runtime.PruneScope(request.Context(), token, input)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, result)
+	return nil
+}
+
+func queryInt64(request *http.Request, name string, defaultValue int64) (int64, error) {
+	value := request.URL.Query().Get(name)
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, Errorf(CodeInvalidArgument, name+" must be an integer")
+	}
+	return parsed, nil
+}
+
+func (s *Server) events(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	after, err := queryInt64(request, "after", 0)
+	if err != nil {
+		return err
+	}
+	limitValue, err := queryInt64(request, "limit", defaultEventLimit)
+	if err != nil {
+		return err
+	}
+	waitMS, err := queryInt64(request, "waitMs", 0)
+	if err != nil {
+		return err
+	}
+	if limitValue < 1 || limitValue > maxEventLimit {
+		return Errorf(CodeInvalidArgument, "limit must be between 1 and 100")
+	}
+	if waitMS < 0 || waitMS > maxEventWaitMS {
+		return Errorf(CodeInvalidArgument, "waitMs must be between 0 and 25000")
+	}
+	parentContext := request.Context()
+	waitContext, cancel := s.inboxWaitContext(parentContext)
+	defer cancel()
+	result, err := s.runtime.Events(waitContext, token, after, int(limitValue), time.Duration(waitMS)*time.Millisecond)
+	if s.inboxWaitStopped(parentContext, err) {
+		result, err = s.runtime.Events(parentContext, token, after, int(limitValue), 0)
+	}
 	if err != nil {
 		return err
 	}

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -9,11 +9,12 @@ const (
 	maxExpiryMS int64 = 30 * 24 * 60 * 60 * 1000
 	// Inbox waits stay below the server and default client timeout of 30 seconds.
 	maxInboxWaitMS int64 = 25 * 1000
+	maxEventWaitMS int64 = 25 * 1000
 )
 
 type Runtime struct {
-	store        *Store
-	inboxSignals *inboxSignals
+	store   *Store
+	signals *runtimeSignals
 }
 
 func Open(source string) (*Runtime, error) {
@@ -21,7 +22,7 @@ func Open(source string) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Runtime{store: store, inboxSignals: newInboxSignals()}, nil
+	return &Runtime{store: store, signals: newRuntimeSignals()}, nil
 }
 
 func (r *Runtime) Close() error { return r.store.Close() }
@@ -64,7 +65,8 @@ func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input Re
 	}
 	result, err := r.store.RegisterAgent(ctx, scopeID, input)
 	if err == nil {
-		r.inboxSignals.notify(inboxSignalKey{scopeID: result.ScopeID, agentID: result.AgentID})
+		r.signals.notify(signalKey{scopeID: result.ScopeID, consumerID: result.AgentID})
+		r.notifyScope(result.ScopeID)
 	}
 	return result, err
 }
@@ -88,7 +90,11 @@ func (r *Runtime) LinkAgents(ctx context.Context, scopeToken, left, right string
 	if err := validateIdentity(right, "right", false); err != nil {
 		return err
 	}
-	return r.store.LinkAgents(ctx, scopeID, left, right)
+	err = r.store.LinkAgents(ctx, scopeID, left, right)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return err
 }
 
 func (r *Runtime) Principal(ctx context.Context, agentToken string) (Principal, error) {
@@ -110,7 +116,11 @@ func (r *Runtime) Heartbeat(ctx context.Context, agentToken string, input Heartb
 	if err != nil {
 		return Agent{}, err
 	}
-	return r.store.Heartbeat(ctx, principal, input)
+	result, changed, err := r.store.Heartbeat(ctx, principal, input)
+	if err == nil && changed {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) ListPeers(ctx context.Context, agentToken string) ([]Agent, error) {
@@ -152,7 +162,8 @@ func (r *Runtime) SendMessage(ctx context.Context, agentToken string, input Send
 	}
 	result, err := r.store.SendMessage(ctx, principal, input)
 	if err == nil {
-		r.inboxSignals.notify(inboxSignalKey{scopeID: principal.ScopeID, agentID: input.To})
+		r.signals.notify(signalKey{scopeID: principal.ScopeID, consumerID: input.To})
+		r.notifyScope(principal.ScopeID)
 	}
 	return result, err
 }
@@ -165,7 +176,11 @@ func (r *Runtime) Receipt(ctx context.Context, agentToken, messageID string) (De
 	if err := validateIdentity(messageID, "messageId", false); err != nil {
 		return DeliveryReceipt{}, err
 	}
-	return r.store.Receipt(ctx, principal, messageID)
+	result, err := r.store.Receipt(ctx, principal, messageID)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func normalizedInboxLimit(limit int) (int, error) {
@@ -194,18 +209,25 @@ func (r *Runtime) ReserveInbox(ctx context.Context, agentToken string, limit int
 		return nil, Errorf(CodeInvalidArgument, "waitMs must be between 0 and 25000")
 	}
 	if waitMS == 0 {
-		return r.store.ReserveInbox(ctx, principal, limit)
+		reservation, err := r.store.ReserveInbox(ctx, principal, limit)
+		if err == nil {
+			r.notifyScope(principal.ScopeID)
+		}
+		return reservation, err
 	}
 	deadline := time.Now().Add(time.Duration(waitMS) * time.Millisecond)
-	key := inboxSignalKey{scopeID: principal.ScopeID, agentID: principal.AgentID}
+	key := signalKey{scopeID: principal.ScopeID, consumerID: principal.AgentID}
 	for {
-		signal, unsubscribe := r.inboxSignals.subscribe(key)
+		signal, unsubscribe := r.signals.subscribe(key)
 		principal, err = r.Principal(ctx, agentToken)
 		if err != nil {
 			unsubscribe()
 			return nil, err
 		}
 		reservation, err := r.store.ReserveInbox(ctx, principal, limit)
+		if err == nil {
+			r.notifyScope(principal.ScopeID)
+		}
 		if err != nil || reservation != nil {
 			unsubscribe()
 			return reservation, err
@@ -268,7 +290,11 @@ func (r *Runtime) CommitInbox(ctx context.Context, agentToken, reservationID str
 	if err := validateIdentity(reservationID, "reservationId", false); err != nil {
 		return nil, err
 	}
-	return r.store.CommitInbox(ctx, principal, reservationID)
+	result, err := r.store.CommitInbox(ctx, principal, reservationID)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) ReleaseInbox(ctx context.Context, agentToken, reservationID string) error {
@@ -281,7 +307,8 @@ func (r *Runtime) ReleaseInbox(ctx context.Context, agentToken, reservationID st
 	}
 	err = r.store.ReleaseInbox(ctx, principal, reservationID)
 	if err == nil {
-		r.inboxSignals.notify(inboxSignalKey{scopeID: principal.ScopeID, agentID: principal.AgentID})
+		r.signals.notify(signalKey{scopeID: principal.ScopeID, consumerID: principal.AgentID})
+		r.notifyScope(principal.ScopeID)
 	}
 	return err
 }
@@ -299,7 +326,11 @@ func (r *Runtime) AcknowledgeMessages(ctx context.Context, agentToken string, me
 			return 0, err
 		}
 	}
-	return r.store.AcknowledgeMessages(ctx, principal, messageIDs)
+	count, err := r.store.AcknowledgeMessages(ctx, principal, messageIDs)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return count, err
 }
 
 func (r *Runtime) AddTask(ctx context.Context, agentToken string, input AddTaskInput) (Task, error) {
@@ -321,7 +352,11 @@ func (r *Runtime) AddTask(ctx context.Context, agentToken string, input AddTaskI
 			return Task{}, err
 		}
 	}
-	return r.store.AddTask(ctx, scopeID, createdBy, input)
+	result, err := r.store.AddTask(ctx, scopeID, createdBy, input)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) ClaimTask(ctx context.Context, agentToken, taskID string) (Task, error) {
@@ -332,7 +367,11 @@ func (r *Runtime) ClaimTask(ctx context.Context, agentToken, taskID string) (Tas
 	if err := validateIdentity(taskID, "taskId", false); err != nil {
 		return Task{}, err
 	}
-	return r.store.ClaimTask(ctx, principal, taskID)
+	result, err := r.store.ClaimTask(ctx, principal, taskID)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) ReleaseTask(ctx context.Context, agentToken, taskID string) (Task, error) {
@@ -343,7 +382,11 @@ func (r *Runtime) ReleaseTask(ctx context.Context, agentToken, taskID string) (T
 	if err := validateIdentity(taskID, "taskId", false); err != nil {
 		return Task{}, err
 	}
-	return r.store.ReleaseTask(ctx, principal, taskID)
+	result, err := r.store.ReleaseTask(ctx, principal, taskID)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) CompleteTask(ctx context.Context, agentToken, taskID, note string) (Task, error) {
@@ -357,7 +400,11 @@ func (r *Runtime) CompleteTask(ctx context.Context, agentToken, taskID, note str
 	if err := validateText(note, "note", 16384, true); err != nil {
 		return Task{}, err
 	}
-	return r.store.CompleteTask(ctx, principal, taskID, note)
+	result, err := r.store.CompleteTask(ctx, principal, taskID, note)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) AddTaskProgress(ctx context.Context, agentToken, taskID string, input AddTaskProgressInput) (TaskProgress, error) {
@@ -376,7 +423,11 @@ func (r *Runtime) AddTaskProgress(ctx context.Context, agentToken, taskID string
 	if err := validateText(input.Text, "text", 4000, false); err != nil {
 		return TaskProgress{}, err
 	}
-	return r.store.AddTaskProgress(ctx, principal, taskID, input)
+	result, err := r.store.AddTaskProgress(ctx, principal, taskID, input)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) ListTaskProgress(ctx context.Context, token, taskID string) ([]TaskProgress, error) {
@@ -395,7 +446,11 @@ func (r *Runtime) ListTasks(ctx context.Context, token string, readyOnly bool) (
 	if err != nil {
 		return nil, err
 	}
-	return r.store.ListTasks(ctx, scopeID, readyOnly)
+	result, err := r.store.ListTasks(ctx, scopeID, readyOnly)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) StorageSummary(ctx context.Context, scopeToken string) (StorageSummary, error) {
@@ -403,7 +458,11 @@ func (r *Runtime) StorageSummary(ctx context.Context, scopeToken string) (Storag
 	if err != nil {
 		return StorageSummary{}, err
 	}
-	return r.store.StorageSummary(ctx, scopeID)
+	result, err := r.store.StorageSummary(ctx, scopeID)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) PruneScope(ctx context.Context, scopeToken string, input PruneScopeInput) (PruneScopeResult, error) {
@@ -415,7 +474,11 @@ func (r *Runtime) PruneScope(ctx context.Context, scopeToken string, input Prune
 	if err != nil {
 		return PruneScopeResult{}, Errorf(CodeInvalidArgument, "before must be an RFC 3339 timestamp")
 	}
-	return r.store.PruneScope(ctx, scopeID, before.UnixMilli(), input.Execute)
+	result, err := r.store.PruneScope(ctx, scopeID, before.UnixMilli(), input.Execute)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) taskAuthority(ctx context.Context, token string) (scopeID, createdBy string, err error) {
@@ -446,7 +509,11 @@ func (r *Runtime) AskHuman(ctx context.Context, agentToken string, input AskHuma
 			return HumanEscalation{}, err
 		}
 	}
-	return r.store.AskHuman(ctx, principal, input)
+	result, err := r.store.AskHuman(ctx, principal, input)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) Escalation(ctx context.Context, agentToken, escalationID string) (HumanEscalation, error) {
@@ -479,7 +546,11 @@ func (r *Runtime) ResolveEscalation(ctx context.Context, scopeToken, escalationI
 	if err := validateText(answer, "answer", 16384, false); err != nil {
 		return HumanEscalation{}, err
 	}
-	return r.store.ResolveEscalation(ctx, scopeID, escalationID, answer)
+	result, err := r.store.ResolveEscalation(ctx, scopeID, escalationID, answer)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
 }
 
 func (r *Runtime) NodeStatus(ctx context.Context, agentToken string) (NodeStatus, error) {

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -464,7 +464,7 @@ func TestOlderSchemaFailsBeforeServingWork(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = Open(path)
-	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 4") {
+	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 5") {
 		t.Fatalf("older schema did not fail clearly: %v", err)
 	}
 }

--- a/bus/storage.go
+++ b/bus/storage.go
@@ -36,6 +36,8 @@ FROM task_progress WHERE scope_id=? GROUP BY kind ORDER BY kind`},
 		{"escalation", `SELECT status,COUNT(*),COALESCE(SUM(length(CAST(question AS BLOB))+length(CAST(options_json AS BLOB))+COALESCE(length(CAST(answer AS BLOB)),0)),0),
 MIN(CASE status WHEN 'pending' THEN created_at ELSE resolved_at END)
 FROM escalations WHERE scope_id=? GROUP BY status ORDER BY status`},
+		{"event", `SELECT event_type,COUNT(*),COALESCE(SUM(length(CAST(event_type AS BLOB))+length(CAST(subject_id AS BLOB))+length(CAST(attributes_json AS BLOB))),0),MIN(created_at)
+FROM events WHERE scope_id=? GROUP BY event_type ORDER BY event_type`},
 	}
 	for _, query := range queries {
 		rows, err := tx.QueryContext(ctx, query.statement, scopeID)
@@ -217,6 +219,25 @@ func (s *Store) PruneScope(ctx context.Context, scopeID string, before int64, ex
 	if err != nil {
 		return PruneScopeResult{}, err
 	}
+	var currentRevision, currentFloor int64
+	if err := tx.QueryRowContext(ctx, `SELECT event_revision,event_floor_revision FROM scopes WHERE scope_id=?`, scopeID).Scan(&currentRevision, &currentFloor); err != nil {
+		return PruneScopeResult{}, err
+	}
+	var firstRetained sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `SELECT MIN(revision) FROM events WHERE scope_id=? AND created_at>=?`, scopeID, before).Scan(&firstRetained); err != nil {
+		return PruneScopeResult{}, err
+	}
+	eventFloor := currentRevision
+	if firstRetained.Valid {
+		eventFloor = firstRetained.Int64 - 1
+	}
+	if eventFloor < currentFloor {
+		eventFloor = currentFloor
+	}
+	var eventCount int64
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE scope_id=? AND revision<=?`, scopeID, eventFloor).Scan(&eventCount); err != nil {
+		return PruneScopeResult{}, err
+	}
 	var taskProgressCount int64
 	for _, taskID := range tasks {
 		var count int64
@@ -228,7 +249,7 @@ func (s *Store) PruneScope(ctx context.Context, scopeID string, before int64, ex
 	result := PruneScopeResult{
 		ScopeID: scopeID, Before: time.UnixMilli(before).UTC().Format(time.RFC3339Nano), DryRun: !execute,
 		Records: RetentionCounts{
-			Messages: int64(len(messages)), Tasks: int64(len(tasks)), TaskProgress: taskProgressCount, Escalations: int64(len(escalations)),
+			Messages: int64(len(messages)), Tasks: int64(len(tasks)), TaskProgress: taskProgressCount, Escalations: int64(len(escalations)), Events: eventCount,
 		},
 	}
 	if execute {
@@ -255,6 +276,14 @@ func (s *Store) PruneScope(ctx context.Context, scopeID string, before int64, ex
 		}
 		for _, escalationID := range escalations {
 			if _, err := tx.ExecContext(ctx, `DELETE FROM escalations WHERE scope_id=? AND escalation_id=?`, scopeID, escalationID); err != nil {
+				return PruneScopeResult{}, err
+			}
+		}
+		if eventCount > 0 {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE scope_id=? AND revision<=?`, scopeID, eventFloor); err != nil {
+				return PruneScopeResult{}, err
+			}
+			if _, err := tx.ExecContext(ctx, `UPDATE scopes SET event_floor_revision=MAX(event_floor_revision,?) WHERE scope_id=?`, eventFloor, scopeID); err != nil {
 				return PruneScopeResult{}, err
 			}
 		}

--- a/bus/store.go
+++ b/bus/store.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	schemaVersion                = 4
+	schemaVersion                = 5
 	reservationTTL               = 30 * time.Second
 	messageBacklogCap            = 10000
 	activeTaskCap                = 5000
@@ -83,7 +83,9 @@ BEGIN IMMEDIATE;
 CREATE TABLE scopes (
   scope_id TEXT PRIMARY KEY,
   token_hash TEXT NOT NULL UNIQUE,
-  created_at INTEGER NOT NULL
+	created_at INTEGER NOT NULL,
+	event_revision INTEGER NOT NULL DEFAULT 0,
+	event_floor_revision INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE agents (
   scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
@@ -188,7 +190,19 @@ CREATE TABLE escalations (
   FOREIGN KEY(scope_id, agent_id) REFERENCES agents(scope_id, agent_id)
 );
 CREATE INDEX escalations_scope_status ON escalations(scope_id, status, created_at);
-PRAGMA user_version=4;
+CREATE TABLE events (
+	event_id TEXT PRIMARY KEY,
+	scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
+	revision INTEGER NOT NULL CHECK(revision>0),
+	event_type TEXT NOT NULL,
+	subject_id TEXT NOT NULL,
+	attributes_json TEXT NOT NULL,
+	created_at INTEGER NOT NULL,
+	UNIQUE(scope_id, revision)
+);
+CREATE INDEX events_scope_revision ON events(scope_id, revision);
+CREATE INDEX events_scope_created ON events(scope_id, created_at);
+PRAGMA user_version=5;
 COMMIT;`)
 	return err
 }
@@ -324,9 +338,21 @@ ON CONFLICT(scope_id,agent_id) DO UPDATE SET
 	if err != nil {
 		return RegisterAgentResult{}, err
 	}
+	if err := appendEvent(ctx, tx, scopeID, "agent.registered", agentID, eventAttributes(
+		"executionId", executionID, "lifecycle", string(LifecycleStarting), "ready", "false", "leaseExpiresAt", instant(leaseExpiresAt),
+	), now); err != nil {
+		return RegisterAgentResult{}, err
+	}
 	for _, peer := range unique(input.ConnectTo) {
-		if err := linkAgents(ctx, tx, scopeID, agentID, peer, now); err != nil {
+		created, err := linkAgents(ctx, tx, scopeID, agentID, peer, now)
+		if err != nil {
 			return RegisterAgentResult{}, err
+		}
+		if created {
+			a, b := orderedPeers(agentID, peer)
+			if err := appendEvent(ctx, tx, scopeID, "link.created", a+":"+b, eventAttributes("leftAgent", a, "rightAgent", b), now); err != nil {
+				return RegisterAgentResult{}, err
+			}
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -389,18 +415,47 @@ func (s *Store) Agent(ctx context.Context, scopeID, agentID string) (Agent, erro
 	return agent, err
 }
 
-func (s *Store) Heartbeat(ctx context.Context, principal Principal, input HeartbeatInput) (Agent, error) {
+func (s *Store) Heartbeat(ctx context.Context, principal Principal, input HeartbeatInput) (Agent, bool, error) {
 	now := nowMillis()
-	result, err := s.db.ExecContext(ctx, `UPDATE agents SET lifecycle=?,ready=?,lease_expires_at=?,updated_at=? WHERE scope_id=? AND agent_id=? AND execution_id=?`,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Agent{}, false, err
+	}
+	defer tx.Rollback()
+	var previousLifecycle AgentLifecycle
+	var previousReady int
+	if err := tx.QueryRowContext(ctx, `SELECT lifecycle,ready FROM agents WHERE scope_id=? AND agent_id=? AND execution_id=?`, principal.ScopeID, principal.AgentID, principal.ExecutionID).
+		Scan(&previousLifecycle, &previousReady); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Agent{}, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
+		}
+		return Agent{}, false, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE agents SET lifecycle=?,ready=?,lease_expires_at=?,updated_at=? WHERE scope_id=? AND agent_id=? AND execution_id=?`,
 		input.Lifecycle, input.Ready, now+input.LeaseMS, now, principal.ScopeID, principal.AgentID, principal.ExecutionID)
 	if err != nil {
-		return Agent{}, err
+		return Agent{}, false, err
 	}
 	changed, _ := result.RowsAffected()
 	if changed != 1 {
-		return Agent{}, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
+		return Agent{}, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
 	}
-	return s.Agent(ctx, principal.ScopeID, principal.AgentID)
+	stateChanged := previousLifecycle != input.Lifecycle || (previousReady == 1) != input.Ready
+	if stateChanged {
+		if err := appendEvent(ctx, tx, principal.ScopeID, "agent.lifecycle_changed", principal.AgentID, eventAttributes(
+			"executionId", principal.ExecutionID, "lifecycle", string(input.Lifecycle), "ready", fmt.Sprintf("%t", input.Ready), "leaseExpiresAt", instant(now+input.LeaseMS),
+		), now); err != nil {
+			return Agent{}, false, err
+		}
+	}
+	agent, err := scanAgent(tx.QueryRowContext(ctx, `SELECT `+agentColumns+` FROM agents WHERE scope_id=? AND agent_id=?`, principal.ScopeID, principal.AgentID))
+	if err != nil {
+		return Agent{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Agent{}, false, err
+	}
+	return agent, stateChanged, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context, scopeID string) ([]Agent, error) {
@@ -430,27 +485,47 @@ func orderedPeers(left, right string) (string, string) {
 func linkAgents(ctx context.Context, executor interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	QueryRowContext(context.Context, string, ...any) *sql.Row
-}, scopeID, left, right string, now int64) error {
+}, scopeID, left, right string, now int64) (bool, error) {
 	if left == right {
-		return Errorf(CodeInvalidArgument, "An agent cannot link to itself")
+		return false, Errorf(CodeInvalidArgument, "An agent cannot link to itself")
 	}
 	for _, id := range []string{left, right} {
 		var found int
 		err := executor.QueryRowContext(ctx, `SELECT 1 FROM agents WHERE scope_id=? AND agent_id=?`, scopeID, id).Scan(&found)
 		if errors.Is(err, sql.ErrNoRows) {
-			return Errorf(CodeNotFound, "Agent "+id+" was not found")
+			return false, Errorf(CodeNotFound, "Agent "+id+" was not found")
 		}
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 	a, b := orderedPeers(left, right)
-	_, err := executor.ExecContext(ctx, `INSERT OR IGNORE INTO peer_links(scope_id,left_agent,right_agent,created_at) VALUES(?,?,?,?)`, scopeID, a, b, now)
-	return err
+	result, err := executor.ExecContext(ctx, `INSERT OR IGNORE INTO peer_links(scope_id,left_agent,right_agent,created_at) VALUES(?,?,?,?)`, scopeID, a, b, now)
+	if err != nil {
+		return false, err
+	}
+	changed, err := result.RowsAffected()
+	return changed == 1, err
 }
 
 func (s *Store) LinkAgents(ctx context.Context, scopeID, left, right string) error {
-	return linkAgents(ctx, s.db, scopeID, left, right, nowMillis())
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	now := nowMillis()
+	created, err := linkAgents(ctx, tx, scopeID, left, right, now)
+	if err != nil {
+		return err
+	}
+	if created {
+		a, b := orderedPeers(left, right)
+		if err := appendEvent(ctx, tx, scopeID, "link.created", a+":"+b, eventAttributes("leftAgent", a, "rightAgent", b), now); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ListPeers(ctx context.Context, principal Principal) ([]Agent, error) {
@@ -521,11 +596,44 @@ func receiptFromMessage(message Message) DeliveryReceipt {
 	}
 }
 
-func expireMessages(ctx context.Context, query interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
-}, scopeID string, now int64) error {
-	_, err := query.ExecContext(ctx, `UPDATE messages SET state='expired',reservation_id=NULL WHERE scope_id=? AND expires_at IS NOT NULL AND expires_at<=? AND state NOT IN ('acknowledged','expired')`, scopeID, now)
-	return err
+func expireMessages(ctx context.Context, tx *sql.Tx, scopeID string, now int64) error {
+	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_agent,to_agent,mode FROM messages WHERE scope_id=? AND expires_at IS NOT NULL AND expires_at<=? AND state NOT IN ('acknowledged','expired')`, scopeID, now)
+	if err != nil {
+		return err
+	}
+	type expiringMessage struct {
+		id, from, to string
+		mode         MessageMode
+	}
+	values := []expiringMessage{}
+	for rows.Next() {
+		var value expiringMessage
+		if err := rows.Scan(&value.id, &value.from, &value.to, &value.mode); err != nil {
+			rows.Close()
+			return err
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	for _, value := range values {
+		result, err := tx.ExecContext(ctx, `UPDATE messages SET state='expired',reservation_id=NULL WHERE message_id=? AND scope_id=? AND state NOT IN ('acknowledged','expired')`, value.id, scopeID)
+		if err != nil {
+			return err
+		}
+		changed, _ := result.RowsAffected()
+		if changed == 1 {
+			if err := appendEvent(ctx, tx, scopeID, "message.expired", value.id, eventAttributes(
+				"from", value.from, "to", value.to, "mode", string(value.mode), "state", string(DeliveryExpired),
+			), now); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func messageRequestHash(input SendMessageInput, mode MessageMode, contextJSON string) string {
@@ -597,6 +705,11 @@ func (s *Store) SendMessage(ctx context.Context, principal Principal, input Send
 	if err != nil {
 		return DeliveryReceipt{}, err
 	}
+	if err := appendEvent(ctx, tx, principal.ScopeID, "message.accepted", messageID, eventAttributes(
+		"from", principal.AgentID, "to", input.To, "mode", string(mode), "state", string(DeliveryQueued), "responseTo", input.ResponseTo,
+	), now); err != nil {
+		return DeliveryReceipt{}, err
+	}
 	if mode == MessageResponse {
 		if input.ResponseTo == "" {
 			return DeliveryReceipt{}, Errorf(CodeInvalidArgument, "responseTo is required for a response")
@@ -642,6 +755,11 @@ func (s *Store) SendMessage(ctx context.Context, principal Principal, input Send
 		if changed != 1 {
 			return DeliveryReceipt{}, Errorf(CodeConflict, "The request already has a response")
 		}
+		if err := appendEvent(ctx, tx, principal.ScopeID, "message.replied", input.ResponseTo, eventAttributes(
+			"responseMessageId", messageID, "from", input.To, "to", principal.AgentID,
+		), now); err != nil {
+			return DeliveryReceipt{}, err
+		}
 	}
 	message, err := scanMessage(tx.QueryRowContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE message_id=?`, messageID))
 	if err != nil {
@@ -684,11 +802,44 @@ func (s *Store) Receipt(ctx context.Context, principal Principal, messageID stri
 }
 
 func releaseReservation(ctx context.Context, tx *sql.Tx, scopeID, agentID, reservationID string) error {
+	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_agent,to_agent,mode,CASE WHEN delivered_at IS NULL THEN 'queued' ELSE 'delivered' END FROM messages WHERE reservation_id=? AND scope_id=? AND to_agent=? AND state='reserved'`, reservationID, scopeID, agentID)
+	if err != nil {
+		return err
+	}
+	type releasedMessage struct {
+		id, from, to string
+		mode         MessageMode
+		state        DeliveryState
+	}
+	values := []releasedMessage{}
+	for rows.Next() {
+		var value releasedMessage
+		if err := rows.Scan(&value.id, &value.from, &value.to, &value.mode, &value.state); err != nil {
+			rows.Close()
+			return err
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
 	if _, err := tx.ExecContext(ctx, `UPDATE messages SET state=CASE WHEN delivered_at IS NULL THEN 'queued' ELSE 'delivered' END,reservation_id=NULL WHERE reservation_id=? AND scope_id=? AND to_agent=? AND state='reserved'`, reservationID, scopeID, agentID); err != nil {
 		return err
 	}
-	_, err := tx.ExecContext(ctx, `DELETE FROM reservations WHERE reservation_id=? AND scope_id=? AND agent_id=?`, reservationID, scopeID, agentID)
-	return err
+	if _, err := tx.ExecContext(ctx, `DELETE FROM reservations WHERE reservation_id=? AND scope_id=? AND agent_id=?`, reservationID, scopeID, agentID); err != nil {
+		return err
+	}
+	now := nowMillis()
+	for _, value := range values {
+		if err := appendEvent(ctx, tx, scopeID, "message.released", value.id, eventAttributes(
+			"from", value.from, "to", value.to, "mode", string(value.mode), "state", string(value.state),
+		), now); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func requireCurrentExecution(ctx context.Context, tx *sql.Tx, principal Principal, now int64) error {
@@ -772,6 +923,11 @@ func (s *Store) ReserveInbox(ctx context.Context, principal Principal, limit int
 		changed, _ := result.RowsAffected()
 		if changed == 1 {
 			messages[i].State = DeliveryReserved
+			if err := appendEvent(ctx, tx, principal.ScopeID, "message.reserved", messages[i].ID, eventAttributes(
+				"from", messages[i].From, "to", messages[i].To, "mode", string(messages[i].Mode), "state", string(DeliveryReserved),
+			), now); err != nil {
+				return nil, err
+			}
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -837,6 +993,13 @@ func (s *Store) CommitInbox(ctx context.Context, principal Principal, reservatio
 	if _, err := tx.ExecContext(ctx, `DELETE FROM reservations WHERE reservation_id=?`, reservationID); err != nil {
 		return nil, err
 	}
+	for _, message := range messages {
+		if err := appendEvent(ctx, tx, principal.ScopeID, "message.delivered", message.ID, eventAttributes(
+			"from", message.From, "to", message.To, "mode", string(message.Mode), "state", string(DeliveryDelivered),
+		), deliveredAt); err != nil {
+			return nil, err
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
@@ -875,13 +1038,26 @@ func (s *Store) AcknowledgeMessages(ctx context.Context, principal Principal, me
 	}
 	var count int64
 	for _, messageID := range unique(messageIDs) {
+		now := nowMillis()
 		result, err := tx.ExecContext(ctx, `UPDATE messages SET state='acknowledged',acknowledged_at=? WHERE message_id=? AND scope_id=? AND to_agent=? AND state='delivered'`,
-			nowMillis(), messageID, principal.ScopeID, principal.AgentID)
+			now, messageID, principal.ScopeID, principal.AgentID)
 		if err != nil {
 			return 0, err
 		}
 		changed, _ := result.RowsAffected()
 		count += changed
+		if changed == 1 {
+			var from, to string
+			var mode MessageMode
+			if err := tx.QueryRowContext(ctx, `SELECT from_agent,to_agent,mode FROM messages WHERE message_id=?`, messageID).Scan(&from, &to, &mode); err != nil {
+				return 0, err
+			}
+			if err := appendEvent(ctx, tx, principal.ScopeID, "message.acknowledged", messageID, eventAttributes(
+				"from", from, "to", to, "mode", string(mode), "state", string(DeliveryAcknowledged),
+			), now); err != nil {
+				return 0, err
+			}
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, err
@@ -951,15 +1127,44 @@ func taskFrom(ctx context.Context, query interface {
 
 func releaseStaleTaskClaims(ctx context.Context, tx *sql.Tx, scopeID string) error {
 	now := nowMillis()
-	_, err := tx.ExecContext(ctx, `UPDATE tasks SET status='open',claimed_by=NULL,claimed_execution_id=NULL,updated_at=?
-WHERE scope_id=? AND status='claimed' AND NOT EXISTS (
+	rows, err := tx.QueryContext(ctx, `SELECT task_id,claimed_by FROM tasks WHERE scope_id=? AND status='claimed' AND NOT EXISTS (
   SELECT 1 FROM agents
   WHERE agents.scope_id=tasks.scope_id
     AND agents.agent_id=tasks.claimed_by
     AND agents.execution_id=tasks.claimed_execution_id
     AND agents.lease_expires_at>?
-)`, now, scopeID, now)
-	return err
+) ORDER BY task_id`, scopeID, now)
+	if err != nil {
+		return err
+	}
+	type staleTask struct{ id, claimedBy string }
+	stale := []staleTask{}
+	for rows.Next() {
+		var taskID, claimedBy string
+		if err := rows.Scan(&taskID, &claimedBy); err != nil {
+			rows.Close()
+			return err
+		}
+		stale = append(stale, staleTask{id: taskID, claimedBy: claimedBy})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	for _, task := range stale {
+		result, err := tx.ExecContext(ctx, `UPDATE tasks SET status='open',claimed_by=NULL,claimed_execution_id=NULL,updated_at=? WHERE scope_id=? AND task_id=? AND status='claimed'`, now, scopeID, task.id)
+		if err != nil {
+			return err
+		}
+		changed, _ := result.RowsAffected()
+		if changed == 1 {
+			if err := appendEvent(ctx, tx, scopeID, "task.released", task.id, eventAttributes("previousClaimedBy", task.claimedBy, "reason", "execution_expired", "status", "open"), now); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (s *Store) AddTask(ctx context.Context, scopeID, createdBy string, input AddTaskInput) (Task, error) {
@@ -1000,6 +1205,9 @@ func (s *Store) AddTask(ctx context.Context, scopeID, createdBy string, input Ad
 	if err != nil {
 		return Task{}, err
 	}
+	if err := appendEvent(ctx, tx, scopeID, "task.created", taskID, eventAttributes("createdBy", createdBy, "status", "open"), now); err != nil {
+		return Task{}, err
+	}
 	task, err := taskFrom(ctx, tx, scopeID, taskID)
 	if err != nil {
 		return Task{}, err
@@ -1033,14 +1241,20 @@ func (s *Store) ClaimTask(ctx context.Context, principal Principal, taskID strin
 			return Task{}, Errorf(CodeConflict, "Task "+taskID+" is blocked by "+dependency)
 		}
 	}
+	now := nowMillis()
 	result, err := tx.ExecContext(ctx, `UPDATE tasks SET status='claimed',claimed_by=?,claimed_execution_id=?,updated_at=? WHERE task_id=? AND scope_id=? AND status='open'`,
-		principal.AgentID, principal.ExecutionID, nowMillis(), taskID, principal.ScopeID)
+		principal.AgentID, principal.ExecutionID, now, taskID, principal.ScopeID)
 	if err != nil {
 		return Task{}, err
 	}
 	changed, _ := result.RowsAffected()
 	if changed != 1 {
 		return Task{}, Errorf(CodeConflict, "Task "+taskID+" was claimed by another agent")
+	}
+	if err := appendEvent(ctx, tx, principal.ScopeID, "task.claimed", taskID, eventAttributes(
+		"claimedBy", principal.AgentID, "executionId", principal.ExecutionID, "status", "claimed",
+	), now); err != nil {
+		return Task{}, err
 	}
 	task, err = taskFrom(ctx, tx, principal.ScopeID, taskID)
 	if err != nil {
@@ -1053,8 +1267,14 @@ func (s *Store) ClaimTask(ctx context.Context, principal Principal, taskID strin
 }
 
 func (s *Store) CompleteTask(ctx context.Context, principal Principal, taskID, note string) (Task, error) {
-	result, err := s.db.ExecContext(ctx, `UPDATE tasks SET status='done',note=?,updated_at=? WHERE task_id=? AND scope_id=? AND status='claimed' AND claimed_by=? AND claimed_execution_id=?`,
-		nullableString(note), nowMillis(), taskID, principal.ScopeID, principal.AgentID, principal.ExecutionID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Task{}, err
+	}
+	defer tx.Rollback()
+	now := nowMillis()
+	result, err := tx.ExecContext(ctx, `UPDATE tasks SET status='done',note=?,updated_at=? WHERE task_id=? AND scope_id=? AND status='claimed' AND claimed_by=? AND claimed_execution_id=?`,
+		nullableString(note), now, taskID, principal.ScopeID, principal.AgentID, principal.ExecutionID)
 	if err != nil {
 		return Task{}, err
 	}
@@ -1062,12 +1282,30 @@ func (s *Store) CompleteTask(ctx context.Context, principal Principal, taskID, n
 	if changed != 1 {
 		return Task{}, Errorf(CodeConflict, "Task "+taskID+" is not claimed by this agent")
 	}
-	return taskFrom(ctx, s.db, principal.ScopeID, taskID)
+	if err := appendEvent(ctx, tx, principal.ScopeID, "task.completed", taskID, eventAttributes(
+		"claimedBy", principal.AgentID, "executionId", principal.ExecutionID, "status", "done",
+	), now); err != nil {
+		return Task{}, err
+	}
+	task, err := taskFrom(ctx, tx, principal.ScopeID, taskID)
+	if err != nil {
+		return Task{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Task{}, err
+	}
+	return task, nil
 }
 
 func (s *Store) ReleaseTask(ctx context.Context, principal Principal, taskID string) (Task, error) {
-	result, err := s.db.ExecContext(ctx, `UPDATE tasks SET status='open',claimed_by=NULL,claimed_execution_id=NULL,updated_at=? WHERE task_id=? AND scope_id=? AND status='claimed' AND claimed_by=? AND claimed_execution_id=?`,
-		nowMillis(), taskID, principal.ScopeID, principal.AgentID, principal.ExecutionID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Task{}, err
+	}
+	defer tx.Rollback()
+	now := nowMillis()
+	result, err := tx.ExecContext(ctx, `UPDATE tasks SET status='open',claimed_by=NULL,claimed_execution_id=NULL,updated_at=? WHERE task_id=? AND scope_id=? AND status='claimed' AND claimed_by=? AND claimed_execution_id=?`,
+		now, taskID, principal.ScopeID, principal.AgentID, principal.ExecutionID)
 	if err != nil {
 		return Task{}, err
 	}
@@ -1075,7 +1313,19 @@ func (s *Store) ReleaseTask(ctx context.Context, principal Principal, taskID str
 	if changed != 1 {
 		return Task{}, Errorf(CodeConflict, "Task "+taskID+" is not claimed by this execution")
 	}
-	return taskFrom(ctx, s.db, principal.ScopeID, taskID)
+	if err := appendEvent(ctx, tx, principal.ScopeID, "task.released", taskID, eventAttributes(
+		"previousClaimedBy", principal.AgentID, "executionId", principal.ExecutionID, "reason", "released", "status", "open",
+	), now); err != nil {
+		return Task{}, err
+	}
+	task, err := taskFrom(ctx, tx, principal.ScopeID, taskID)
+	if err != nil {
+		return Task{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Task{}, err
+	}
+	return task, nil
 }
 
 func (s *Store) ListTasks(ctx context.Context, scopeID string, readyOnly bool) ([]Task, error) {
@@ -1198,9 +1448,13 @@ func (s *Store) AskHuman(ctx context.Context, principal Principal, input AskHuma
 	if err != nil {
 		return HumanEscalation{}, err
 	}
+	now := nowMillis()
 	_, err = tx.ExecContext(ctx, `INSERT INTO escalations(escalation_id,scope_id,agent_id,question,options_json,status,answer,created_at,resolved_at) VALUES(?,?,?,?,?,'pending',NULL,?,NULL)`,
-		id, principal.ScopeID, principal.AgentID, input.Question, options, nowMillis())
+		id, principal.ScopeID, principal.AgentID, input.Question, options, now)
 	if err != nil {
+		return HumanEscalation{}, err
+	}
+	if err := appendEvent(ctx, tx, principal.ScopeID, "escalation.created", id, eventAttributes("agentId", principal.AgentID, "status", "pending"), now); err != nil {
 		return HumanEscalation{}, err
 	}
 	escalation, err := escalationFrom(ctx, tx, principal.ScopeID, id)
@@ -1235,8 +1489,14 @@ func (s *Store) ListEscalations(ctx context.Context, scopeID string) ([]HumanEsc
 }
 
 func (s *Store) ResolveEscalation(ctx context.Context, scopeID, escalationID, answer string) (HumanEscalation, error) {
-	result, err := s.db.ExecContext(ctx, `UPDATE escalations SET status='resolved',answer=?,resolved_at=? WHERE scope_id=? AND escalation_id=? AND status='pending'`,
-		answer, nowMillis(), scopeID, escalationID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return HumanEscalation{}, err
+	}
+	defer tx.Rollback()
+	now := nowMillis()
+	result, err := tx.ExecContext(ctx, `UPDATE escalations SET status='resolved',answer=?,resolved_at=? WHERE scope_id=? AND escalation_id=? AND status='pending'`,
+		answer, now, scopeID, escalationID)
 	if err != nil {
 		return HumanEscalation{}, err
 	}
@@ -1244,5 +1504,19 @@ func (s *Store) ResolveEscalation(ctx context.Context, scopeID, escalationID, an
 	if changed != 1 {
 		return HumanEscalation{}, Errorf(CodeConflict, "Escalation is not pending")
 	}
-	return escalationFrom(ctx, s.db, scopeID, escalationID)
+	var agentID string
+	if err := tx.QueryRowContext(ctx, `SELECT agent_id FROM escalations WHERE scope_id=? AND escalation_id=?`, scopeID, escalationID).Scan(&agentID); err != nil {
+		return HumanEscalation{}, err
+	}
+	if err := appendEvent(ctx, tx, scopeID, "escalation.resolved", escalationID, eventAttributes("agentId", agentID, "status", "resolved"), now); err != nil {
+		return HumanEscalation{}, err
+	}
+	escalation, err := escalationFrom(ctx, tx, scopeID, escalationID)
+	if err != nil {
+		return HumanEscalation{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return HumanEscalation{}, err
+	}
+	return escalation, nil
 }

--- a/bus/task_progress.go
+++ b/bus/task_progress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 )
 
 const (
@@ -107,6 +108,11 @@ func (s *Store) AddTaskProgress(ctx context.Context, principal Principal, taskID
 	progress := TaskProgress{
 		TaskID: taskID, Sequence: sequence, AgentID: principal.AgentID, ExecutionID: principal.ExecutionID,
 		Kind: input.Kind, Text: input.Text, CreatedAt: instant(now),
+	}
+	if err := appendEvent(ctx, tx, principal.ScopeID, "task.progress_added", taskID, eventAttributes(
+		"agentId", principal.AgentID, "executionId", principal.ExecutionID, "kind", input.Kind, "sequence", fmt.Sprintf("%d", sequence),
+	), now); err != nil {
+		return TaskProgress{}, err
 	}
 	if err := tx.Commit(); err != nil {
 		return TaskProgress{}, err

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -400,6 +400,45 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		return result, err
 	}
 
+	if err := record.check("resumable-scope-events", func() error {
+		initial, err := owner.Events(ctx, 0, 100, 0)
+		if err != nil || initial.ResyncRequired || len(initial.Events) == 0 || initial.NextRevision != initial.CurrentRevision {
+			return fmt.Errorf("unexpected initial event batch: %#v, %v", initial, err)
+		}
+		for _, event := range initial.Events {
+			for _, value := range event.Attributes {
+				if value == "The retry path is correct" || value == "Proceed?" || value == "Reviewed" {
+					return fmt.Errorf("event exposed record content: %#v", event)
+				}
+			}
+		}
+		type eventResult struct {
+			batch bus.EventBatch
+			err   error
+		}
+		waiting := make(chan eventResult, 1)
+		go func() {
+			batch, err := owner.Events(ctx, initial.NextRevision, 100, 2*time.Second)
+			waiting <- eventResult{batch: batch, err: err}
+		}()
+		time.Sleep(50 * time.Millisecond)
+		if _, err := planner.Heartbeat(ctx, bus.HeartbeatInput{Lifecycle: bus.LifecycleWorking, Ready: true, LeaseMS: 30000}); err != nil {
+			return err
+		}
+		select {
+		case value := <-waiting:
+			if value.err != nil || len(value.batch.Events) != 1 || value.batch.Events[0].Type != "agent.lifecycle_changed" {
+				return fmt.Errorf("unexpected waited event batch: %#v, %v", value.batch, value.err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		_, err = planner.Events(ctx, 0, 10, 0)
+		return requireCode(err, bus.CodeUnauthenticated)
+	}); err != nil {
+		return result, err
+	}
+
 	if err := record.check("storage-diagnostics-and-retention", func() error {
 		summary, err := owner.StorageSummary(ctx)
 		if err != nil || len(summary.Records) == 0 || summary.TotalEstimatedBytes == 0 {
@@ -420,6 +459,10 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		executed, err := owner.PruneScope(ctx, bus.PruneScopeInput{Before: before, Execute: true})
 		if err != nil || executed.DryRun || executed.Records != dryRun.Records {
 			return fmt.Errorf("unexpected retention execution: %#v, %v", executed, err)
+		}
+		stale, err := owner.Events(ctx, 0, 100, 0)
+		if err != nil || !stale.ResyncRequired {
+			return fmt.Errorf("pruned event cursor did not require resync: %#v, %v", stale, err)
 		}
 		return nil
 	}); err != nil {

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -7,7 +7,7 @@ October Bus currently ships a Go client in this module and a TypeScript client o
 Use the narrowest credential for each operation:
 
 - admin token for scope creation and daemon shutdown;
-- scope token for agent registration, peer links, project task management, storage controls, and human escalation resolution;
+- scope token for agent registration, peer links, project task management, event streams, storage controls, and human escalation resolution;
 - agent token for heartbeat, discovery, messages, tasks, and escalation creation.
 
 Keep admin and scope tokens outside model context. A managed session gives the harness only its execution-bound agent token.
@@ -34,6 +34,17 @@ messages, err := agent.PullInbox(ctx, 50, 25*time.Second)
 
 ownerTasks, err := owner.ListTasks(ctx, true)
 storage, err := owner.StorageSummary(ctx)
+events, err := owner.Events(ctx, lastRevision, 50, 25*time.Second)
+
+for batch, err := range owner.WatchEvents(ctx, lastRevision, 50) {
+    if err != nil {
+        return err
+    }
+    if batch.ResyncRequired {
+        break
+    }
+    lastRevision = batch.NextRevision
+}
 
 progress, err := agent.AddTaskProgress(ctx, taskID, bus.AddTaskProgressInput{
     Kind: "progress",
@@ -70,6 +81,12 @@ await session.setState('ready', true)
 const peers = await session.client.listPeers({ timeoutMs: 10_000 })
 const messages = await session.client.pullInbox(50, { waitMs: 25_000 })
 const readyTasks = await new OctoberBusScopeClient(address, scopeToken).listTasks({ ready: true })
+const owner = new OctoberBusScopeClient(address, scopeToken)
+
+for await (const batch of owner.watchEvents({ after: lastRevision })) {
+  if (batch.resyncRequired) break
+  lastRevision = batch.nextRevision
+}
 
 await session.client.addTaskProgress(taskId, {
   kind: 'progress',
@@ -77,7 +94,9 @@ await session.client.addTaskProgress(taskId, {
 })
 ```
 
-Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argument. Inbox reservation and pull operations also accept `waitMs` up to 25 seconds. The default request timeout is 30 seconds.
+Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argument. Inbox and event operations support bounded waits up to 25 seconds. The default request timeout is 30 seconds.
+
+Persist an event batch's `nextRevision` only after applying the whole batch. If `resyncRequired` is true, rebuild from the resource APIs before saving the returned cursor. Event envelopes contain state metadata but not message, task, progress, or escalation contents.
 
 Prefer bounded inbox waiting for efficient pull delivery. `pollInbox` provides an async iterator over repeated bounded waits. Use `withClaimedTask` to release a task if work or completion fails. Keep the managed session alive while holding a claim.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -88,7 +88,9 @@ Retention is explicit and keeps indefinite storage as the default. First run a d
 october-bus scope prune --before 2026-08-01T00:00:00Z
 ```
 
-Pass `--yes` to remove the reported records in one transaction. Only terminal messages, completed tasks, and resolved escalations can be removed. Requests and responses are removed together. Work with an outstanding delivery, reply, task, dependency, or human obligation is preserved.
+Pass `--yes` to remove the reported records in one transaction. Only terminal messages, completed tasks, resolved escalations, and old scope events can be removed. Requests and responses are removed together. Work with an outstanding delivery, reply, task, dependency, or human obligation is preserved.
+
+Pruning scope events can make an old event cursor incomplete. Event clients receive `resyncRequired` and must rebuild their projection from the resource APIs before continuing.
 
 Choose a cutoff older than the longest client retry window you support. Removing a message also removes its idempotency-key binding.
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.6",
+  "version": "0.1.0-next.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.6",
+      "version": "0.1.0-next.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.6",
+  "version": "0.1.0-next.7",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -12,6 +12,7 @@ import type {
   CreateScopeInput,
   CreateScopeResult,
   DeliveryReceipt,
+  EventBatch,
   HumanEscalation,
   InboxReservation,
   PruneScopeInput,
@@ -44,6 +45,12 @@ export interface InboxReservationOptions extends OperationOptions {
 
 export interface ListTasksOptions extends OperationOptions {
   ready?: boolean
+}
+
+export interface EventOptions extends OperationOptions {
+  after?: number
+  limit?: number
+  waitMs?: number
 }
 
 async function request<T>(
@@ -180,6 +187,39 @@ export class OctoberBusScopeClient {
 
   pruneScope(input: PruneScopeInput, options?: OperationOptions): Promise<PruneScopeResult> {
     return request(this.address, this.scopeToken, 'POST', '/v1/scope/storage/prune', input, options)
+  }
+
+  events(options: EventOptions = {}): Promise<EventBatch> {
+    const { after = 0, limit = 50, waitMs = 0, ...operationOptions } = options
+    const query = new URLSearchParams({
+      after: String(after),
+      limit: String(limit),
+      waitMs: String(waitMs)
+    })
+    return request(this.address, this.scopeToken, 'GET', `/v1/events?${query}`, undefined, operationOptions)
+  }
+
+  async *watchEvents(options: EventOptions = {}): AsyncGenerator<EventBatch> {
+    const waitMs = options.waitMs ?? 25_000
+    if (!Number.isInteger(waitMs) || waitMs < 1 || waitMs > 25_000) {
+      throw new BusError('INVALID_ARGUMENT', 'waitMs must be an integer between 1 and 25000')
+    }
+    let after = options.after ?? 0
+    while (!options.signal?.aborted) {
+      let batch: EventBatch
+      try {
+        batch = await this.events({ ...options, after, waitMs })
+      } catch (error) {
+        if (options.signal?.aborted) return
+        throw error
+      }
+      if (batch.resyncRequired) {
+        yield batch
+        return
+      }
+      after = batch.nextRevision
+      if (batch.events.length > 0) yield batch
+    }
   }
 
   listEscalations(options?: OperationOptions): Promise<HumanEscalation[]> {

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -104,6 +104,25 @@ export interface TaskProgress {
   createdAt: string
 }
 
+export interface BusEvent {
+  id: string
+  scopeId: ScopeId
+  type: string
+  subjectId: string
+  revision: number
+  attributes: Record<string, string>
+  createdAt: string
+}
+
+export interface EventBatch {
+  scopeId: ScopeId
+  events: BusEvent[]
+  nextRevision: number
+  currentRevision: number
+  minimumCursor: number
+  resyncRequired: boolean
+}
+
 export interface HumanEscalation {
   id: string
   scopeId: ScopeId
@@ -160,7 +179,7 @@ export interface AddTaskProgressInput {
 }
 
 export interface StorageRecordSummary {
-  recordType: 'message' | 'task' | 'taskProgress' | 'escalation'
+  recordType: 'message' | 'task' | 'taskProgress' | 'escalation' | 'event'
   state: string
   count: number
   estimatedBytes: number
@@ -184,6 +203,7 @@ export interface RetentionCounts {
   tasks: number
   taskProgress: number
   escalations: number
+  events: number
 }
 
 export interface PruneScopeResult {

--- a/sdk/typescript/test/errors.mjs
+++ b/sdk/typescript/test/errors.mjs
@@ -5,6 +5,7 @@ import {
   BusError,
   OctoberBusAgentSession,
   OctoberBusClient,
+  OctoberBusScopeClient,
   newIdempotencyKey,
   pollInbox,
   requiredEnvironmentValue,
@@ -87,6 +88,10 @@ assert.equal(polled.done, false)
 assert.equal(polled.value[0].id, 'message_1')
 await inbox.return()
 await assert.rejects(() => pollInbox(pollingClient, { waitMs: 0 }).next(), /waitMs must be an integer between 1 and 25000/)
+await assert.rejects(
+  () => new OctoberBusScopeClient('not a url', 'token').watchEvents({ waitMs: 0 }).next(),
+  /waitMs must be an integer between 1 and 25000/
+)
 
 const server = createServer((_request, response) => {
   response.writeHead(502, { 'content-type': 'text/plain' })

--- a/sdk/typescript/test/integration.mjs
+++ b/sdk/typescript/test/integration.mjs
@@ -74,6 +74,20 @@ try {
   await reviewerSession.setState('ready', true)
   const planner = plannerSession.client
   const reviewer = reviewerSession.client
+  const initialEvents = await owner.events({ limit: 100 })
+  assert.equal(initialEvents.events.length > 0, true)
+  assert.equal(initialEvents.resyncRequired, false)
+  const eventIterator = owner.watchEvents({
+    after: initialEvents.nextRevision,
+    waitMs: 2_000,
+    timeoutMs: 3_000
+  })
+  const nextEvents = eventIterator.next()
+  await planner.heartbeat('working', true)
+  const eventResult = await nextEvents
+  assert.equal(eventResult.done, false)
+  assert.equal(eventResult.value.events.some((event) => event.type === 'agent.lifecycle_changed'), true)
+  await eventIterator.return()
   const peers = await planner.listPeers()
   assert.equal(peers.length, 1)
   assert.equal(peers[0].id, 'reviewer')
@@ -119,6 +133,7 @@ try {
   const pruned = await owner.pruneScope({ before, execute: true })
   assert.equal(pruned.dryRun, false)
   assert.equal(pruned.records.tasks, 1)
+  assert.equal((await owner.events({ after: 0 })).resyncRequired, true)
   await reviewerSession.close()
   await plannerSession.close()
   const agentsAfterClose = await owner.listAgents()

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -134,6 +134,26 @@ Explicit retention can remove only terminal records older than a caller-provided
 
 Retention MUST support a dry run and report exact record counts. The reference CLI requires `--yes` before deletion.
 
+## Scope events
+
+Scope authority MAY follow a durable event log to update external projections. Each event has an opaque ID and a scope-local, monotonically increasing revision. Clients resume by requesting events after the last revision they committed.
+
+Events describe state changes without carrying protected record content. Message bodies and context, task titles, descriptions and progress text, escalation questions and answers, and credentials MUST NOT appear in an event envelope.
+
+Protocol 0.1 defines these event types:
+
+- `agent.registered` and `agent.lifecycle_changed`
+- `link.created`
+- `message.accepted`, `message.replied`, `message.reserved`, `message.released`, `message.delivered`, `message.acknowledged`, and `message.expired`
+- `task.created`, `task.claimed`, `task.released`, `task.completed`, and `task.progress_added`
+- `escalation.created` and `escalation.resolved`
+
+Each listed transition event MUST be committed atomically with the transition it describes. Retrying an idempotent operation that made no new state change MUST NOT append another event. A heartbeat that only renews a lease does not append a lifecycle event.
+
+Implementations MAY retain a bounded event history. `minimumCursor` identifies the oldest cursor that can still produce a complete continuation. When retention removes revisions required by a cursor, the event API MUST return an explicit resync result instead of silently skipping history. The client then rebuilds from the resource APIs and resumes at the current revision.
+
+The reference runtime allows at most 128 concurrent event waits per scope credential and returns `BACKPRESSURE` above that limit. Waiting clients do not hold mutation locks or private in-memory event queues.
+
 ## Human escalation
 
 An agent MAY create an escalation with a question and either no options or two to four options. Creating an escalation does not grant the agent permission or answer the question.
@@ -145,7 +165,7 @@ Only scope authority resolves escalations. Agent authority can create and read e
 | Credential | Allowed operations |
 | --- | --- |
 | Admin token | Create a scope and request local daemon shutdown |
-| Scope token | Register and list agents, create peer links, add and list tasks, inspect and prune storage, list and resolve escalations |
+| Scope token | Register and list agents, create peer links, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
 | Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, create and read escalations |
 
 Tokens are bearer credentials. Implementations MUST compare them safely, MUST NOT log them, and MUST reject empty credentials. Agent tokens MUST stop working after lease expiry or execution replacement.

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -63,6 +63,7 @@ Failures use:
 | `POST` | `/v1/scope/escalations/{escalationId}/resolve` | Scope | Resolved escalation |
 | `GET` | `/v1/scope/storage` | Scope | Counts, estimated bytes, and oldest timestamps |
 | `POST` | `/v1/scope/storage/prune` | Scope | Dry-run or executed retention result |
+| `GET` | `/v1/events` | Scope | Resumable scope event batch |
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
 
 `POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
@@ -70,6 +71,10 @@ Failures use:
 `GET /v1/tasks?ready=true` returns only open, unclaimed tasks whose dependencies are complete. The default returns every task in the scope.
 
 `POST /v1/scope/storage/prune` requires an RFC 3339 `before` timestamp. Omitted or false `execute` performs a dry run. `execute=true` removes the reported terminal records in one transaction.
+
+`GET /v1/events?after=0&limit=50&waitMs=25000` returns events after the supplied scope revision. The limit is 1 through 100 and the bounded wait is 0 through 25000 milliseconds. The default cursor is 0, the default limit is 50, and the default wait returns immediately. Event envelopes contain identifiers and state metadata, not message bodies, task text, progress text, escalation questions, answers, or credentials.
+
+Clients resume from `nextRevision`. `minimumCursor` is the oldest cursor that can still produce a complete continuation. A batch with `resyncRequired: true` means retention removed events needed by the supplied cursor. The client must rebuild its projection from the resource APIs and resume from the returned `nextRevision`.
 
 Request and result shapes are defined in [protocol.schema.json](schemas/protocol.schema.json). Consumers can reference individual definitions with a fragment such as:
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -321,12 +321,46 @@
         }
       ]
     },
+    "busEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "scopeId", "type", "subjectId", "revision", "attributes", "createdAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "scopeId": { "$ref": "#/$defs/identifier" },
+        "type": { "type": "string", "minLength": 1 },
+        "subjectId": { "type": "string", "minLength": 1 },
+        "revision": { "type": "integer", "minimum": 1 },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "createdAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "eventBatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scopeId", "events", "nextRevision", "currentRevision", "minimumCursor", "resyncRequired"],
+      "properties": {
+        "scopeId": { "$ref": "#/$defs/identifier" },
+        "events": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/busEvent" }
+        },
+        "nextRevision": { "type": "integer", "minimum": 0 },
+        "currentRevision": { "type": "integer", "minimum": 0 },
+        "minimumCursor": { "type": "integer", "minimum": 0 },
+        "resyncRequired": { "type": "boolean" }
+      }
+    },
     "storageRecordSummary": {
       "type": "object",
       "additionalProperties": false,
       "required": ["recordType", "state", "count", "estimatedBytes"],
       "properties": {
-        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation"] },
+        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event"] },
         "state": { "type": "string", "minLength": 1 },
         "count": { "type": "integer", "minimum": 0 },
         "estimatedBytes": { "type": "integer", "minimum": 0 },
@@ -359,12 +393,13 @@
     "retentionCounts": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["messages", "tasks", "taskProgress", "escalations"],
+      "required": ["messages", "tasks", "taskProgress", "escalations", "events"],
       "properties": {
         "messages": { "type": "integer", "minimum": 0 },
         "tasks": { "type": "integer", "minimum": 0 },
         "taskProgress": { "type": "integer", "minimum": 0 },
-        "escalations": { "type": "integer", "minimum": 0 }
+        "escalations": { "type": "integer", "minimum": 0 },
+        "events": { "type": "integer", "minimum": 0 }
       }
     },
     "pruneScopeResult": {

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -141,6 +141,14 @@ func TestProtocolSchemas(t *testing.T) {
 		"taskId": "task_123", "sequence": float64(1), "agentId": "reviewer", "executionId": "exec_123",
 		"kind": "blocker", "text": "Waiting for an API decision", "createdAt": "2026-08-30T00:00:01Z",
 	})
+	events := resolvedSchema(t, path, "eventBatch")
+	requireValid(t, events, map[string]any{
+		"scopeId": "scope", "events": []any{map[string]any{
+			"id": "evt_123", "scopeId": "scope", "type": "task.created", "subjectId": "task_123",
+			"revision": float64(1), "attributes": map[string]any{"status": "open"}, "createdAt": "2026-08-30T00:00:00Z",
+		}},
+		"nextRevision": float64(1), "currentRevision": float64(1), "minimumCursor": float64(0), "resyncRequired": false,
+	})
 
 	prune := resolvedSchema(t, path, "pruneScopeInput")
 	requireValid(t, prune, map[string]any{"before": "2026-08-01T00:00:00Z"})
@@ -281,6 +289,11 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 	if err != nil || len(progressHistory) != 1 {
 		t.Fatalf("unexpected progress history: %#v, %v", progressHistory, err)
 	}
+	events, err := owner.Events(ctx, 0, 100, 0)
+	if err != nil || len(events.Events) == 0 {
+		t.Fatalf("unexpected scope events: %#v, %v", events, err)
+	}
+	requireValid(t, resolvedSchema(t, path, "eventBatch"), jsonValue(t, events))
 	storage, err := owner.StorageSummary(ctx)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- add a durable, monotonic event log for each scope
- expose bounded long polling and resumable cursors over HTTP and the Go and TypeScript clients
- emit metadata-only events for agent, message, task, progress, and escalation transitions
- integrate event retention with explicit stale-cursor resync
- add event-stream coverage to the local conformance profile

Closes #23

## Validation

- ok  	github.com/october-dev/october-bus/a2abridge	1.493s
ok  	github.com/october-dev/october-bus/bus	6.520s
ok  	github.com/october-dev/october-bus/cmd/october-bus	5.934s
ok  	github.com/october-dev/october-bus/cmd/october-bus-conformance	2.372s
ok  	github.com/october-dev/october-bus/conformance	38.824s
ok  	github.com/october-dev/october-bus/spec	4.072s
- 
- TypeScript typecheck, build, error tests, and Go-to-TypeScript integration
- Linux and Windows cross-compiles
- isolated local-runtime conformance, 18/18 checks
- two-agent demo