### PR TITLE
Add scoped A2A credentials

### DIFF
--- a/bus/a2a_principal_routes.go
+++ b/bus/a2a_principal_routes.go
@@ -1,0 +1,75 @@
+package bus
+
+import "net/http"
+
+func (s *Server) createA2APrincipal(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input CreateA2APrincipalInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	result, err := s.runtime.CreateA2APrincipal(request.Context(), token, input)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusCreated, result)
+	return nil
+}
+
+func (s *Server) listA2APrincipals(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	result, err := s.runtime.ListA2APrincipals(request.Context(), token)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, result)
+	return nil
+}
+
+func (s *Server) rotateA2APrincipal(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input emptyInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	result, err := s.runtime.RotateA2APrincipal(request.Context(), token, request.PathValue("principalId"))
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, result)
+	return nil
+}
+
+func (s *Server) setA2APrincipal(response http.ResponseWriter, request *http.Request, enabled bool) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input emptyInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	result, err := s.runtime.SetA2APrincipalEnabled(request.Context(), token, request.PathValue("principalId"), enabled)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, result)
+	return nil
+}
+
+func (s *Server) enableA2APrincipal(response http.ResponseWriter, request *http.Request) error {
+	return s.setA2APrincipal(response, request, true)
+}
+
+func (s *Server) disableA2APrincipal(response http.ResponseWriter, request *http.Request) error {
+	return s.setA2APrincipal(response, request, false)
+}

--- a/bus/a2a_principals.go
+++ b/bus/a2a_principals.go
@@ -1,0 +1,223 @@
+package bus
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+const (
+	a2aPublicationResource = "a2aPublication"
+	a2aInvokePermission    = "invoke"
+)
+
+func a2aPrincipalFrom(record scopedCredentialRecord, publicationID string) A2APrincipal {
+	return A2APrincipal{
+		ID: record.ID, ScopeID: record.ScopeID, PublicationID: publicationID, Label: record.Label, Enabled: record.Enabled,
+		CreatedAt: instant(record.CreatedAt), UpdatedAt: instant(record.UpdatedAt),
+	}
+}
+
+func (s *Store) CreateA2APrincipal(ctx context.Context, scopeID string, input CreateA2APrincipalInput) (IssuedA2APrincipal, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	defer tx.Rollback()
+	var found int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM a2a_publications WHERE scope_id=? AND publication_id=?`, scopeID, input.PublicationID).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+		return IssuedA2APrincipal{}, Errorf(CodeNotFound, "Agent Card publication was not found")
+	} else if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	now := nowMillis()
+	record, credential, err := createScopedCredential(ctx, tx, scopeID, input.Label, []scopedCredentialGrant{{
+		ResourceType: a2aPublicationResource, ResourceID: input.PublicationID, Permission: a2aInvokePermission,
+	}}, now)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := appendEvent(ctx, tx, scopeID, "credential.created", record.ID, eventAttributes(
+		"resourceType", a2aPublicationResource, "resourceId", input.PublicationID, "permission", a2aInvokePermission, "enabled", "true",
+	), now); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	return IssuedA2APrincipal{Principal: a2aPrincipalFrom(record, input.PublicationID), Credential: credential}, nil
+}
+
+func (s *Store) ListA2APrincipals(ctx context.Context, scopeID string) ([]A2APrincipal, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT c.credential_id,c.scope_id,c.label,c.enabled,c.created_at,c.updated_at,g.resource_id
+FROM scoped_credentials c
+JOIN scoped_credential_grants g ON g.credential_id=c.credential_id
+WHERE c.scope_id=? AND g.resource_type=? AND g.permission=?
+ORDER BY c.created_at,c.credential_id`, scopeID, a2aPublicationResource, a2aInvokePermission)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	principals := []A2APrincipal{}
+	for rows.Next() {
+		var record scopedCredentialRecord
+		var enabled int
+		var publicationID string
+		if err := rows.Scan(&record.ID, &record.ScopeID, &record.Label, &enabled, &record.CreatedAt, &record.UpdatedAt, &publicationID); err != nil {
+			return nil, err
+		}
+		record.Enabled = enabled == 1
+		principals = append(principals, a2aPrincipalFrom(record, publicationID))
+	}
+	return principals, rows.Err()
+}
+
+func a2aPrincipalPublication(ctx context.Context, tx *sql.Tx, scopeID, principalID string) (string, error) {
+	var publicationID string
+	err := tx.QueryRowContext(ctx, `SELECT g.resource_id FROM scoped_credentials c
+JOIN scoped_credential_grants g ON g.credential_id=c.credential_id
+WHERE c.scope_id=? AND c.credential_id=? AND g.resource_type=? AND g.permission=?`,
+		scopeID, principalID, a2aPublicationResource, a2aInvokePermission).Scan(&publicationID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", Errorf(CodeNotFound, "A2A principal was not found")
+	}
+	return publicationID, err
+}
+
+func (s *Store) RotateA2APrincipal(ctx context.Context, scopeID, principalID string) (IssuedA2APrincipal, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	defer tx.Rollback()
+	publicationID, err := a2aPrincipalPublication(ctx, tx, scopeID, principalID)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	now := nowMillis()
+	record, credential, err := rotateScopedCredential(ctx, tx, scopeID, principalID, now)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := appendEvent(ctx, tx, scopeID, "credential.rotated", record.ID, eventAttributes(
+		"resourceType", a2aPublicationResource, "resourceId", publicationID, "permission", a2aInvokePermission,
+	), now); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	return IssuedA2APrincipal{Principal: a2aPrincipalFrom(record, publicationID), Credential: credential}, nil
+}
+
+func (s *Store) SetA2APrincipalEnabled(ctx context.Context, scopeID, principalID string, enabled bool) (A2APrincipal, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return A2APrincipal{}, err
+	}
+	defer tx.Rollback()
+	publicationID, err := a2aPrincipalPublication(ctx, tx, scopeID, principalID)
+	if err != nil {
+		return A2APrincipal{}, err
+	}
+	now := nowMillis()
+	record, changed, err := setScopedCredentialEnabled(ctx, tx, scopeID, principalID, enabled, now)
+	if err != nil {
+		return A2APrincipal{}, err
+	}
+	if changed {
+		eventType := "credential.disabled"
+		if enabled {
+			eventType = "credential.enabled"
+		}
+		if err := appendEvent(ctx, tx, scopeID, eventType, record.ID, eventAttributes(
+			"resourceType", a2aPublicationResource, "resourceId", publicationID, "permission", a2aInvokePermission, "enabled", boolString(enabled),
+		), now); err != nil {
+			return A2APrincipal{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return A2APrincipal{}, err
+	}
+	return a2aPrincipalFrom(record, publicationID), nil
+}
+
+func (s *Store) AuthenticateA2APrincipal(ctx context.Context, credential, publicationID string) (A2APrincipal, error) {
+	record, err := s.authenticateScopedCredential(ctx, credential, scopedCredentialGrant{
+		ResourceType: a2aPublicationResource, ResourceID: publicationID, Permission: a2aInvokePermission,
+	})
+	if err != nil {
+		return A2APrincipal{}, err
+	}
+	var enabled int
+	if err := s.db.QueryRowContext(ctx, `SELECT enabled FROM a2a_publications WHERE scope_id=? AND publication_id=?`, record.ScopeID, publicationID).Scan(&enabled); err != nil || enabled != 1 {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return A2APrincipal{}, err
+		}
+		return A2APrincipal{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
+	}
+	return a2aPrincipalFrom(record, publicationID), nil
+}
+
+func (r *Runtime) CreateA2APrincipal(ctx context.Context, scopeToken string, input CreateA2APrincipalInput) (IssuedA2APrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := validateIdentity(input.PublicationID, "publicationId", false); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := validateText(input.Label, "label", 256, false); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	result, err := r.store.CreateA2APrincipal(ctx, scopeID, input)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
+}
+
+func (r *Runtime) ListA2APrincipals(ctx context.Context, scopeToken string) ([]A2APrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return nil, err
+	}
+	return r.store.ListA2APrincipals(ctx, scopeID)
+}
+
+func (r *Runtime) RotateA2APrincipal(ctx context.Context, scopeToken, principalID string) (IssuedA2APrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	if err := validateIdentity(principalID, "principalId", false); err != nil {
+		return IssuedA2APrincipal{}, err
+	}
+	result, err := r.store.RotateA2APrincipal(ctx, scopeID, principalID)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
+}
+
+func (r *Runtime) SetA2APrincipalEnabled(ctx context.Context, scopeToken, principalID string, enabled bool) (A2APrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return A2APrincipal{}, err
+	}
+	if err := validateIdentity(principalID, "principalId", false); err != nil {
+		return A2APrincipal{}, err
+	}
+	result, err := r.store.SetA2APrincipalEnabled(ctx, scopeID, principalID, enabled)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
+}
+
+func (r *Runtime) AuthenticateA2APrincipal(ctx context.Context, credential, publicationID string) (A2APrincipal, error) {
+	if err := validateIdentity(publicationID, "publicationId", false); err != nil {
+		return A2APrincipal{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
+	}
+	return r.store.AuthenticateA2APrincipal(ctx, credential, publicationID)
+}

--- a/bus/a2a_principals_test.go
+++ b/bus/a2a_principals_test.go
@@ -1,0 +1,250 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestA2APrincipalLifecycleAndIsolation(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	reviewerPublication, err := agents.runtime.CreateAgentCardPublication(ctx, agents.scope.ScopeToken, PublishAgentCardInput{AgentID: agents.reviewer.AgentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plannerPublication, err := agents.runtime.CreateAgentCardPublication(ctx, agents.scope.ScopeToken, PublishAgentCardInput{AgentID: agents.planner.AgentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := agents.runtime.CreateA2APrincipal(ctx, agents.scope.ScopeToken, CreateA2APrincipalInput{
+		PublicationID: reviewerPublication.ID, Label: "Review service",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issued.Principal.ID == "" || !issued.Principal.Enabled || issued.Principal.PublicationID != reviewerPublication.ID || issued.Credential == "" {
+		t.Fatalf("unexpected issued principal: %#v", issued)
+	}
+	if !strings.HasPrefix(issued.Credential, issued.Principal.ID+".") {
+		t.Fatalf("credential does not use its stable principal id: %q", issued.Credential)
+	}
+	listed, err := agents.runtime.ListA2APrincipals(ctx, agents.scope.ScopeToken)
+	if err != nil || len(listed) != 1 || listed[0] != issued.Principal {
+		t.Fatalf("unexpected principal list: %#v, %v", listed, err)
+	}
+	encoded, err := json.Marshal(listed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), issued.Credential) {
+		t.Fatal("principal list exposed a credential")
+	}
+	if _, err := agents.runtime.AuthenticateA2APrincipal(ctx, issued.Credential, reviewerPublication.ID); err != nil {
+		t.Fatalf("issued credential did not authenticate: %v", err)
+	}
+	for _, attempt := range []struct {
+		credential    string
+		publicationID string
+	}{
+		{issued.Credential, plannerPublication.ID},
+		{issued.Credential + "x", reviewerPublication.ID},
+		{"cred_unknown.invalid", reviewerPublication.ID},
+	} {
+		_, err := agents.runtime.AuthenticateA2APrincipal(ctx, attempt.credential, attempt.publicationID)
+		requireCode(t, err, CodeUnauthenticated)
+		if err.Error() != "Invalid scoped credential" {
+			t.Fatalf("authentication failure exposed details: %v", err)
+		}
+	}
+	disabled, err := agents.runtime.SetA2APrincipalEnabled(ctx, agents.scope.ScopeToken, issued.Principal.ID, false)
+	if err != nil || disabled.Enabled {
+		t.Fatalf("unexpected disabled principal: %#v, %v", disabled, err)
+	}
+	_, err = agents.runtime.AuthenticateA2APrincipal(ctx, issued.Credential, reviewerPublication.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	enabled, err := agents.runtime.SetA2APrincipalEnabled(ctx, agents.scope.ScopeToken, issued.Principal.ID, true)
+	if err != nil || !enabled.Enabled {
+		t.Fatalf("unexpected enabled principal: %#v, %v", enabled, err)
+	}
+	if _, err := agents.runtime.AuthenticateA2APrincipal(ctx, issued.Credential, reviewerPublication.ID); err != nil {
+		t.Fatalf("re-enabled credential did not authenticate: %v", err)
+	}
+	rotated, err := agents.runtime.RotateA2APrincipal(ctx, agents.scope.ScopeToken, issued.Principal.ID)
+	if err != nil || rotated.Principal.ID != issued.Principal.ID || rotated.Credential == issued.Credential {
+		t.Fatalf("unexpected rotation: %#v, %v", rotated, err)
+	}
+	_, err = agents.runtime.AuthenticateA2APrincipal(ctx, issued.Credential, reviewerPublication.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	if _, err := agents.runtime.AuthenticateA2APrincipal(ctx, rotated.Credential, reviewerPublication.ID); err != nil {
+		t.Fatalf("rotated credential did not authenticate: %v", err)
+	}
+	if _, err := agents.runtime.SetAgentCardPublicationEnabled(ctx, agents.scope.ScopeToken, reviewerPublication.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.AuthenticateA2APrincipal(ctx, rotated.Credential, reviewerPublication.ID)
+	requireCode(t, err, CodeUnauthenticated)
+
+	events, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, 0, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantEvents := map[string]bool{
+		"credential.created": false, "credential.disabled": false, "credential.enabled": false, "credential.rotated": false,
+	}
+	for _, event := range events.Events {
+		if _, exists := wantEvents[event.Type]; !exists || event.SubjectID != issued.Principal.ID {
+			continue
+		}
+		wantEvents[event.Type] = true
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), issued.Credential) || strings.Contains(string(data), rotated.Credential) || strings.Contains(string(data), issued.Principal.Label) {
+			t.Fatalf("credential event exposed private material: %s", data)
+		}
+	}
+	for eventType, found := range wantEvents {
+		if !found {
+			t.Fatalf("missing %s event", eventType)
+		}
+	}
+}
+
+func TestA2APrincipalAuthorityAndRetention(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, err := agents.runtime.CreateAgentCardPublication(ctx, agents.scope.ScopeToken, PublishAgentCardInput{AgentID: agents.reviewer.AgentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := agents.runtime.CreateA2APrincipal(ctx, agents.scope.ScopeToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Remote caller"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.CreateA2APrincipal(ctx, agents.plannerToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Denied"}); err == nil {
+		t.Fatal("agent authority created a remote principal")
+	} else {
+		requireCode(t, err, CodeUnauthenticated)
+	}
+	otherScope, err := agents.runtime.CreateScope(ctx, CreateScopeInput{ID: "other"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.SetA2APrincipalEnabled(ctx, otherScope.ScopeToken, issued.Principal.ID, false); err == nil {
+		t.Fatal("another scope changed a principal")
+	} else {
+		requireCode(t, err, CodeNotFound)
+	}
+	summary, err := agents.runtime.StorageSummary(ctx, agents.scope.ScopeToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, record := range summary.Records {
+		if record.RecordType == "credential" && record.State == "enabled" && record.Count == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("storage summary omitted credential: %#v", summary)
+	}
+	if _, err := agents.runtime.PruneScope(ctx, agents.scope.ScopeToken, PruneScopeInput{Before: "2999-01-01T00:00:00Z", Execute: true}); err != nil {
+		t.Fatal(err)
+	}
+	listed, err := agents.runtime.ListA2APrincipals(ctx, agents.scope.ScopeToken)
+	if err != nil || len(listed) != 1 || listed[0].ID != issued.Principal.ID {
+		t.Fatalf("retention removed principal: %#v, %v", listed, err)
+	}
+}
+
+func TestA2APrincipalPersistsWithoutExposingSecretToBusAPIs(t *testing.T) {
+	database := filepath.Join(t.TempDir(), "bus.db")
+	agents := setupAgents(t, database)
+	ctx := context.Background()
+	publication, err := agents.runtime.CreateAgentCardPublication(ctx, agents.scope.ScopeToken, PublishAgentCardInput{AgentID: agents.reviewer.AgentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := agents.runtime.CreateA2APrincipal(ctx, agents.scope.ScopeToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Persistent caller"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(agents.runtime, ServerOptions{})
+	for _, path := range []string{"/v1/agents", "/mcp"} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		request.Header.Set("Authorization", "Bearer "+issued.Credential)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("scoped credential accessed %s: %d %s", path, response.Code, response.Body.String())
+		}
+	}
+	if _, err := agents.runtime.SetA2APrincipalEnabled(ctx, agents.scope.ScopeToken, issued.Principal.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := agents.runtime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restarted.Close()
+	listed, err := restarted.ListA2APrincipals(ctx, agents.scope.ScopeToken)
+	if err != nil || len(listed) != 1 || listed[0].Enabled {
+		t.Fatalf("principal status did not survive restart: %#v, %v", listed, err)
+	}
+	_, err = restarted.AuthenticateA2APrincipal(ctx, issued.Credential, publication.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	if _, err := restarted.SetA2APrincipalEnabled(ctx, agents.scope.ScopeToken, issued.Principal.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	principal, err := restarted.AuthenticateA2APrincipal(ctx, issued.Credential, publication.ID)
+	if err != nil || principal.ID != issued.Principal.ID || principal.Label != issued.Principal.Label {
+		t.Fatalf("credential did not survive restart: %#v, %v", principal, err)
+	}
+}
+
+func TestA2APrincipalHTTPControlsReturnSecretOnlyWhenIssued(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, err := agents.runtime.CreateAgentCardPublication(ctx, agents.scope.ScopeToken, PublishAgentCardInput{AgentID: agents.reviewer.AgentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(agents.runtime, ServerOptions{})
+	call := func(method, path, body string) *httptest.ResponseRecorder {
+		request := httptest.NewRequest(method, path, strings.NewReader(body))
+		request.Header.Set("Authorization", "Bearer "+agents.scope.ScopeToken)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		return response
+	}
+	created := call(http.MethodPost, "/v1/a2a/principals", `{"publicationId":"`+publication.ID+`","label":"Web client"}`)
+	if created.Code != http.StatusCreated || !strings.Contains(created.Body.String(), `"credential"`) {
+		t.Fatalf("unexpected create response: %d %s", created.Code, created.Body.String())
+	}
+	var envelope struct {
+		Result IssuedA2APrincipal `json:"result"`
+	}
+	if err := json.Unmarshal(created.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	listed := call(http.MethodGet, "/v1/a2a/principals", "")
+	if listed.Code != http.StatusOK || strings.Contains(listed.Body.String(), envelope.Result.Credential) || strings.Contains(listed.Body.String(), `"credential"`) {
+		t.Fatalf("unexpected list response: %d %s", listed.Code, listed.Body.String())
+	}
+	rotated := call(http.MethodPost, "/v1/a2a/principals/"+envelope.Result.Principal.ID+"/rotate", `{}`)
+	if rotated.Code != http.StatusOK || !strings.Contains(rotated.Body.String(), `"credential"`) || strings.Contains(rotated.Body.String(), envelope.Result.Credential) {
+		t.Fatalf("unexpected rotate response: %d %s", rotated.Code, rotated.Body.String())
+	}
+}

--- a/bus/client.go
+++ b/bus/client.go
@@ -210,6 +210,26 @@ func (c Client) SetAgentCardPublicationEnabled(ctx context.Context, publicationI
 	return request[AgentCardPublication](ctx, c, http.MethodPost, "/v1/a2a/publications/"+url.PathEscape(publicationID)+"/"+action, map[string]any{})
 }
 
+func (c Client) CreateA2APrincipal(ctx context.Context, input CreateA2APrincipalInput) (IssuedA2APrincipal, error) {
+	return request[IssuedA2APrincipal](ctx, c, http.MethodPost, "/v1/a2a/principals", input)
+}
+
+func (c Client) ListA2APrincipals(ctx context.Context) ([]A2APrincipal, error) {
+	return request[[]A2APrincipal](ctx, c, http.MethodGet, "/v1/a2a/principals", nil)
+}
+
+func (c Client) RotateA2APrincipal(ctx context.Context, principalID string) (IssuedA2APrincipal, error) {
+	return request[IssuedA2APrincipal](ctx, c, http.MethodPost, "/v1/a2a/principals/"+url.PathEscape(principalID)+"/rotate", map[string]any{})
+}
+
+func (c Client) SetA2APrincipalEnabled(ctx context.Context, principalID string, enabled bool) (A2APrincipal, error) {
+	action := "disable"
+	if enabled {
+		action = "enable"
+	}
+	return request[A2APrincipal](ctx, c, http.MethodPost, "/v1/a2a/principals/"+url.PathEscape(principalID)+"/"+action, map[string]any{})
+}
+
 func (c Client) WatchEvents(ctx context.Context, after int64, limit int) iter.Seq2[EventBatch, error] {
 	return func(yield func(EventBatch, error) bool) {
 		for ctx.Err() == nil {

--- a/bus/protocol.go
+++ b/bus/protocol.go
@@ -158,6 +158,26 @@ type PublishAgentCardInput struct {
 	AgentID string `json:"agentId"`
 }
 
+type A2APrincipal struct {
+	ID            string `json:"id"`
+	ScopeID       string `json:"scopeId"`
+	PublicationID string `json:"publicationId"`
+	Label         string `json:"label"`
+	Enabled       bool   `json:"enabled"`
+	CreatedAt     string `json:"createdAt"`
+	UpdatedAt     string `json:"updatedAt"`
+}
+
+type CreateA2APrincipalInput struct {
+	PublicationID string `json:"publicationId"`
+	Label         string `json:"label"`
+}
+
+type IssuedA2APrincipal struct {
+	Principal  A2APrincipal `json:"principal"`
+	Credential string       `json:"credential"`
+}
+
 type StorageRecordSummary struct {
 	RecordType     string `json:"recordType"`
 	State          string `json:"state"`

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -143,6 +143,19 @@ func (s *Server) newRouter() http.Handler {
 	registerRoute(router, "/v1/a2a/publications/{publicationId}/disable",
 		routeMethod{http.MethodPost, s.disableAgentCardPublication},
 	)
+	registerRoute(router, "/v1/a2a/principals",
+		routeMethod{http.MethodGet, s.listA2APrincipals},
+		routeMethod{http.MethodPost, s.createA2APrincipal},
+	)
+	registerRoute(router, "/v1/a2a/principals/{principalId}/rotate",
+		routeMethod{http.MethodPost, s.rotateA2APrincipal},
+	)
+	registerRoute(router, "/v1/a2a/principals/{principalId}/enable",
+		routeMethod{http.MethodPost, s.enableA2APrincipal},
+	)
+	registerRoute(router, "/v1/a2a/principals/{principalId}/disable",
+		routeMethod{http.MethodPost, s.disableA2APrincipal},
+	)
 	registerRoute(router, "/a2a/agents/{publicationId}/.well-known/agent-card.json",
 		routeMethod{http.MethodGet, s.servePublishedAgentCard},
 		routeMethod{http.MethodHead, s.servePublishedAgentCard},

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -464,7 +464,7 @@ func TestOlderSchemaFailsBeforeServingWork(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = Open(path)
-	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 6") {
+	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 7") {
 		t.Fatalf("older schema did not fail clearly: %v", err)
 	}
 }

--- a/bus/scoped_credentials.go
+++ b/bus/scoped_credentials.go
@@ -1,0 +1,141 @@
+package bus
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+)
+
+const scopedCredentialCapPerScope = 1000
+
+type scopedCredentialGrant struct {
+	ResourceType string
+	ResourceID   string
+	Permission   string
+}
+
+type scopedCredentialRecord struct {
+	ID        string
+	ScopeID   string
+	Label     string
+	Enabled   bool
+	CreatedAt int64
+	UpdatedAt int64
+}
+
+const scopedCredentialColumns = `credential_id,scope_id,label,enabled,created_at,updated_at`
+
+func scanScopedCredential(row rowScanner) (scopedCredentialRecord, error) {
+	var credential scopedCredentialRecord
+	var enabled int
+	err := row.Scan(&credential.ID, &credential.ScopeID, &credential.Label, &enabled, &credential.CreatedAt, &credential.UpdatedAt)
+	credential.Enabled = enabled == 1
+	return credential, err
+}
+
+func createScopedCredential(ctx context.Context, tx *sql.Tx, scopeID, label string, grants []scopedCredentialGrant, now int64) (scopedCredentialRecord, string, error) {
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM scoped_credentials WHERE scope_id=?`, scopeID).Scan(&count); err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	if count >= scopedCredentialCapPerScope {
+		return scopedCredentialRecord{}, "", Errorf(CodeBackpressure, "Scope credential limit is full")
+	}
+	credentialID, err := randomID("cred_")
+	if err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	secret, err := randomValue(32)
+	if err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO scoped_credentials(credential_id,scope_id,label,token_hash,enabled,created_at,updated_at) VALUES(?,?,?,?,1,?,?)`,
+		credentialID, scopeID, label, tokenDigest(secret), now, now); err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	for _, grant := range grants {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO scoped_credential_grants(credential_id,resource_type,resource_id,permission) VALUES(?,?,?,?)`,
+			credentialID, grant.ResourceType, grant.ResourceID, grant.Permission); err != nil {
+			return scopedCredentialRecord{}, "", err
+		}
+	}
+	record := scopedCredentialRecord{ID: credentialID, ScopeID: scopeID, Label: label, Enabled: true, CreatedAt: now, UpdatedAt: now}
+	return record, credentialID + "." + secret, nil
+}
+
+func rotateScopedCredential(ctx context.Context, tx *sql.Tx, scopeID, credentialID string, now int64) (scopedCredentialRecord, string, error) {
+	record, err := scanScopedCredential(tx.QueryRowContext(ctx, `SELECT `+scopedCredentialColumns+` FROM scoped_credentials WHERE scope_id=? AND credential_id=?`, scopeID, credentialID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return scopedCredentialRecord{}, "", Errorf(CodeNotFound, "Scoped credential was not found")
+	}
+	if err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	secret, err := randomValue(32)
+	if err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE scoped_credentials SET token_hash=?,updated_at=? WHERE scope_id=? AND credential_id=?`, tokenDigest(secret), now, scopeID, credentialID); err != nil {
+		return scopedCredentialRecord{}, "", err
+	}
+	record.UpdatedAt = now
+	return record, credentialID + "." + secret, nil
+}
+
+func setScopedCredentialEnabled(ctx context.Context, tx *sql.Tx, scopeID, credentialID string, enabled bool, now int64) (scopedCredentialRecord, bool, error) {
+	record, err := scanScopedCredential(tx.QueryRowContext(ctx, `SELECT `+scopedCredentialColumns+` FROM scoped_credentials WHERE scope_id=? AND credential_id=?`, scopeID, credentialID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return scopedCredentialRecord{}, false, Errorf(CodeNotFound, "Scoped credential was not found")
+	}
+	if err != nil {
+		return scopedCredentialRecord{}, false, err
+	}
+	if record.Enabled == enabled {
+		return record, false, nil
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE scoped_credentials SET enabled=?,updated_at=? WHERE scope_id=? AND credential_id=?`, enabled, now, scopeID, credentialID); err != nil {
+		return scopedCredentialRecord{}, false, err
+	}
+	record.Enabled = enabled
+	record.UpdatedAt = now
+	return record, true, nil
+}
+
+func splitScopedCredential(value string) (string, string, bool) {
+	credentialID, secret, found := strings.Cut(value, ".")
+	if !found || credentialID == "" || secret == "" || strings.Contains(secret, ".") {
+		return "", "", false
+	}
+	return credentialID, secret, true
+}
+
+func (s *Store) authenticateScopedCredential(ctx context.Context, supplied string, grant scopedCredentialGrant) (scopedCredentialRecord, error) {
+	credentialID, secret, valid := splitScopedCredential(supplied)
+	if !valid {
+		secureEqual(tokenDigest("invalid"), tokenDigest(supplied))
+		return scopedCredentialRecord{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
+	}
+	var record scopedCredentialRecord
+	var enabled int
+	var expectedHash string
+	err := s.db.QueryRowContext(ctx, `SELECT c.credential_id,c.scope_id,c.label,c.enabled,c.created_at,c.updated_at,c.token_hash
+FROM scoped_credentials c
+JOIN scoped_credential_grants g ON g.credential_id=c.credential_id
+WHERE c.credential_id=? AND g.resource_type=? AND g.resource_id=? AND g.permission=?`,
+		credentialID, grant.ResourceType, grant.ResourceID, grant.Permission).
+		Scan(&record.ID, &record.ScopeID, &record.Label, &enabled, &record.CreatedAt, &record.UpdatedAt, &expectedHash)
+	record.Enabled = enabled == 1
+	actualHash := tokenDigest(secret)
+	if errors.Is(err, sql.ErrNoRows) {
+		secureEqual(tokenDigest("invalid"), actualHash)
+		return scopedCredentialRecord{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
+	}
+	if err != nil {
+		return scopedCredentialRecord{}, err
+	}
+	if !record.Enabled || !secureEqual(expectedHash, actualHash) {
+		return scopedCredentialRecord{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
+	}
+	return record, nil
+}

--- a/bus/storage.go
+++ b/bus/storage.go
@@ -40,6 +40,8 @@ FROM escalations WHERE scope_id=? GROUP BY status ORDER BY status`},
 FROM events WHERE scope_id=? GROUP BY event_type ORDER BY event_type`},
 		{"a2aPublication", `SELECT CASE enabled WHEN 1 THEN 'enabled' ELSE 'disabled' END,COUNT(*),0,MIN(created_at)
 FROM a2a_publications WHERE scope_id=? GROUP BY enabled ORDER BY enabled DESC`},
+		{"credential", `SELECT CASE enabled WHEN 1 THEN 'enabled' ELSE 'disabled' END,COUNT(*),COALESCE(SUM(length(CAST(label AS BLOB))),0),MIN(created_at)
+FROM scoped_credentials WHERE scope_id=? GROUP BY enabled ORDER BY enabled DESC`},
 	}
 	for _, query := range queries {
 		rows, err := tx.QueryContext(ctx, query.statement, scopeID)

--- a/bus/store.go
+++ b/bus/store.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	schemaVersion                = 6
+	schemaVersion                = 7
 	reservationTTL               = 30 * time.Second
 	messageBacklogCap            = 10000
 	activeTaskCap                = 5000
@@ -213,7 +213,25 @@ CREATE TABLE a2a_publications (
 	FOREIGN KEY(scope_id, agent_id) REFERENCES agents(scope_id, agent_id)
 );
 CREATE INDEX a2a_publications_scope_created ON a2a_publications(scope_id, created_at);
-PRAGMA user_version=6;
+CREATE TABLE scoped_credentials (
+	credential_id TEXT PRIMARY KEY,
+	scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
+	label TEXT NOT NULL,
+	token_hash TEXT NOT NULL UNIQUE,
+	enabled INTEGER NOT NULL CHECK(enabled IN (0,1)),
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL
+);
+CREATE INDEX scoped_credentials_scope_created ON scoped_credentials(scope_id, created_at);
+CREATE TABLE scoped_credential_grants (
+	credential_id TEXT NOT NULL REFERENCES scoped_credentials(credential_id) ON DELETE CASCADE,
+	resource_type TEXT NOT NULL,
+	resource_id TEXT NOT NULL,
+	permission TEXT NOT NULL,
+	PRIMARY KEY(credential_id, resource_type, resource_id, permission)
+);
+CREATE INDEX scoped_credential_grants_resource ON scoped_credential_grants(resource_type, resource_id, permission);
+PRAGMA user_version=7;
 COMMIT;`)
 	return err
 }

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -146,11 +146,13 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 	planner := bus.Client{Address: options.Address, Token: plannerRegistration.AgentToken}
 	reviewer := bus.Client{Address: options.Address, Token: reviewerRegistration.AgentToken}
 
+	var reviewerPublication bus.AgentCardPublication
 	if err := record.check("owner-controlled-agent-card-publication", func() error {
 		publication, err := owner.CreateAgentCardPublication(ctx, bus.PublishAgentCardInput{AgentID: "reviewer"})
 		if err != nil || !publication.Enabled || publication.ID == "" {
 			return fmt.Errorf("unexpected publication: %#v, %v", publication, err)
 		}
+		reviewerPublication = publication
 		listed, err := owner.ListAgentCardPublications(ctx)
 		if err != nil || len(listed) != 1 || listed[0].ID != publication.ID {
 			return fmt.Errorf("unexpected publications: %#v, %v", listed, err)
@@ -188,6 +190,38 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		}
 		_, err = planner.CreateAgentCardPublication(ctx, bus.PublishAgentCardInput{AgentID: "planner"})
 		return requireCode(err, bus.CodeUnauthenticated)
+	}); err != nil {
+		return result, err
+	}
+
+	if err := record.check("scoped-a2a-principal-credentials", func() error {
+		issued, err := owner.CreateA2APrincipal(ctx, bus.CreateA2APrincipalInput{
+			PublicationID: reviewerPublication.ID, Label: "Conformance caller",
+		})
+		if err != nil || issued.Principal.ID == "" || issued.Credential == "" || !issued.Principal.Enabled {
+			return fmt.Errorf("unexpected issued principal: %#v, %v", issued, err)
+		}
+		listed, err := owner.ListA2APrincipals(ctx)
+		if err != nil || len(listed) != 1 || listed[0].ID != issued.Principal.ID {
+			return fmt.Errorf("unexpected principals: %#v, %v", listed, err)
+		}
+		remote := bus.Client{Address: options.Address, Token: issued.Credential}
+		if _, err := remote.ListAgents(ctx); requireCode(err, bus.CodeUnauthenticated) != nil {
+			return fmt.Errorf("scoped credential accessed Bus APIs: %v", err)
+		}
+		disabled, err := owner.SetA2APrincipalEnabled(ctx, issued.Principal.ID, false)
+		if err != nil || disabled.Enabled {
+			return fmt.Errorf("unexpected disabled principal: %#v, %v", disabled, err)
+		}
+		rotated, err := owner.RotateA2APrincipal(ctx, issued.Principal.ID)
+		if err != nil || rotated.Credential == "" || rotated.Credential == issued.Credential || rotated.Principal.Enabled {
+			return fmt.Errorf("unexpected rotated principal: %#v, %v", rotated, err)
+		}
+		enabled, err := owner.SetA2APrincipalEnabled(ctx, issued.Principal.ID, true)
+		if err != nil || !enabled.Enabled {
+			return fmt.Errorf("unexpected enabled principal: %#v, %v", enabled, err)
+		}
+		return nil
 	}); err != nil {
 		return result, err
 	}

--- a/docs/architecture/a2a-bridge.md
+++ b/docs/architecture/a2a-bridge.md
@@ -25,9 +25,12 @@ SDK versions and A2A protocol versions are independent. The bridge records both.
 - A scope owner chooses which agent cards to publish. The shared daemon does not enumerate agents publicly.
 - A deployment gives each published agent a stable interface URL. Execution IDs are never public identity.
 - Agent interfaces use bearer authentication. Loopback HTTP is allowed for local development. Remote interfaces require HTTPS.
+- Remote principals are bound to one publication. Their credentials do not inherit scope, agent, MCP, or administrative authority.
 - October Bus shared work items are a coordination pool. They are not A2A Tasks. A2A Tasks represent one delegated interaction and its result stream.
 
-The reference daemon stores owner-controlled publications and serves enabled Agent Cards at opaque URLs. It does not implement A2A message or task operations yet.
+The reference daemon stores owner-controlled publications and scoped remote principals, then serves enabled Agent Cards at opaque URLs. It does not implement A2A message or task operations yet.
+
+Principal credentials are stored as one-way digests and shown only when created or rotated. Rotation invalidates the previous value immediately. Both the principal and its publication must be enabled for authentication to succeed.
 
 ### Handler caching and conditional requests
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -7,8 +7,9 @@ October Bus currently ships a Go client in this module and a TypeScript client o
 Use the narrowest credential for each operation:
 
 - admin token for scope creation and daemon shutdown;
-- scope token for agent registration, peer links, Agent Card publications, project task management, event streams, storage controls, and human escalation resolution;
+- scope token for agent registration, peer links, Agent Card publications and remote principals, project task management, event streams, storage controls, and human escalation resolution;
 - agent token for heartbeat, discovery, messages, tasks, and escalation creation.
+- scoped A2A credential for one published A2A interface only.
 
 Keep admin and scope tokens outside model context. A managed session gives the harness only its execution-bound agent token.
 
@@ -36,6 +37,11 @@ ownerTasks, err := owner.ListTasks(ctx, true)
 storage, err := owner.StorageSummary(ctx)
 events, err := owner.Events(ctx, lastRevision, 50, 25*time.Second)
 publication, err := owner.CreateAgentCardPublication(ctx, bus.PublishAgentCardInput{AgentID: "reviewer"})
+issued, err := owner.CreateA2APrincipal(ctx, bus.CreateA2APrincipalInput{
+    PublicationID: publication.ID,
+    Label:         "CI reviewer",
+})
+// Store issued.Credential securely. It cannot be retrieved later.
 
 for batch, err := range owner.WatchEvents(ctx, lastRevision, 50) {
     if err != nil {
@@ -84,6 +90,11 @@ const messages = await session.client.pullInbox(50, { waitMs: 25_000 })
 const readyTasks = await new OctoberBusScopeClient(address, scopeToken).listTasks({ ready: true })
 const owner = new OctoberBusScopeClient(address, scopeToken)
 const publication = await owner.createAgentCardPublication({ agentId: 'reviewer' })
+const issued = await owner.createA2APrincipal({
+  publicationId: publication.id,
+  label: 'CI reviewer'
+})
+// Store issued.credential securely. It cannot be retrieved later.
 
 for await (const batch of owner.watchEvents({ after: lastRevision })) {
   if (batch.resyncRequired) break
@@ -99,6 +110,8 @@ await session.client.addTaskProgress(taskId, {
 Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argument. Inbox and event operations support bounded waits up to 25 seconds. The default request timeout is 30 seconds.
 
 Persist an event batch's `nextRevision` only after applying the whole batch. If `resyncRequired` is true, rebuild from the resource APIs before saving the returned cursor. Event envelopes contain state metadata but not message, task, progress, or escalation contents.
+
+Store a remote principal credential when it is created. It cannot be retrieved later. Rotation returns a replacement and invalidates the previous value immediately. Principal lists never include credentials.
 
 Prefer bounded inbox waiting for efficient pull delivery. `pollInbox` provides an async iterator over repeated bounded waits. Use `withClaimedTask` to release a task if work or completion fails. Keep the managed session alive while holding a claim.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -92,7 +92,7 @@ Pass `--yes` to remove the reported records in one transaction. Only terminal me
 
 Pruning scope events can make an old event cursor incomplete. Event clients receive `resyncRequired` and must rebuild their projection from the resource APIs before continuing.
 
-Agent Card publications are configuration records and are not removed by retention. Disable a publication to stop serving its public card.
+Agent Card publications and remote principals are configuration records and are not removed by retention. Disable a publication to stop serving its public card and reject its principals. Disable an individual principal to suspend only that caller.
 
 Choose a cutoff older than the longest client retry window you support. Removing a message also removes its idempotency-key binding.
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -44,6 +44,13 @@ const task = await scope.addTask({
 const readyTasks = await scope.listTasks({ ready: true })
 const storage = await scope.storageSummary()
 
+const publication = await scope.createAgentCardPublication({ agentId: 'reviewer' })
+const issued = await scope.createA2APrincipal({
+  publicationId: publication.id,
+  label: 'CI reviewer'
+})
+// Store issued.credential securely. It cannot be retrieved later.
+
 const dryRun = await scope.pruneScope({ before: '2026-08-01T00:00:00Z' })
 
 const claimed = await reviewer.claimTask(task.id)
@@ -73,6 +80,8 @@ const messages = await reviewer.pullInbox(50, { waitMs: 25_000 })
 The server caps each wait at 25 seconds. Cancellation through `AbortSignal` does not reserve or lose a message.
 
 Scope credentials create agents, manage the project task board, and handle human escalations. Agent credentials discover peers, exchange messages, coordinate tasks, and ask for human input. Claims and completion always require an execution-bound agent credential.
+
+A remote principal credential is returned only when the principal is created or rotated. Store it securely. It is restricted to one published A2A interface and cannot access the Bus API or MCP endpoint.
 
 Operations time out after 30 seconds by default. Pass `{ timeoutMs, signal }` as the final method argument to set a shorter deadline or cancel a request.
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.8",
+  "version": "0.1.0-next.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.8",
+      "version": "0.1.0-next.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.8",
+  "version": "0.1.0-next.9",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -3,6 +3,7 @@ import type { BusErrorCode } from './errors.js'
 import type {
   Agent,
   AgentCardPublication,
+  A2APrincipal,
   AgentLifecycle,
   AddTaskInput,
   AddTaskProgressInput,
@@ -12,10 +13,12 @@ import type {
   BusTask,
   CreateScopeInput,
   CreateScopeResult,
+  CreateA2APrincipalInput,
   DeliveryReceipt,
   EventBatch,
   HumanEscalation,
   InboxReservation,
+  IssuedA2APrincipal,
   PruneScopeInput,
   PruneScopeResult,
   PublishAgentCardInput,
@@ -243,6 +246,41 @@ export class OctoberBusScopeClient {
       this.scopeToken,
       'POST',
       `/v1/a2a/publications/${encodeURIComponent(publicationId)}/${action}`,
+      {},
+      options
+    )
+  }
+
+  createA2APrincipal(input: CreateA2APrincipalInput, options?: OperationOptions): Promise<IssuedA2APrincipal> {
+    return request(this.address, this.scopeToken, 'POST', '/v1/a2a/principals', input, options)
+  }
+
+  listA2APrincipals(options?: OperationOptions): Promise<A2APrincipal[]> {
+    return request(this.address, this.scopeToken, 'GET', '/v1/a2a/principals', undefined, options)
+  }
+
+  rotateA2APrincipal(principalId: string, options?: OperationOptions): Promise<IssuedA2APrincipal> {
+    return request(
+      this.address,
+      this.scopeToken,
+      'POST',
+      `/v1/a2a/principals/${encodeURIComponent(principalId)}/rotate`,
+      {},
+      options
+    )
+  }
+
+  setA2APrincipalEnabled(
+    principalId: string,
+    enabled: boolean,
+    options?: OperationOptions
+  ): Promise<A2APrincipal> {
+    const action = enabled ? 'enable' : 'disable'
+    return request(
+      this.address,
+      this.scopeToken,
+      'POST',
+      `/v1/a2a/principals/${encodeURIComponent(principalId)}/${action}`,
       {},
       options
     )

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -138,6 +138,26 @@ export interface PublishAgentCardInput {
   agentId: AgentId
 }
 
+export interface A2APrincipal {
+  id: string
+  scopeId: ScopeId
+  publicationId: string
+  label: string
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateA2APrincipalInput {
+  publicationId: string
+  label: string
+}
+
+export interface IssuedA2APrincipal {
+  principal: A2APrincipal
+  credential: string
+}
+
 export interface HumanEscalation {
   id: string
   scopeId: ScopeId
@@ -194,7 +214,7 @@ export interface AddTaskProgressInput {
 }
 
 export interface StorageRecordSummary {
-  recordType: 'message' | 'task' | 'taskProgress' | 'escalation' | 'event' | 'a2aPublication'
+  recordType: 'message' | 'task' | 'taskProgress' | 'escalation' | 'event' | 'a2aPublication' | 'credential'
   state: string
   count: number
   estimatedBytes: number

--- a/sdk/typescript/test/integration.mjs
+++ b/sdk/typescript/test/integration.mjs
@@ -82,6 +82,27 @@ try {
   const enabledPublication = await owner.setAgentCardPublicationEnabled(publication.id, true)
   assert.equal(enabledPublication.enabled, true)
   assert.equal(enabledPublication.cardUrl, publication.cardUrl)
+  const issuedPrincipal = await owner.createA2APrincipal({
+    publicationId: publication.id,
+    label: 'Integration caller'
+  })
+  assert.match(issuedPrincipal.principal.id, /^cred_[0-9a-f]{32}$/)
+  assert.match(issuedPrincipal.credential, new RegExp(`^${issuedPrincipal.principal.id}\\.`))
+  const principals = await owner.listA2APrincipals()
+  assert.equal(principals.length, 1)
+  assert.equal(principals[0].id, issuedPrincipal.principal.id)
+  assert.equal(Object.hasOwn(principals[0], 'credential'), false)
+  const scopedAccess = await fetch(`${run.address}/v1/agents`, {
+    headers: { authorization: `Bearer ${issuedPrincipal.credential}` }
+  })
+  assert.equal(scopedAccess.status, 401)
+  const disabledPrincipal = await owner.setA2APrincipalEnabled(issuedPrincipal.principal.id, false)
+  assert.equal(disabledPrincipal.enabled, false)
+  const rotatedPrincipal = await owner.rotateA2APrincipal(issuedPrincipal.principal.id)
+  assert.equal(rotatedPrincipal.principal.enabled, false)
+  assert.notEqual(rotatedPrincipal.credential, issuedPrincipal.credential)
+  const enabledPrincipal = await owner.setA2APrincipalEnabled(issuedPrincipal.principal.id, true)
+  assert.equal(enabledPrincipal.enabled, true)
   const agentsBeforeReady = await owner.listAgents()
   assert.equal(agentsBeforeReady.every((agent) => !agent.ready), true)
   await plannerSession.setState('ready', true)

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -148,6 +148,7 @@ Protocol 0.1 defines these event types:
 - `task.created`, `task.claimed`, `task.released`, `task.completed`, and `task.progress_added`
 - `escalation.created` and `escalation.resolved`
 - `a2a.publication_created`, `a2a.publication_enabled`, and `a2a.publication_disabled`
+- `credential.created`, `credential.rotated`, `credential.enabled`, and `credential.disabled`
 
 Each listed transition event MUST be committed atomically with the transition it describes. Retrying an idempotent operation that made no new state change MUST NOT append another event. A heartbeat that only renews a lease does not append a lifecycle event.
 
@@ -163,6 +164,14 @@ An enabled publication exposes an A2A Agent Card at its returned card URL. The c
 
 Scope authority MAY disable and re-enable a publication without changing its ID or URLs. Card and interface URLs MUST be derived from trusted runtime configuration instead of request headers. The reference runtime permits loopback HTTP and requires HTTPS for non-loopback publication URLs.
 
+## Scoped A2A credentials
+
+A scope owner MAY create remote principals for an Agent Card publication. Each principal has a stable opaque ID, a human-readable label, and one bearer credential restricted to invoking that publication. The plaintext credential is returned only when the principal is created or rotated. It MUST NOT appear in lists, Agent Cards, events, logs, or errors.
+
+Rotating a principal invalidates its previous credential immediately without changing the principal ID. Disabling a principal suspends its current credential, and re-enabling it restores that credential unless it was rotated. Disabling the publication also prevents its principals from authenticating.
+
+A scoped A2A credential grants no access to the Bus HTTP API, MCP endpoint, scope authority, agent authority, other publications, or daemon administration. Implementations MUST store a one-way digest instead of the plaintext credential and compare presented credentials in constant time.
+
 ## Human escalation
 
 An agent MAY create an escalation with a question and either no options or two to four options. Creating an escalation does not grant the agent permission or answer the question.
@@ -174,8 +183,9 @@ Only scope authority resolves escalations. Agent authority can create and read e
 | Credential | Allowed operations |
 | --- | --- |
 | Admin token | Create a scope and request local daemon shutdown |
-| Scope token | Register and list agents, create peer links, manage Agent Card publications, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
+| Scope token | Register and list agents, create peer links, manage Agent Card publications and their remote principals, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
 | Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, create and read escalations |
+| Scoped A2A credential | Invoke one published A2A agent interface when that operation is supported |
 
 Tokens are bearer credentials. Implementations MUST compare them safely, MUST NOT log them, and MUST reject empty credentials. Agent tokens MUST stop working after lease expiry or execution replacement.
 

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -68,6 +68,11 @@ Failures use:
 | `GET` | `/v1/a2a/publications` | Scope | Agent Card publications in the scope |
 | `POST` | `/v1/a2a/publications/{publicationId}/enable` | Scope | Enabled publication |
 | `POST` | `/v1/a2a/publications/{publicationId}/disable` | Scope | Disabled publication |
+| `POST` | `/v1/a2a/principals` | Scope | New principal and one-time credential |
+| `GET` | `/v1/a2a/principals` | Scope | Remote A2A principals without credentials |
+| `POST` | `/v1/a2a/principals/{principalId}/rotate` | Scope | Principal and replacement credential |
+| `POST` | `/v1/a2a/principals/{principalId}/enable` | Scope | Enabled principal |
+| `POST` | `/v1/a2a/principals/{principalId}/disable` | Scope | Disabled principal |
 | `GET` | `/a2a/agents/{publicationId}/.well-known/agent-card.json` | None | Enabled A2A Agent Card |
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
 
@@ -82,6 +87,8 @@ Failures use:
 Clients resume from `nextRevision`. `minimumCursor` is the oldest cursor that can still produce a complete continuation. A batch with `resyncRequired: true` means retention removed events needed by the supplied cursor. The client must rebuild its projection from the resource APIs and resume from the returned `nextRevision`.
 
 Agent Card publications are absent by default. A scope owner publishes one registered agent by sending its exact `agentId`. The returned opaque publication ID and URLs remain stable while the publication is disabled and re-enabled. Public card requests for unknown and disabled IDs return the same `NOT_FOUND` response. Card and interface URLs come from the runtime's trusted address configuration, never the request `Host` header.
+
+`POST /v1/a2a/principals` accepts a publication ID and label. Create and rotate responses are the only responses that contain the bearer credential. List, enable, and disable responses return principal metadata only. A principal credential is restricted to its publication and cannot authenticate to any `/v1` or `/mcp` operation.
 
 Request and result shapes are defined in [protocol.schema.json](schemas/protocol.schema.json). Consumers can reference individual definitions with a fragment such as:
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -378,12 +378,44 @@
         "updatedAt": { "$ref": "#/$defs/instant" }
       }
     },
+    "createA2APrincipalInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["publicationId", "label"],
+      "properties": {
+        "publicationId": { "$ref": "#/$defs/identifier" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 256 }
+      }
+    },
+    "a2aPrincipal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "scopeId", "publicationId", "label", "enabled", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "scopeId": { "$ref": "#/$defs/identifier" },
+        "publicationId": { "$ref": "#/$defs/identifier" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "enabled": { "type": "boolean" },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "issuedA2APrincipal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principal", "credential"],
+      "properties": {
+        "principal": { "$ref": "#/$defs/a2aPrincipal" },
+        "credential": { "type": "string", "minLength": 1 }
+      }
+    },
     "storageRecordSummary": {
       "type": "object",
       "additionalProperties": false,
       "required": ["recordType", "state", "count", "estimatedBytes"],
       "properties": {
-        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event", "a2aPublication"] },
+        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event", "a2aPublication", "credential"] },
         "state": { "type": "string", "minLength": 1 },
         "count": { "type": "integer", "minimum": 0 },
         "estimatedBytes": { "type": "integer", "minimum": 0 },

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -159,6 +159,22 @@ func TestProtocolSchemas(t *testing.T) {
 	publishInput := resolvedSchema(t, path, "publishAgentCardInput")
 	requireValid(t, publishInput, map[string]any{"agentId": "reviewer"})
 	requireInvalid(t, publishInput, map[string]any{"agentId": "reviewer", "scopeId": "scope"})
+	principal := resolvedSchema(t, path, "a2aPrincipal")
+	requireValid(t, principal, map[string]any{
+		"id": "cred_123", "scopeId": "scope", "publicationId": "pub_123", "label": "Review service", "enabled": true,
+		"createdAt": "2026-09-02T00:00:00Z", "updatedAt": "2026-09-02T00:00:00Z",
+	})
+	issuedPrincipal := resolvedSchema(t, path, "issuedA2APrincipal")
+	requireValid(t, issuedPrincipal, map[string]any{
+		"principal": map[string]any{
+			"id": "cred_123", "scopeId": "scope", "publicationId": "pub_123", "label": "Review service", "enabled": true,
+			"createdAt": "2026-09-02T00:00:00Z", "updatedAt": "2026-09-02T00:00:00Z",
+		},
+		"credential": "cred_123.secret",
+	})
+	createPrincipal := resolvedSchema(t, path, "createA2APrincipalInput")
+	requireValid(t, createPrincipal, map[string]any{"publicationId": "pub_123", "label": "Review service"})
+	requireInvalid(t, createPrincipal, map[string]any{"publicationId": "pub_123", "label": ""})
 
 	prune := resolvedSchema(t, path, "pruneScopeInput")
 	requireValid(t, prune, map[string]any{"before": "2026-08-01T00:00:00Z"})
@@ -270,6 +286,11 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	requireValid(t, resolvedSchema(t, path, "agentCardPublication"), jsonValue(t, publication))
+	principal, err := owner.CreateA2APrincipal(ctx, bus.CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Review service"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireValid(t, resolvedSchema(t, path, "issuedA2APrincipal"), jsonValue(t, principal))
 	planner := bus.Client{Address: address, Token: plannerRegistration.AgentToken}
 	reviewer := bus.Client{Address: address, Token: reviewerRegistration.AgentToken}
 	agent, err := planner.Heartbeat(ctx, bus.HeartbeatInput{Lifecycle: bus.LifecycleReady, Ready: true})


### PR DESCRIPTION
## Summary

- add durable remote principals bound to one Agent Card publication
- store bearer secrets as one-way digests and return plaintext only on creation or rotation
- add owner controls, Go and TypeScript clients, protocol schemas, events, and storage visibility
- isolate these credentials from existing Bus, MCP, scope, agent, and admin authority

## Validation

- Go race tests and vet
- TypeScript typecheck, build, error tests, and Go to TypeScript integration
- local runtime conformance: 20/20
- Linux and Windows cross-builds

Closes #8