### PR TITLE
Add addressable output streams

### DIFF
--- a/bus/client.go
+++ b/bus/client.go
@@ -230,6 +230,66 @@ func (c Client) SetA2APrincipalEnabled(ctx context.Context, principalID string, 
 	return request[A2APrincipal](ctx, c, http.MethodPost, "/v1/a2a/principals/"+url.PathEscape(principalID)+"/"+action, map[string]any{})
 }
 
+func (c Client) CreateOutputStream(ctx context.Context, input CreateOutputStreamInput) (OutputStream, error) {
+	return request[OutputStream](ctx, c, http.MethodPost, "/v1/output-streams", input)
+}
+
+func (c Client) ListOutputStreams(ctx context.Context) ([]OutputStream, error) {
+	return request[[]OutputStream](ctx, c, http.MethodGet, "/v1/output-streams", nil)
+}
+
+func (c Client) OutputStream(ctx context.Context, streamID string) (OutputStream, error) {
+	return request[OutputStream](ctx, c, http.MethodGet, "/v1/output-streams/"+url.PathEscape(streamID), nil)
+}
+
+func (c Client) RemoveOutputStream(ctx context.Context, streamID string) error {
+	_, err := request[map[string]bool](ctx, c, http.MethodDelete, "/v1/output-streams/"+url.PathEscape(streamID), nil)
+	return err
+}
+
+func (c Client) SetOutputPublisher(ctx context.Context, streamID, agentID string, allowed bool) (OutputStream, error) {
+	method := http.MethodDelete
+	if allowed {
+		method = http.MethodPut
+	}
+	return request[OutputStream](ctx, c, method, "/v1/output-streams/"+url.PathEscape(streamID)+"/publishers/"+url.PathEscape(agentID), nil)
+}
+
+func (c Client) CreateOutputPrincipal(ctx context.Context, input CreateOutputPrincipalInput) (IssuedOutputPrincipal, error) {
+	return request[IssuedOutputPrincipal](ctx, c, http.MethodPost, "/v1/output-principals", input)
+}
+
+func (c Client) ListOutputPrincipals(ctx context.Context) ([]OutputPrincipal, error) {
+	return request[[]OutputPrincipal](ctx, c, http.MethodGet, "/v1/output-principals", nil)
+}
+
+func (c Client) RotateOutputPrincipal(ctx context.Context, principalID string) (IssuedOutputPrincipal, error) {
+	return request[IssuedOutputPrincipal](ctx, c, http.MethodPost, "/v1/output-principals/"+url.PathEscape(principalID)+"/rotate", map[string]any{})
+}
+
+func (c Client) SetOutputPrincipalEnabled(ctx context.Context, principalID string, enabled bool) (OutputPrincipal, error) {
+	action := "disable"
+	if enabled {
+		action = "enable"
+	}
+	return request[OutputPrincipal](ctx, c, http.MethodPost, "/v1/output-principals/"+url.PathEscape(principalID)+"/"+action, map[string]any{})
+}
+
+func (c Client) PublishOutput(ctx context.Context, streamID string, input PublishOutputInput) (OutputValue, error) {
+	return request[OutputValue](ctx, c, http.MethodPost, "/outputs/"+url.PathEscape(streamID)+"/values", input)
+}
+
+func (c Client) LatestOutput(ctx context.Context, streamID string) (*OutputValue, error) {
+	return request[*OutputValue](ctx, c, http.MethodGet, "/outputs/"+url.PathEscape(streamID)+"/latest", nil)
+}
+
+func (c Client) OutputHistory(ctx context.Context, streamID string, after int64, limit int) (OutputHistory, error) {
+	query := url.Values{}
+	query.Set("after", fmt.Sprintf("%d", after))
+	query.Set("limit", fmt.Sprintf("%d", limit))
+	return request[OutputHistory](ctx, c, http.MethodGet, "/outputs/"+url.PathEscape(streamID)+"/values?"+query.Encode(), nil)
+}
+
 func (c Client) WatchEvents(ctx context.Context, after int64, limit int) iter.Seq2[EventBatch, error] {
 	return func(yield func(EventBatch, error) bool) {
 		for ctx.Err() == nil {

--- a/bus/daemon.go
+++ b/bus/daemon.go
@@ -239,7 +239,13 @@ func StartDaemon(ctx context.Context, port int, paths *DaemonPaths) (*RunningDae
 		return nil, err
 	}
 	startedAt := time.Now().UTC().Format(time.RFC3339Nano)
-	server := NewServer(runtimeValue, ServerOptions{Port: port, AdminToken: adminToken, StartedAt: startedAt})
+	allowedOrigins := []string{}
+	for _, origin := range strings.Split(os.Getenv("OCTOBER_BUS_ALLOWED_ORIGINS"), ",") {
+		if origin = strings.TrimSpace(origin); origin != "" {
+			allowedOrigins = append(allowedOrigins, origin)
+		}
+	}
+	server := NewServer(runtimeValue, ServerOptions{Port: port, AdminToken: adminToken, StartedAt: startedAt, AllowedOrigins: unique(allowedOrigins)})
 	address, err := server.Start()
 	if err != nil {
 		runtimeValue.Close()

--- a/bus/output_principals.go
+++ b/bus/output_principals.go
@@ -1,0 +1,265 @@
+package bus
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sort"
+	"strings"
+)
+
+const outputStreamResource = "outputStream"
+
+func outputPrincipalFrom(record scopedCredentialRecord, streamID string, permissions []OutputPermission) OutputPrincipal {
+	if permissions == nil {
+		permissions = []OutputPermission{}
+	}
+	return OutputPrincipal{
+		ID: record.ID, ScopeID: record.ScopeID, StreamID: streamID, Label: record.Label,
+		Permissions: permissions, Enabled: record.Enabled, CreatedAt: instant(record.CreatedAt), UpdatedAt: instant(record.UpdatedAt),
+	}
+}
+
+func validateOutputPermissions(values []OutputPermission) ([]OutputPermission, error) {
+	if len(values) == 0 || len(values) > 2 {
+		return nil, Errorf(CodeInvalidArgument, "permissions must contain read, publish, or both")
+	}
+	seen := map[OutputPermission]bool{}
+	result := make([]OutputPermission, 0, len(values))
+	for _, value := range values {
+		if value != OutputRead && value != OutputPublish {
+			return nil, Errorf(CodeInvalidArgument, "permissions contains an invalid value")
+		}
+		if seen[value] {
+			return nil, Errorf(CodeInvalidArgument, "permissions must be unique")
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left] < result[right] })
+	return result, nil
+}
+
+func (s *Store) CreateOutputPrincipal(ctx context.Context, scopeID string, input CreateOutputPrincipalInput) (IssuedOutputPrincipal, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	defer tx.Rollback()
+	var found int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM output_streams WHERE scope_id=? AND stream_id=?`, scopeID, input.StreamID).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+		return IssuedOutputPrincipal{}, Errorf(CodeNotFound, "Output stream "+input.StreamID+" was not found")
+	} else if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	grants := make([]scopedCredentialGrant, 0, len(input.Permissions))
+	for _, permission := range input.Permissions {
+		grants = append(grants, scopedCredentialGrant{ResourceType: outputStreamResource, ResourceID: input.StreamID, Permission: string(permission)})
+	}
+	now := nowMillis()
+	record, credential, err := createScopedCredential(ctx, tx, scopeID, input.Label, grants, now)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := appendEvent(ctx, tx, scopeID, "credential.created", record.ID, eventAttributes(
+		"resourceType", outputStreamResource, "resourceId", input.StreamID, "permissions", outputPermissionString(input.Permissions), "enabled", "true",
+	), now); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	return IssuedOutputPrincipal{Principal: outputPrincipalFrom(record, input.StreamID, input.Permissions), Credential: credential}, nil
+}
+
+func outputPermissionString(values []OutputPermission) string {
+	parts := make([]string, len(values))
+	for index, value := range values {
+		parts[index] = string(value)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (s *Store) ListOutputPrincipals(ctx context.Context, scopeID string) ([]OutputPrincipal, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT c.credential_id,c.scope_id,c.label,c.enabled,c.created_at,c.updated_at,g.resource_id,g.permission
+FROM scoped_credentials c
+JOIN scoped_credential_grants g ON g.credential_id=c.credential_id
+WHERE c.scope_id=? AND g.resource_type=?
+ORDER BY c.created_at,c.credential_id,g.permission`, scopeID, outputStreamResource)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	principals := []OutputPrincipal{}
+	for rows.Next() {
+		var record scopedCredentialRecord
+		var enabled int
+		var streamID string
+		var permission OutputPermission
+		if err := rows.Scan(&record.ID, &record.ScopeID, &record.Label, &enabled, &record.CreatedAt, &record.UpdatedAt, &streamID, &permission); err != nil {
+			return nil, err
+		}
+		record.Enabled = enabled == 1
+		last := len(principals) - 1
+		if last >= 0 && principals[last].ID == record.ID {
+			principals[last].Permissions = append(principals[last].Permissions, permission)
+			continue
+		}
+		principals = append(principals, outputPrincipalFrom(record, streamID, []OutputPermission{permission}))
+	}
+	return principals, rows.Err()
+}
+
+func outputPrincipalDetails(ctx context.Context, tx *sql.Tx, scopeID, principalID string) (scopedCredentialRecord, string, []OutputPermission, error) {
+	record, err := scanScopedCredential(tx.QueryRowContext(ctx, `SELECT `+scopedCredentialColumns+` FROM scoped_credentials WHERE scope_id=? AND credential_id=?`, scopeID, principalID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return scopedCredentialRecord{}, "", nil, Errorf(CodeNotFound, "Output principal was not found")
+	}
+	if err != nil {
+		return scopedCredentialRecord{}, "", nil, err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT resource_id,permission FROM scoped_credential_grants WHERE credential_id=? AND resource_type=? ORDER BY permission`, principalID, outputStreamResource)
+	if err != nil {
+		return scopedCredentialRecord{}, "", nil, err
+	}
+	defer rows.Close()
+	streamID := ""
+	permissions := []OutputPermission{}
+	for rows.Next() {
+		var resourceID string
+		var permission OutputPermission
+		if err := rows.Scan(&resourceID, &permission); err != nil {
+			return scopedCredentialRecord{}, "", nil, err
+		}
+		if streamID != "" && streamID != resourceID {
+			return scopedCredentialRecord{}, "", nil, Errorf(CodeInternal, "Output principal has inconsistent grants")
+		}
+		streamID = resourceID
+		permissions = append(permissions, permission)
+	}
+	if err := rows.Err(); err != nil {
+		return scopedCredentialRecord{}, "", nil, err
+	}
+	if streamID == "" {
+		return scopedCredentialRecord{}, "", nil, Errorf(CodeNotFound, "Output principal was not found")
+	}
+	return record, streamID, permissions, nil
+}
+
+func (s *Store) RotateOutputPrincipal(ctx context.Context, scopeID, principalID string) (IssuedOutputPrincipal, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	defer tx.Rollback()
+	_, streamID, permissions, err := outputPrincipalDetails(ctx, tx, scopeID, principalID)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	now := nowMillis()
+	record, credential, err := rotateScopedCredential(ctx, tx, scopeID, principalID, now)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := appendEvent(ctx, tx, scopeID, "credential.rotated", record.ID, eventAttributes(
+		"resourceType", outputStreamResource, "resourceId", streamID, "permissions", outputPermissionString(permissions),
+	), now); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	return IssuedOutputPrincipal{Principal: outputPrincipalFrom(record, streamID, permissions), Credential: credential}, nil
+}
+
+func (s *Store) SetOutputPrincipalEnabled(ctx context.Context, scopeID, principalID string, enabled bool) (OutputPrincipal, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutputPrincipal{}, err
+	}
+	defer tx.Rollback()
+	_, streamID, permissions, err := outputPrincipalDetails(ctx, tx, scopeID, principalID)
+	if err != nil {
+		return OutputPrincipal{}, err
+	}
+	now := nowMillis()
+	record, changed, err := setScopedCredentialEnabled(ctx, tx, scopeID, principalID, enabled, now)
+	if err != nil {
+		return OutputPrincipal{}, err
+	}
+	if changed {
+		eventType := "credential.disabled"
+		if enabled {
+			eventType = "credential.enabled"
+		}
+		if err := appendEvent(ctx, tx, scopeID, eventType, record.ID, eventAttributes(
+			"resourceType", outputStreamResource, "resourceId", streamID, "permissions", outputPermissionString(permissions), "enabled", boolString(enabled),
+		), now); err != nil {
+			return OutputPrincipal{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return OutputPrincipal{}, err
+	}
+	return outputPrincipalFrom(record, streamID, permissions), nil
+}
+
+func (r *Runtime) CreateOutputPrincipal(ctx context.Context, scopeToken string, input CreateOutputPrincipalInput) (IssuedOutputPrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := validateIdentity(input.StreamID, "streamId", false); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := validateText(input.Label, "label", 256, false); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	input.Permissions, err = validateOutputPermissions(input.Permissions)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	result, err := r.store.CreateOutputPrincipal(ctx, scopeID, input)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
+}
+
+func (r *Runtime) ListOutputPrincipals(ctx context.Context, scopeToken string) ([]OutputPrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return nil, err
+	}
+	return r.store.ListOutputPrincipals(ctx, scopeID)
+}
+
+func (r *Runtime) RotateOutputPrincipal(ctx context.Context, scopeToken, principalID string) (IssuedOutputPrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	if err := validateIdentity(principalID, "principalId", false); err != nil {
+		return IssuedOutputPrincipal{}, err
+	}
+	result, err := r.store.RotateOutputPrincipal(ctx, scopeID, principalID)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
+}
+
+func (r *Runtime) SetOutputPrincipalEnabled(ctx context.Context, scopeToken, principalID string, enabled bool) (OutputPrincipal, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return OutputPrincipal{}, err
+	}
+	if err := validateIdentity(principalID, "principalId", false); err != nil {
+		return OutputPrincipal{}, err
+	}
+	result, err := r.store.SetOutputPrincipalEnabled(ctx, scopeID, principalID, enabled)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return result, err
+}

--- a/bus/output_routes.go
+++ b/bus/output_routes.go
@@ -1,0 +1,259 @@
+package bus
+
+import (
+	"net/http"
+	"strconv"
+)
+
+func (s *Server) prepareOutputCORS(response http.ResponseWriter, request *http.Request) error {
+	origin := request.Header.Get("Origin")
+	if origin == "" {
+		return nil
+	}
+	response.Header().Add("Vary", "Origin")
+	allowed := false
+	for _, candidate := range s.options.AllowedOrigins {
+		if origin == candidate {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return Errorf(CodePermissionDenied, "Browser origin is not allowed")
+	}
+	response.Header().Set("Access-Control-Allow-Origin", origin)
+	response.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+	response.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	return nil
+}
+
+func (s *Server) outputOptions(response http.ResponseWriter, request *http.Request) error {
+	if err := s.prepareOutputCORS(response, request); err != nil {
+		return err
+	}
+	response.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+func (s *Server) createOutputStream(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input CreateOutputStreamInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	stream, err := s.runtime.CreateOutputStream(request.Context(), token, input)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusCreated, stream)
+	return nil
+}
+
+func (s *Server) listOutputStreams(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	streams, err := s.runtime.ListOutputStreams(request.Context(), token)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, streams)
+	return nil
+}
+
+func (s *Server) getOutputStream(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	stream, err := s.runtime.OutputStream(request.Context(), token, request.PathValue("streamId"))
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, stream)
+	return nil
+}
+
+func (s *Server) removeOutputStream(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	if err := s.runtime.RemoveOutputStream(request.Context(), token, request.PathValue("streamId")); err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, map[string]bool{"removed": true})
+	return nil
+}
+
+func (s *Server) setOutputPublisher(response http.ResponseWriter, request *http.Request, allowed bool) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	stream, err := s.runtime.SetOutputPublisher(request.Context(), token, request.PathValue("streamId"), request.PathValue("agentId"), allowed)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, stream)
+	return nil
+}
+
+func (s *Server) addOutputPublisher(response http.ResponseWriter, request *http.Request) error {
+	return s.setOutputPublisher(response, request, true)
+}
+
+func (s *Server) removeOutputPublisher(response http.ResponseWriter, request *http.Request) error {
+	return s.setOutputPublisher(response, request, false)
+}
+
+func (s *Server) createOutputPrincipal(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input CreateOutputPrincipalInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	principal, err := s.runtime.CreateOutputPrincipal(request.Context(), token, input)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusCreated, principal)
+	return nil
+}
+
+func (s *Server) listOutputPrincipals(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	principals, err := s.runtime.ListOutputPrincipals(request.Context(), token)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, principals)
+	return nil
+}
+
+func (s *Server) rotateOutputPrincipal(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input emptyInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	principal, err := s.runtime.RotateOutputPrincipal(request.Context(), token, request.PathValue("principalId"))
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, principal)
+	return nil
+}
+
+func (s *Server) setOutputPrincipal(response http.ResponseWriter, request *http.Request, enabled bool) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input emptyInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	principal, err := s.runtime.SetOutputPrincipalEnabled(request.Context(), token, request.PathValue("principalId"), enabled)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, principal)
+	return nil
+}
+
+func (s *Server) enableOutputPrincipal(response http.ResponseWriter, request *http.Request) error {
+	return s.setOutputPrincipal(response, request, true)
+}
+
+func (s *Server) disableOutputPrincipal(response http.ResponseWriter, request *http.Request) error {
+	return s.setOutputPrincipal(response, request, false)
+}
+
+func (s *Server) publishOutput(response http.ResponseWriter, request *http.Request) error {
+	if err := s.prepareOutputCORS(response, request); err != nil {
+		return err
+	}
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	var input PublishOutputInput
+	if err := decodeBody(response, request, &input); err != nil {
+		return err
+	}
+	value, err := s.runtime.PublishOutput(request.Context(), token, request.PathValue("streamId"), input)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusCreated, value)
+	return nil
+}
+
+func (s *Server) latestOutput(response http.ResponseWriter, request *http.Request) error {
+	if err := s.prepareOutputCORS(response, request); err != nil {
+		return err
+	}
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	value, err := s.runtime.LatestOutput(request.Context(), token, request.PathValue("streamId"))
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, value)
+	return nil
+}
+
+func (s *Server) outputHistory(response http.ResponseWriter, request *http.Request) error {
+	if err := s.prepareOutputCORS(response, request); err != nil {
+		return err
+	}
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	after, err := queryInteger(request, "after", 0)
+	if err != nil {
+		return err
+	}
+	limit64, err := queryInteger(request, "limit", defaultOutputLimit)
+	if err != nil {
+		return err
+	}
+	if limit64 > int64(^uint(0)>>1) {
+		return Errorf(CodeInvalidArgument, "limit is invalid")
+	}
+	history, err := s.runtime.OutputHistory(request.Context(), token, request.PathValue("streamId"), after, int(limit64))
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, history)
+	return nil
+}
+
+func queryInteger(request *http.Request, name string, fallback int64) (int64, error) {
+	value := request.URL.Query().Get(name)
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, Errorf(CodeInvalidArgument, name+" must be an integer")
+	}
+	return parsed, nil
+}

--- a/bus/output_streams.go
+++ b/bus/output_streams.go
@@ -1,0 +1,746 @@
+package bus
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+)
+
+const (
+	defaultOutputRetention = 1000
+	maxOutputRetention     = 10000
+	maxOutputStreams       = 1000
+	maxOutputPublishers    = 128
+	maxOutputTextBytes     = 64 * 1024
+	maxOutputJSONBytes     = 256 * 1024
+	outputPublishRate      = 120
+	outputReadRate         = 600
+	defaultOutputLimit     = 50
+	maxOutputLimit         = 100
+)
+
+type outputStreamRecord struct {
+	ID              string
+	ScopeID         string
+	Name            string
+	RetentionLimit  int
+	CurrentSequence int64
+	MinimumCursor   int64
+	CreatedAt       int64
+	UpdatedAt       int64
+}
+
+const outputStreamColumns = `stream_id,scope_id,name,retention_limit,sequence,floor_sequence,created_at,updated_at`
+
+func scanOutputStream(row rowScanner) (outputStreamRecord, error) {
+	var stream outputStreamRecord
+	err := row.Scan(&stream.ID, &stream.ScopeID, &stream.Name, &stream.RetentionLimit, &stream.CurrentSequence, &stream.MinimumCursor, &stream.CreatedAt, &stream.UpdatedAt)
+	return stream, err
+}
+
+func outputStreamFrom(record outputStreamRecord, publishers []string) OutputStream {
+	if publishers == nil {
+		publishers = []string{}
+	}
+	return OutputStream{
+		ID: record.ID, ScopeID: record.ScopeID, Name: record.Name, RetentionLimit: record.RetentionLimit,
+		CurrentSequence: record.CurrentSequence, MinimumCursor: record.MinimumCursor,
+		PublisherAgentIDs: publishers, CreatedAt: instant(record.CreatedAt), UpdatedAt: instant(record.UpdatedAt),
+	}
+}
+
+func outputPublishers(ctx context.Context, query interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, scopeID string) (map[string][]string, error) {
+	rows, err := query.QueryContext(ctx, `SELECT stream_id,agent_id FROM output_stream_publishers WHERE scope_id=? ORDER BY stream_id,agent_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := map[string][]string{}
+	for rows.Next() {
+		var streamID, agentID string
+		if err := rows.Scan(&streamID, &agentID); err != nil {
+			return nil, err
+		}
+		result[streamID] = append(result[streamID], agentID)
+	}
+	return result, rows.Err()
+}
+
+func outputStreamFromQuery(ctx context.Context, query interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}, scopeID, streamID string) (OutputStream, error) {
+	record, err := scanOutputStream(query.QueryRowContext(ctx, `SELECT `+outputStreamColumns+` FROM output_streams WHERE scope_id=? AND stream_id=?`, scopeID, streamID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return OutputStream{}, Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+	}
+	if err != nil {
+		return OutputStream{}, err
+	}
+	publishers, err := outputPublishers(ctx, query, scopeID)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	return outputStreamFrom(record, publishers[record.ID]), nil
+}
+
+func (s *Store) CreateOutputStream(ctx context.Context, scopeID string, input CreateOutputStreamInput) (OutputStream, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	defer tx.Rollback()
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM output_streams WHERE scope_id=?`, scopeID).Scan(&count); err != nil {
+		return OutputStream{}, err
+	}
+	if count >= maxOutputStreams {
+		return OutputStream{}, Errorf(CodeBackpressure, "Scope output stream limit is full")
+	}
+	for _, agentID := range input.PublisherAgentIDs {
+		var found int
+		err := tx.QueryRowContext(ctx, `SELECT 1 FROM agents WHERE scope_id=? AND agent_id=?`, scopeID, agentID).Scan(&found)
+		if errors.Is(err, sql.ErrNoRows) {
+			return OutputStream{}, Errorf(CodeNotFound, "Agent "+agentID+" was not found")
+		}
+		if err != nil {
+			return OutputStream{}, err
+		}
+	}
+	streamID, err := randomID("out_")
+	if err != nil {
+		return OutputStream{}, err
+	}
+	now := nowMillis()
+	_, err = tx.ExecContext(ctx, `INSERT INTO output_streams(stream_id,scope_id,name,retention_limit,created_at,updated_at) VALUES(?,?,?,?,?,?)`,
+		streamID, scopeID, input.Name, input.RetentionLimit, now, now)
+	if err != nil {
+		if isSQLiteConstraint(err) {
+			return OutputStream{}, Errorf(CodeConflict, "Output stream name already exists")
+		}
+		return OutputStream{}, err
+	}
+	for _, agentID := range input.PublisherAgentIDs {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO output_stream_publishers(stream_id,scope_id,agent_id) VALUES(?,?,?)`, streamID, scopeID, agentID); err != nil {
+			return OutputStream{}, err
+		}
+	}
+	if err := appendEvent(ctx, tx, scopeID, "output.stream_created", streamID, eventAttributes(
+		"retentionLimit", fmt.Sprintf("%d", input.RetentionLimit),
+	), now); err != nil {
+		return OutputStream{}, err
+	}
+	stream, err := outputStreamFromQuery(ctx, tx, scopeID, streamID)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OutputStream{}, err
+	}
+	return stream, nil
+}
+
+func (s *Store) ListOutputStreams(ctx context.Context, scopeID string) ([]OutputStream, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	rows, err := tx.QueryContext(ctx, `SELECT `+outputStreamColumns+` FROM output_streams WHERE scope_id=? ORDER BY created_at,stream_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	records := []outputStreamRecord{}
+	for rows.Next() {
+		record, err := scanOutputStream(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+	publishers, err := outputPublishers(ctx, tx, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	streams := make([]OutputStream, 0, len(records))
+	for _, record := range records {
+		streams = append(streams, outputStreamFrom(record, publishers[record.ID]))
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return streams, nil
+}
+
+func (s *Store) OutputStream(ctx context.Context, scopeID, streamID string) (OutputStream, error) {
+	return outputStreamFromQuery(ctx, s.db, scopeID, streamID)
+}
+
+func (s *Store) RemoveOutputStream(ctx context.Context, scopeID, streamID string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var found int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM output_streams WHERE scope_id=? AND stream_id=?`, scopeID, streamID).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+		return Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+	} else if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM scoped_credentials WHERE credential_id IN (
+		SELECT credential_id FROM scoped_credential_grants WHERE resource_type=? AND resource_id=?
+	)`, outputStreamResource, streamID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM output_streams WHERE scope_id=? AND stream_id=?`, scopeID, streamID); err != nil {
+		return err
+	}
+	now := nowMillis()
+	if err := appendEvent(ctx, tx, scopeID, "output.stream_removed", streamID, nil, now); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) SetOutputPublisher(ctx context.Context, scopeID, streamID, agentID string, allowed bool) (OutputStream, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	defer tx.Rollback()
+	var found int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM output_streams WHERE scope_id=? AND stream_id=?`, scopeID, streamID).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+		return OutputStream{}, Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+	} else if err != nil {
+		return OutputStream{}, err
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM agents WHERE scope_id=? AND agent_id=?`, scopeID, agentID).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+		return OutputStream{}, Errorf(CodeNotFound, "Agent "+agentID+" was not found")
+	} else if err != nil {
+		return OutputStream{}, err
+	}
+	now := nowMillis()
+	changed := false
+	if allowed {
+		var exists int
+		err := tx.QueryRowContext(ctx, `SELECT 1 FROM output_stream_publishers WHERE stream_id=? AND agent_id=?`, streamID, agentID).Scan(&exists)
+		if err == nil {
+			stream, err := outputStreamFromQuery(ctx, tx, scopeID, streamID)
+			if err != nil {
+				return OutputStream{}, err
+			}
+			if err := tx.Commit(); err != nil {
+				return OutputStream{}, err
+			}
+			return stream, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return OutputStream{}, err
+		}
+		var count int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM output_stream_publishers WHERE stream_id=?`, streamID).Scan(&count); err != nil {
+			return OutputStream{}, err
+		}
+		if count >= maxOutputPublishers {
+			return OutputStream{}, Errorf(CodeBackpressure, "Output publisher limit is full")
+		}
+		result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO output_stream_publishers(stream_id,scope_id,agent_id) VALUES(?,?,?)`, streamID, scopeID, agentID)
+		if err != nil {
+			return OutputStream{}, err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return OutputStream{}, err
+		}
+		changed = rows > 0
+	} else {
+		result, err := tx.ExecContext(ctx, `DELETE FROM output_stream_publishers WHERE stream_id=? AND scope_id=? AND agent_id=?`, streamID, scopeID, agentID)
+		if err != nil {
+			return OutputStream{}, err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return OutputStream{}, err
+		}
+		changed = rows > 0
+	}
+	if changed {
+		eventType := "output.publisher_removed"
+		if allowed {
+			eventType = "output.publisher_added"
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE output_streams SET updated_at=? WHERE scope_id=? AND stream_id=?`, now, scopeID, streamID); err != nil {
+			return OutputStream{}, err
+		}
+		if err := appendEvent(ctx, tx, scopeID, eventType, streamID, eventAttributes("agentId", agentID), now); err != nil {
+			return OutputStream{}, err
+		}
+	}
+	stream, err := outputStreamFromQuery(ctx, tx, scopeID, streamID)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OutputStream{}, err
+	}
+	return stream, nil
+}
+
+func consumeOutputQuota(ctx context.Context, tx *sql.Tx, scopeID, principalType, principalID string, publish bool, now int64) error {
+	window := now - now%60000
+	if _, err := tx.ExecContext(ctx, `DELETE FROM output_rate_usage WHERE window_start<?`, window-60000); err != nil {
+		return err
+	}
+	column, cap := "read_count", outputReadRate
+	if publish {
+		column, cap = "publish_count", outputPublishRate
+	}
+	statement := `INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,` + column + `) VALUES(?,?,?,?,1)
+	ON CONFLICT(scope_id,principal_type,principal_id,window_start) DO UPDATE SET ` + column + `=` + column + `+1 RETURNING ` + column
+	var count int
+	if err := tx.QueryRowContext(ctx, statement, scopeID, principalType, principalID, window).Scan(&count); err != nil {
+		return err
+	}
+	if count > cap {
+		return Errorf(CodeBackpressure, "Output request rate limit is full")
+	}
+	return nil
+}
+
+type outputPublisher struct {
+	Agent      *Principal
+	Credential string
+}
+
+func (s *Store) PublishOutput(ctx context.Context, authority outputPublisher, streamID string, input PublishOutputInput, valueJSON, referenceJSON string) (OutputValue, string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutputValue{}, "", err
+	}
+	defer tx.Rollback()
+	record, err := scanOutputStream(tx.QueryRowContext(ctx, `SELECT `+outputStreamColumns+` FROM output_streams WHERE stream_id=?`, streamID))
+	if errors.Is(err, sql.ErrNoRows) {
+		if authority.Agent == nil {
+			return OutputValue{}, "", Errorf(CodeUnauthenticated, "Invalid output credential")
+		}
+		return OutputValue{}, "", Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+	}
+	if err != nil {
+		return OutputValue{}, "", err
+	}
+	producerType, producerID := "", ""
+	if authority.Agent != nil {
+		principal := *authority.Agent
+		if principal.ScopeID != record.ScopeID {
+			return OutputValue{}, "", Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+		}
+		if err := requireCurrentExecution(ctx, tx, principal, nowMillis()); err != nil {
+			return OutputValue{}, "", err
+		}
+		var found int
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM output_stream_publishers WHERE stream_id=? AND scope_id=? AND agent_id=?`, streamID, record.ScopeID, principal.AgentID).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+			return OutputValue{}, "", Errorf(CodePermissionDenied, "Agent is not allowed to publish to this output stream")
+		} else if err != nil {
+			return OutputValue{}, "", err
+		}
+		producerType, producerID = "agent", principal.AgentID
+	} else {
+		credential, err := authenticateScopedCredential(ctx, tx, authority.Credential, scopedCredentialGrant{
+			ResourceType: outputStreamResource, ResourceID: streamID, Permission: string(OutputPublish),
+		})
+		if err != nil {
+			var failure *BusError
+			if errors.As(err, &failure) && failure.Code == CodeUnauthenticated {
+				return OutputValue{}, "", Errorf(CodeUnauthenticated, "Invalid output credential")
+			}
+			return OutputValue{}, "", err
+		}
+		if credential.ScopeID != record.ScopeID {
+			return OutputValue{}, "", Errorf(CodeUnauthenticated, "Invalid output credential")
+		}
+		producerType, producerID = "principal", credential.ID
+	}
+	now := nowMillis()
+	if err := consumeOutputQuota(ctx, tx, record.ScopeID, producerType, producerID, true, now); err != nil {
+		return OutputValue{}, "", err
+	}
+	var sequence int64
+	if err := tx.QueryRowContext(ctx, `UPDATE output_streams SET sequence=sequence+1,updated_at=? WHERE stream_id=? RETURNING sequence`, now, streamID).Scan(&sequence); err != nil {
+		return OutputValue{}, "", err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO output_values(stream_id,sequence,producer_type,producer_id,content_type,value_json,reference_json,created_at) VALUES(?,?,?,?,?,?,?,?)`,
+		streamID, sequence, producerType, producerID, input.ContentType, valueJSON, nullableString(referenceJSON), now); err != nil {
+		return OutputValue{}, "", err
+	}
+	floor := sequence - int64(record.RetentionLimit)
+	if floor > record.MinimumCursor {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM output_values WHERE stream_id=? AND sequence<=?`, streamID, floor); err != nil {
+			return OutputValue{}, "", err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE output_streams SET floor_sequence=? WHERE stream_id=?`, floor, streamID); err != nil {
+			return OutputValue{}, "", err
+		}
+	}
+	if err := appendEvent(ctx, tx, record.ScopeID, "output.published", streamID, eventAttributes(
+		"sequence", fmt.Sprintf("%d", sequence), "producerType", producerType, "producerId", producerID, "contentType", string(input.ContentType),
+	), now); err != nil {
+		return OutputValue{}, "", err
+	}
+	value := OutputValue{
+		StreamID: streamID, Sequence: sequence, ProducerType: producerType, ProducerID: producerID,
+		ContentType: input.ContentType, Value: input.Value, Reference: input.Reference, CreatedAt: instant(now),
+	}
+	if err := tx.Commit(); err != nil {
+		return OutputValue{}, "", err
+	}
+	return value, record.ScopeID, nil
+}
+
+func scanOutputValue(row rowScanner) (OutputValue, error) {
+	var value OutputValue
+	var valueJSON string
+	var referenceJSON sql.NullString
+	var createdAt int64
+	if err := row.Scan(&value.StreamID, &value.Sequence, &value.ProducerType, &value.ProducerID, &value.ContentType, &valueJSON, &referenceJSON, &createdAt); err != nil {
+		return OutputValue{}, err
+	}
+	if err := json.Unmarshal([]byte(valueJSON), &value.Value); err != nil {
+		return OutputValue{}, err
+	}
+	if referenceJSON.Valid {
+		value.Reference = &OutputReference{}
+		if err := json.Unmarshal([]byte(referenceJSON.String), value.Reference); err != nil {
+			return OutputValue{}, err
+		}
+	}
+	value.CreatedAt = instant(createdAt)
+	return value, nil
+}
+
+const outputValueColumns = `stream_id,sequence,producer_type,producer_id,content_type,value_json,reference_json,created_at`
+
+func outputHistory(ctx context.Context, tx *sql.Tx, stream outputStreamRecord, after int64, limit int) (OutputHistory, error) {
+	history := OutputHistory{
+		StreamID: stream.ID, Values: []OutputValue{}, NextSequence: after,
+		CurrentSequence: stream.CurrentSequence, MinimumCursor: stream.MinimumCursor,
+	}
+	if after > stream.CurrentSequence {
+		return OutputHistory{}, Errorf(CodeInvalidArgument, "after exceeds the current output sequence")
+	}
+	if after < stream.MinimumCursor {
+		history.ResyncRequired = true
+		history.NextSequence = stream.CurrentSequence
+		return history, nil
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT `+outputValueColumns+` FROM output_values WHERE stream_id=? AND sequence>? ORDER BY sequence LIMIT ?`, stream.ID, after, limit)
+	if err != nil {
+		return OutputHistory{}, err
+	}
+	for rows.Next() {
+		value, err := scanOutputValue(rows)
+		if err != nil {
+			rows.Close()
+			return OutputHistory{}, err
+		}
+		history.Values = append(history.Values, value)
+		history.NextSequence = value.Sequence
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return OutputHistory{}, err
+	}
+	rows.Close()
+	return history, nil
+}
+
+func (s *Store) readOutput(ctx context.Context, scopeID, credential, streamID string, after int64, limit int, latest bool) (OutputHistory, *OutputValue, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OutputHistory{}, nil, err
+	}
+	defer tx.Rollback()
+	stream, err := scanOutputStream(tx.QueryRowContext(ctx, `SELECT `+outputStreamColumns+` FROM output_streams WHERE stream_id=?`, streamID))
+	if errors.Is(err, sql.ErrNoRows) {
+		if credential != "" {
+			return OutputHistory{}, nil, Errorf(CodeUnauthenticated, "Invalid output credential")
+		}
+		return OutputHistory{}, nil, Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+	}
+	if err != nil {
+		return OutputHistory{}, nil, err
+	}
+	if credential == "" {
+		if scopeID != stream.ScopeID {
+			return OutputHistory{}, nil, Errorf(CodeNotFound, "Output stream "+streamID+" was not found")
+		}
+	} else {
+		principal, err := authenticateScopedCredential(ctx, tx, credential, scopedCredentialGrant{
+			ResourceType: outputStreamResource, ResourceID: streamID, Permission: string(OutputRead),
+		})
+		if err != nil {
+			var failure *BusError
+			if errors.As(err, &failure) && failure.Code == CodeUnauthenticated {
+				return OutputHistory{}, nil, Errorf(CodeUnauthenticated, "Invalid output credential")
+			}
+			return OutputHistory{}, nil, err
+		}
+		if principal.ScopeID != stream.ScopeID {
+			return OutputHistory{}, nil, Errorf(CodeUnauthenticated, "Invalid output credential")
+		}
+		if err := consumeOutputQuota(ctx, tx, stream.ScopeID, "principal", principal.ID, false, nowMillis()); err != nil {
+			return OutputHistory{}, nil, err
+		}
+	}
+	if latest {
+		value, err := scanOutputValue(tx.QueryRowContext(ctx, `SELECT `+outputValueColumns+` FROM output_values WHERE stream_id=? ORDER BY sequence DESC LIMIT 1`, streamID))
+		if errors.Is(err, sql.ErrNoRows) {
+			if err := tx.Commit(); err != nil {
+				return OutputHistory{}, nil, err
+			}
+			return OutputHistory{}, nil, nil
+		}
+		if err != nil {
+			return OutputHistory{}, nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return OutputHistory{}, nil, err
+		}
+		return OutputHistory{}, &value, nil
+	}
+	history, err := outputHistory(ctx, tx, stream, after, limit)
+	if err != nil {
+		return OutputHistory{}, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OutputHistory{}, nil, err
+	}
+	return history, nil, nil
+}
+
+func normalizedOutputRetention(value int) (int, error) {
+	if value == 0 {
+		return defaultOutputRetention, nil
+	}
+	if value < 1 || value > maxOutputRetention {
+		return 0, Errorf(CodeInvalidArgument, "retentionLimit must be between 1 and 10000")
+	}
+	return value, nil
+}
+
+func normalizedOutputLimit(value int) (int, error) {
+	if value == 0 {
+		return defaultOutputLimit, nil
+	}
+	if value < 1 || value > maxOutputLimit {
+		return 0, Errorf(CodeInvalidArgument, "limit must be between 1 and 100")
+	}
+	return value, nil
+}
+
+func validateOutputPublishers(values []string) ([]string, error) {
+	if len(values) > maxOutputPublishers {
+		return nil, Errorf(CodeInvalidArgument, "publisherAgentIds exceeds 128 items")
+	}
+	uniqueValues := unique(values)
+	if len(uniqueValues) != len(values) {
+		return nil, Errorf(CodeInvalidArgument, "publisherAgentIds must be unique")
+	}
+	values = uniqueValues
+	for _, value := range values {
+		if err := validateIdentity(value, "publisherAgentIds", false); err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(values)
+	return values, nil
+}
+
+func validatePublishOutput(input PublishOutputInput) (string, string, error) {
+	if input.Value == nil {
+		return "", "", Errorf(CodeInvalidArgument, "value is required")
+	}
+	valueJSON, err := json.Marshal(input.Value)
+	if err != nil {
+		return "", "", Errorf(CodeInvalidArgument, "value must be valid JSON")
+	}
+	switch input.ContentType {
+	case OutputText:
+		text, ok := input.Value.(string)
+		if !ok {
+			return "", "", Errorf(CodeInvalidArgument, "text/plain value must be a string")
+		}
+		if len(text) > maxOutputTextBytes {
+			return "", "", Errorf(CodeInvalidArgument, "text/plain value exceeds 65536 bytes")
+		}
+	case OutputJSON:
+		if len(valueJSON) > maxOutputJSONBytes {
+			return "", "", Errorf(CodeInvalidArgument, "application/json value exceeds 262144 bytes")
+		}
+	default:
+		return "", "", Errorf(CodeInvalidArgument, "contentType is invalid")
+	}
+	referenceJSON := ""
+	if input.Reference != nil {
+		if err := validateText(input.Reference.URI, "reference.uri", 4096, false); err != nil {
+			return "", "", err
+		}
+		parsed, err := url.Parse(input.Reference.URI)
+		if err != nil || parsed.Scheme == "" {
+			return "", "", Errorf(CodeInvalidArgument, "reference.uri must be an absolute URI")
+		}
+		if err := validateText(input.Reference.Title, "reference.title", 512, true); err != nil {
+			return "", "", err
+		}
+		data, err := json.Marshal(input.Reference)
+		if err != nil {
+			return "", "", err
+		}
+		referenceJSON = string(data)
+	}
+	return string(valueJSON), referenceJSON, nil
+}
+
+func (r *Runtime) CreateOutputStream(ctx context.Context, scopeToken string, input CreateOutputStreamInput) (OutputStream, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	if err := validateIdentity(input.Name, "name", false); err != nil {
+		return OutputStream{}, err
+	}
+	input.RetentionLimit, err = normalizedOutputRetention(input.RetentionLimit)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	input.PublisherAgentIDs, err = validateOutputPublishers(input.PublisherAgentIDs)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	stream, err := r.store.CreateOutputStream(ctx, scopeID, input)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return stream, err
+}
+
+func (r *Runtime) ListOutputStreams(ctx context.Context, scopeToken string) ([]OutputStream, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return nil, err
+	}
+	return r.store.ListOutputStreams(ctx, scopeID)
+}
+
+func (r *Runtime) OutputStream(ctx context.Context, scopeToken, streamID string) (OutputStream, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	if err := validateIdentity(streamID, "streamId", false); err != nil {
+		return OutputStream{}, err
+	}
+	return r.store.OutputStream(ctx, scopeID, streamID)
+}
+
+func (r *Runtime) RemoveOutputStream(ctx context.Context, scopeToken, streamID string) error {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return err
+	}
+	if err := validateIdentity(streamID, "streamId", false); err != nil {
+		return err
+	}
+	if err := r.store.RemoveOutputStream(ctx, scopeID, streamID); err != nil {
+		return err
+	}
+	r.notifyScope(scopeID)
+	return nil
+}
+
+func (r *Runtime) SetOutputPublisher(ctx context.Context, scopeToken, streamID, agentID string, allowed bool) (OutputStream, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return OutputStream{}, err
+	}
+	if err := validateIdentity(streamID, "streamId", false); err != nil {
+		return OutputStream{}, err
+	}
+	if err := validateIdentity(agentID, "agentId", false); err != nil {
+		return OutputStream{}, err
+	}
+	stream, err := r.store.SetOutputPublisher(ctx, scopeID, streamID, agentID, allowed)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return stream, err
+}
+
+func (r *Runtime) PublishOutput(ctx context.Context, token, streamID string, input PublishOutputInput) (OutputValue, error) {
+	if err := validateIdentity(streamID, "streamId", false); err != nil {
+		return OutputValue{}, err
+	}
+	valueJSON, referenceJSON, err := validatePublishOutput(input)
+	if err != nil {
+		return OutputValue{}, err
+	}
+	authority := outputPublisher{Credential: token}
+	if principal, err := r.store.AuthenticateAgent(ctx, token); err == nil {
+		authority = outputPublisher{Agent: &principal}
+	}
+	value, scopeID, err := r.store.PublishOutput(ctx, authority, streamID, input, valueJSON, referenceJSON)
+	if err == nil {
+		r.notifyScope(scopeID)
+	}
+	return value, err
+}
+
+func (r *Runtime) outputReadAuthority(ctx context.Context, token string) (string, string) {
+	if scopeID, err := r.store.AuthenticateScope(ctx, token); err == nil {
+		return scopeID, ""
+	}
+	return "", token
+}
+
+func (r *Runtime) LatestOutput(ctx context.Context, token, streamID string) (*OutputValue, error) {
+	if err := validateIdentity(streamID, "streamId", false); err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, Errorf(CodeUnauthenticated, "Output credential is required")
+	}
+	scopeID, credential := r.outputReadAuthority(ctx, token)
+	_, value, err := r.store.readOutput(ctx, scopeID, credential, streamID, 0, 0, true)
+	return value, err
+}
+
+func (r *Runtime) OutputHistory(ctx context.Context, token, streamID string, after int64, limit int) (OutputHistory, error) {
+	if err := validateIdentity(streamID, "streamId", false); err != nil {
+		return OutputHistory{}, err
+	}
+	if after < 0 {
+		return OutputHistory{}, Errorf(CodeInvalidArgument, "after must not be negative")
+	}
+	if token == "" {
+		return OutputHistory{}, Errorf(CodeUnauthenticated, "Output credential is required")
+	}
+	limit, err := normalizedOutputLimit(limit)
+	if err != nil {
+		return OutputHistory{}, err
+	}
+	scopeID, credential := r.outputReadAuthority(ctx, token)
+	history, _, err := r.store.readOutput(ctx, scopeID, credential, streamID, after, limit, false)
+	return history, err
+}

--- a/bus/output_streams_test.go
+++ b/bus/output_streams_test.go
@@ -1,0 +1,306 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOutputStreamsPublishBoundedOrderedValues(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{
+		Name: "site-preview", RetentionLimit: 2, PublisherAgentIDs: []string{agents.reviewer.AgentID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stream.ID == "" || stream.Name != "site-preview" || stream.RetentionLimit != 2 || len(stream.PublisherAgentIDs) != 1 {
+		t.Fatalf("unexpected stream: %#v", stream)
+	}
+	_, err = agents.runtime.PublishOutput(ctx, agents.plannerToken, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "denied"})
+	requireCode(t, err, CodePermissionDenied)
+	values := []PublishOutputInput{
+		{ContentType: OutputText, Value: "building", Reference: &OutputReference{URI: "https://example.test/build/1", Title: "Build"}},
+		{ContentType: OutputJSON, Value: map[string]any{"status": "ready", "progress": float64(80)}},
+		{ContentType: OutputText, Value: "deployed"},
+	}
+	for index, input := range values {
+		value, err := agents.runtime.PublishOutput(ctx, agents.reviewerToken, stream.ID, input)
+		if err != nil || value.Sequence != int64(index+1) || value.ProducerType != "agent" || value.ProducerID != agents.reviewer.AgentID {
+			t.Fatalf("unexpected output value %d: %#v, %v", index, value, err)
+		}
+	}
+	latest, err := agents.runtime.LatestOutput(ctx, agents.scope.ScopeToken, stream.ID)
+	if err != nil || latest == nil || latest.Sequence != 3 || latest.Value != "deployed" {
+		t.Fatalf("unexpected latest output: %#v, %v", latest, err)
+	}
+	history, err := agents.runtime.OutputHistory(ctx, agents.scope.ScopeToken, stream.ID, 1, 10)
+	if err != nil || history.ResyncRequired || len(history.Values) != 2 || history.Values[0].Sequence != 2 || history.Values[1].Sequence != 3 {
+		t.Fatalf("unexpected retained history: %#v, %v", history, err)
+	}
+	stale, err := agents.runtime.OutputHistory(ctx, agents.scope.ScopeToken, stream.ID, 0, 10)
+	if err != nil || !stale.ResyncRequired || stale.MinimumCursor != 1 || stale.NextSequence != 3 {
+		t.Fatalf("unexpected stale history result: %#v, %v", stale, err)
+	}
+	listed, err := agents.runtime.ListOutputStreams(ctx, agents.scope.ScopeToken)
+	if err != nil || len(listed) != 1 || listed[0].CurrentSequence != 3 || listed[0].MinimumCursor != 1 {
+		t.Fatalf("unexpected stream list: %#v, %v", listed, err)
+	}
+	if _, err := agents.runtime.SetOutputPublisher(ctx, agents.scope.ScopeToken, stream.ID, agents.reviewer.AgentID, false); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.PublishOutput(ctx, agents.reviewerToken, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "denied again"})
+	requireCode(t, err, CodePermissionDenied)
+	updated, err := agents.runtime.SetOutputPublisher(ctx, agents.scope.ScopeToken, stream.ID, agents.planner.AgentID, true)
+	if err != nil || len(updated.PublisherAgentIDs) != 1 || updated.PublisherAgentIDs[0] != agents.planner.AgentID {
+		t.Fatalf("unexpected publisher update: %#v, %v", updated, err)
+	}
+	if _, err := agents.runtime.PublishOutput(ctx, agents.plannerToken, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "planner update"}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := agents.runtime.Events(ctx, agents.scope.ScopeToken, 0, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundPublished := false
+	for _, event := range events.Events {
+		if event.Type != "output.published" || event.SubjectID != stream.ID {
+			continue
+		}
+		foundPublished = true
+		data, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, protected := range []string{"building", "deployed", "planner update", "example.test"} {
+			if strings.Contains(string(data), protected) {
+				t.Fatalf("output event exposed value content: %s", data)
+			}
+		}
+	}
+	if !foundPublished {
+		t.Fatal("output publication did not append a scope event")
+	}
+}
+
+func TestOutputPrincipalsHaveNarrowIndependentPermissions(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{Name: "build-status"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherStream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{Name: "other"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Dashboard", Permissions: []OutputPermission{OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Build service", Permissions: []OutputPermission{OutputPublish},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.PublishOutput(ctx, reader.Credential, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "denied"})
+	requireCode(t, err, CodeUnauthenticated)
+	value, err := agents.runtime.PublishOutput(ctx, publisher.Credential, stream.ID, PublishOutputInput{
+		ContentType: OutputJSON, Value: map[string]any{"status": "ready"},
+	})
+	if err != nil || value.ProducerType != "principal" || value.ProducerID != publisher.Principal.ID {
+		t.Fatalf("unexpected principal publication: %#v, %v", value, err)
+	}
+	_, err = agents.runtime.LatestOutput(ctx, publisher.Credential, stream.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	latest, err := agents.runtime.LatestOutput(ctx, reader.Credential, stream.ID)
+	if err != nil || latest == nil || latest.Sequence != 1 {
+		t.Fatalf("reader could not read its stream: %#v, %v", latest, err)
+	}
+	_, err = agents.runtime.LatestOutput(ctx, reader.Credential, otherStream.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	_, err = agents.runtime.ListAgents(ctx, reader.Credential)
+	requireCode(t, err, CodeUnauthenticated)
+	principals, err := agents.runtime.ListOutputPrincipals(ctx, agents.scope.ScopeToken)
+	if err != nil || len(principals) != 2 {
+		t.Fatalf("unexpected output principals: %#v, %v", principals, err)
+	}
+	data, err := json.Marshal(principals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), reader.Credential) || strings.Contains(string(data), publisher.Credential) || strings.Contains(string(data), `"credential"`) {
+		t.Fatalf("principal list exposed a credential: %s", data)
+	}
+	if _, err := agents.runtime.SetOutputPrincipalEnabled(ctx, agents.scope.ScopeToken, reader.Principal.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.LatestOutput(ctx, reader.Credential, stream.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	rotated, err := agents.runtime.RotateOutputPrincipal(ctx, agents.scope.ScopeToken, reader.Principal.ID)
+	if err != nil || rotated.Credential == reader.Credential || rotated.Principal.Enabled {
+		t.Fatalf("unexpected principal rotation: %#v, %v", rotated, err)
+	}
+	if _, err := agents.runtime.SetOutputPrincipalEnabled(ctx, agents.scope.ScopeToken, reader.Principal.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.LatestOutput(ctx, reader.Credential, stream.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	if _, err := agents.runtime.LatestOutput(ctx, rotated.Credential, stream.ID); err != nil {
+		t.Fatalf("rotated credential did not read: %v", err)
+	}
+}
+
+func TestOutputStreamsPersistAndRemoveTheirDataAndCredentials(t *testing.T) {
+	database := filepath.Join(t.TempDir(), "bus.db")
+	agents := setupAgents(t, database)
+	ctx := context.Background()
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{
+		Name: "preview", PublisherAgentIDs: []string{agents.reviewer.AgentID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Preview page", Permissions: []OutputPermission{OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.PublishOutput(ctx, agents.reviewerToken, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "ready"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agents.runtime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restarted.Close()
+	latest, err := restarted.LatestOutput(ctx, reader.Credential, stream.ID)
+	if err != nil || latest == nil || latest.Value != "ready" {
+		t.Fatalf("output did not survive restart: %#v, %v", latest, err)
+	}
+	if err := restarted.RemoveOutputStream(ctx, agents.scope.ScopeToken, stream.ID); err != nil {
+		t.Fatal(err)
+	}
+	_, err = restarted.LatestOutput(ctx, reader.Credential, stream.ID)
+	requireCode(t, err, CodeUnauthenticated)
+	principals, err := restarted.ListOutputPrincipals(ctx, agents.scope.ScopeToken)
+	if err != nil || len(principals) != 0 {
+		t.Fatalf("stream removal left principals: %#v, %v", principals, err)
+	}
+	var valueCount int
+	if err := restarted.store.db.QueryRow(`SELECT COUNT(*) FROM output_values WHERE stream_id=?`, stream.ID).Scan(&valueCount); err != nil || valueCount != 0 {
+		t.Fatalf("stream removal left values: %d, %v", valueCount, err)
+	}
+}
+
+func TestOutputPayloadLimitsAndPerPrincipalQuota(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{
+		Name: "limited", PublisherAgentIDs: []string{agents.reviewer.AgentID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range []PublishOutputInput{
+		{ContentType: OutputText, Value: map[string]any{"not": "text"}},
+		{ContentType: OutputContentType("image/png"), Value: "no"},
+		{ContentType: OutputText, Value: strings.Repeat("x", maxOutputTextBytes+1)},
+		{ContentType: OutputJSON, Value: strings.Repeat("x", maxOutputJSONBytes+1)},
+		{ContentType: OutputText, Value: "bad reference", Reference: &OutputReference{URI: "/relative"}},
+	} {
+		_, err := agents.runtime.PublishOutput(ctx, agents.reviewerToken, stream.ID, input)
+		requireCode(t, err, CodeInvalidArgument)
+	}
+	window := nowMillis()
+	window -= window % 60000
+	if _, err := agents.runtime.store.db.Exec(`INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,publish_count) VALUES(?,?,?,?,?),(?,?,?,?,?)`,
+		agents.scope.ScopeID, "agent", agents.reviewer.AgentID, window, outputPublishRate,
+		agents.scope.ScopeID, "agent", agents.reviewer.AgentID, window+60000, outputPublishRate); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.PublishOutput(ctx, agents.reviewerToken, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "over limit"})
+	requireCode(t, err, CodeBackpressure)
+	reader, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Limited reader", Permissions: []OutputPermission{OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.store.db.Exec(`INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,read_count) VALUES(?,?,?,?,?),(?,?,?,?,?)`,
+		agents.scope.ScopeID, "principal", reader.Principal.ID, window, outputReadRate,
+		agents.scope.ScopeID, "principal", reader.Principal.ID, window+60000, outputReadRate); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.LatestOutput(ctx, reader.Credential, stream.ID)
+	requireCode(t, err, CodeBackpressure)
+}
+
+func TestOutputRoutesRequireExplicitBrowserOrigin(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{
+		Name: "browser", PublisherAgentIDs: []string{agents.reviewer.AgentID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Browser", Permissions: []OutputPermission{OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.PublishOutput(ctx, agents.reviewerToken, stream.ID, PublishOutputInput{ContentType: OutputText, Value: "ready"}); err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(agents.runtime, ServerOptions{AllowedOrigins: []string{"https://dashboard.example"}})
+	call := func(method, origin string) *httptest.ResponseRecorder {
+		request := httptest.NewRequest(method, "/outputs/"+stream.ID+"/latest", nil)
+		request.Header.Set("Origin", origin)
+		if method != http.MethodOptions {
+			request.Header.Set("Authorization", "Bearer "+reader.Credential)
+		}
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		return response
+	}
+	allowed := call(http.MethodGet, "https://dashboard.example")
+	if allowed.Code != http.StatusOK || allowed.Header().Get("Access-Control-Allow-Origin") != "https://dashboard.example" {
+		t.Fatalf("allowed origin failed: %d %#v", allowed.Code, allowed.Header())
+	}
+	preflight := call(http.MethodOptions, "https://dashboard.example")
+	if preflight.Code != http.StatusNoContent || !strings.Contains(preflight.Header().Get("Access-Control-Allow-Headers"), "Authorization") {
+		t.Fatalf("unexpected preflight: %d %#v", preflight.Code, preflight.Header())
+	}
+	denied := call(http.MethodGet, "https://attacker.example")
+	if denied.Code != http.StatusForbidden || denied.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("unexpected denied origin: %d %#v", denied.Code, denied.Header())
+	}
+	serverToServer := call(http.MethodGet, "")
+	if serverToServer.Code != http.StatusOK || serverToServer.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("server request required browser configuration: %d %#v", serverToServer.Code, serverToServer.Header())
+	}
+	request := httptest.NewRequest(http.MethodGet, "/outputs/"+stream.ID+"/latest?credential="+reader.Credential, nil)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("query-string credential was accepted: %d %s", response.Code, response.Body.String())
+	}
+}

--- a/bus/protocol.go
+++ b/bus/protocol.go
@@ -178,6 +178,91 @@ type IssuedA2APrincipal struct {
 	Credential string       `json:"credential"`
 }
 
+type OutputContentType string
+
+const (
+	OutputText OutputContentType = "text/plain"
+	OutputJSON OutputContentType = "application/json"
+)
+
+type OutputPermission string
+
+const (
+	OutputRead    OutputPermission = "read"
+	OutputPublish OutputPermission = "publish"
+)
+
+type OutputReference struct {
+	URI   string `json:"uri"`
+	Title string `json:"title,omitempty"`
+}
+
+type OutputStream struct {
+	ID                string   `json:"id"`
+	ScopeID           string   `json:"scopeId"`
+	Name              string   `json:"name"`
+	RetentionLimit    int      `json:"retentionLimit"`
+	CurrentSequence   int64    `json:"currentSequence"`
+	MinimumCursor     int64    `json:"minimumCursor"`
+	PublisherAgentIDs []string `json:"publisherAgentIds"`
+	CreatedAt         string   `json:"createdAt"`
+	UpdatedAt         string   `json:"updatedAt"`
+}
+
+type CreateOutputStreamInput struct {
+	Name              string   `json:"name"`
+	RetentionLimit    int      `json:"retentionLimit,omitempty"`
+	PublisherAgentIDs []string `json:"publisherAgentIds,omitempty"`
+}
+
+type PublishOutputInput struct {
+	ContentType OutputContentType `json:"contentType"`
+	Value       any               `json:"value"`
+	Reference   *OutputReference  `json:"reference,omitempty"`
+}
+
+type OutputValue struct {
+	StreamID     string            `json:"streamId"`
+	Sequence     int64             `json:"sequence"`
+	ProducerType string            `json:"producerType"`
+	ProducerID   string            `json:"producerId"`
+	ContentType  OutputContentType `json:"contentType"`
+	Value        any               `json:"value"`
+	Reference    *OutputReference  `json:"reference,omitempty"`
+	CreatedAt    string            `json:"createdAt"`
+}
+
+type OutputHistory struct {
+	StreamID        string        `json:"streamId"`
+	Values          []OutputValue `json:"values"`
+	NextSequence    int64         `json:"nextSequence"`
+	CurrentSequence int64         `json:"currentSequence"`
+	MinimumCursor   int64         `json:"minimumCursor"`
+	ResyncRequired  bool          `json:"resyncRequired"`
+}
+
+type OutputPrincipal struct {
+	ID          string             `json:"id"`
+	ScopeID     string             `json:"scopeId"`
+	StreamID    string             `json:"streamId"`
+	Label       string             `json:"label"`
+	Permissions []OutputPermission `json:"permissions"`
+	Enabled     bool               `json:"enabled"`
+	CreatedAt   string             `json:"createdAt"`
+	UpdatedAt   string             `json:"updatedAt"`
+}
+
+type CreateOutputPrincipalInput struct {
+	StreamID    string             `json:"streamId"`
+	Label       string             `json:"label"`
+	Permissions []OutputPermission `json:"permissions"`
+}
+
+type IssuedOutputPrincipal struct {
+	Principal  OutputPrincipal `json:"principal"`
+	Credential string          `json:"credential"`
+}
+
 type StorageRecordSummary struct {
 	RecordType     string `json:"recordType"`
 	State          string `json:"state"`

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -156,6 +156,40 @@ func (s *Server) newRouter() http.Handler {
 	registerRoute(router, "/v1/a2a/principals/{principalId}/disable",
 		routeMethod{http.MethodPost, s.disableA2APrincipal},
 	)
+	registerRoute(router, "/v1/output-streams",
+		routeMethod{http.MethodGet, s.listOutputStreams},
+		routeMethod{http.MethodPost, s.createOutputStream},
+	)
+	registerRoute(router, "/v1/output-streams/{streamId}",
+		routeMethod{http.MethodGet, s.getOutputStream},
+		routeMethod{http.MethodDelete, s.removeOutputStream},
+	)
+	registerRoute(router, "/v1/output-streams/{streamId}/publishers/{agentId}",
+		routeMethod{http.MethodPut, s.addOutputPublisher},
+		routeMethod{http.MethodDelete, s.removeOutputPublisher},
+	)
+	registerRoute(router, "/v1/output-principals",
+		routeMethod{http.MethodGet, s.listOutputPrincipals},
+		routeMethod{http.MethodPost, s.createOutputPrincipal},
+	)
+	registerRoute(router, "/v1/output-principals/{principalId}/rotate",
+		routeMethod{http.MethodPost, s.rotateOutputPrincipal},
+	)
+	registerRoute(router, "/v1/output-principals/{principalId}/enable",
+		routeMethod{http.MethodPost, s.enableOutputPrincipal},
+	)
+	registerRoute(router, "/v1/output-principals/{principalId}/disable",
+		routeMethod{http.MethodPost, s.disableOutputPrincipal},
+	)
+	registerRoute(router, "/outputs/{streamId}/values",
+		routeMethod{http.MethodGet, s.outputHistory},
+		routeMethod{http.MethodPost, s.publishOutput},
+		routeMethod{http.MethodOptions, s.outputOptions},
+	)
+	registerRoute(router, "/outputs/{streamId}/latest",
+		routeMethod{http.MethodGet, s.latestOutput},
+		routeMethod{http.MethodOptions, s.outputOptions},
+	)
 	registerRoute(router, "/a2a/agents/{publicationId}/.well-known/agent-card.json",
 		routeMethod{http.MethodGet, s.servePublishedAgentCard},
 		routeMethod{http.MethodHead, s.servePublishedAgentCard},

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -464,7 +464,7 @@ func TestOlderSchemaFailsBeforeServingWork(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = Open(path)
-	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 7") {
+	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 8") {
 		t.Fatalf("older schema did not fail clearly: %v", err)
 	}
 }
@@ -657,6 +657,12 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 	plannerClient := Client{Address: address, Token: agents.plannerToken}
 	reviewerClient := Client{Address: address, Token: agents.reviewerToken}
 	ownerClient := Client{Address: address, Token: agents.scope.ScopeToken}
+	outputStream, err := ownerClient.CreateOutputStream(ctx, CreateOutputStreamInput{
+		Name: "mcp-output", PublisherAgentIDs: []string{agents.planner.AgentID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	escalation, err := plannerClient.AskHuman(ctx, AskHumanInput{Question: "Proceed?"})
 	if err != nil {
 		t.Fatal(err)
@@ -700,7 +706,7 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 	}
 	defer session.Close()
 	tools, err := session.ListTools(ctx, nil)
-	if err != nil || len(tools.Tools) != 13 {
+	if err != nil || len(tools.Tools) != 14 {
 		t.Fatalf("unexpected tools: %d, %v", len(tools.Tools), err)
 	}
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_peers", Arguments: map[string]any{}})
@@ -724,6 +730,16 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 	}
 	if _, ok := structured["tasks"].([]any); !ok {
 		t.Fatalf("MCP list_tasks must return a tasks array: %#v", result.StructuredContent)
+	}
+	result, err = session.CallTool(ctx, &mcp.CallToolParams{Name: "publish_output", Arguments: map[string]any{
+		"streamId": outputStream.ID, "contentType": "application/json", "value": map[string]any{"status": "ready"},
+	}})
+	if err != nil || result.IsError {
+		t.Fatalf("MCP publish_output failed: %#v, %v", result, err)
+	}
+	latest, err := ownerClient.LatestOutput(ctx, outputStream.ID)
+	if err != nil || latest == nil || latest.Sequence != 1 {
+		t.Fatalf("MCP output was not stored: %#v, %v", latest, err)
 	}
 	type callResult struct {
 		result *mcp.CallToolResult

--- a/bus/scoped_credentials.go
+++ b/bus/scoped_credentials.go
@@ -110,7 +110,11 @@ func splitScopedCredential(value string) (string, string, bool) {
 	return credentialID, secret, true
 }
 
-func (s *Store) authenticateScopedCredential(ctx context.Context, supplied string, grant scopedCredentialGrant) (scopedCredentialRecord, error) {
+type scopedCredentialQuery interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func authenticateScopedCredential(ctx context.Context, query scopedCredentialQuery, supplied string, grant scopedCredentialGrant) (scopedCredentialRecord, error) {
 	credentialID, secret, valid := splitScopedCredential(supplied)
 	if !valid {
 		secureEqual(tokenDigest("invalid"), tokenDigest(supplied))
@@ -119,7 +123,7 @@ func (s *Store) authenticateScopedCredential(ctx context.Context, supplied strin
 	var record scopedCredentialRecord
 	var enabled int
 	var expectedHash string
-	err := s.db.QueryRowContext(ctx, `SELECT c.credential_id,c.scope_id,c.label,c.enabled,c.created_at,c.updated_at,c.token_hash
+	err := query.QueryRowContext(ctx, `SELECT c.credential_id,c.scope_id,c.label,c.enabled,c.created_at,c.updated_at,c.token_hash
 FROM scoped_credentials c
 JOIN scoped_credential_grants g ON g.credential_id=c.credential_id
 WHERE c.credential_id=? AND g.resource_type=? AND g.resource_id=? AND g.permission=?`,
@@ -138,4 +142,8 @@ WHERE c.credential_id=? AND g.resource_type=? AND g.resource_id=? AND g.permissi
 		return scopedCredentialRecord{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
 	}
 	return record, nil
+}
+
+func (s *Store) authenticateScopedCredential(ctx context.Context, supplied string, grant scopedCredentialGrant) (scopedCredentialRecord, error) {
+	return authenticateScopedCredential(ctx, s.db, supplied, grant)
 }

--- a/bus/server.go
+++ b/bus/server.go
@@ -18,11 +18,12 @@ import (
 const maxBodyBytes = 1024 * 1024
 
 type ServerOptions struct {
-	Host          string
-	Port          int
-	AdminToken    string
-	StartedAt     string
-	PublicBaseURL string
+	Host           string
+	Port           int
+	AdminToken     string
+	StartedAt      string
+	PublicBaseURL  string
+	AllowedOrigins []string
 }
 
 type Server struct {
@@ -303,6 +304,19 @@ func (s *Server) newMCPServer(token string) *mcp.Server {
 		func(ctx context.Context, _ *mcp.CallToolRequest, input listTasksInput) (*mcp.CallToolResult, any, error) {
 			result, err := s.runtime.ListTasks(ctx, token, input.Ready)
 			return nil, map[string]any{"tasks": result}, err
+		})
+	type publishOutputToolInput struct {
+		StreamID    string            `json:"streamId"`
+		ContentType OutputContentType `json:"contentType"`
+		Value       any               `json:"value"`
+		Reference   *OutputReference  `json:"reference,omitempty"`
+	}
+	mcp.AddTool(server, &mcp.Tool{Name: "publish_output", Description: "Publish text or JSON to an authorized output stream."},
+		func(ctx context.Context, _ *mcp.CallToolRequest, input publishOutputToolInput) (*mcp.CallToolResult, any, error) {
+			result, err := s.runtime.PublishOutput(ctx, token, input.StreamID, PublishOutputInput{
+				ContentType: input.ContentType, Value: input.Value, Reference: input.Reference,
+			})
+			return nil, result, err
 		})
 	mcp.AddTool(server, &mcp.Tool{Name: "ask_user", Description: "Request human input or permission."},
 		func(ctx context.Context, _ *mcp.CallToolRequest, input AskHumanInput) (*mcp.CallToolResult, any, error) {

--- a/bus/storage.go
+++ b/bus/storage.go
@@ -42,6 +42,11 @@ FROM events WHERE scope_id=? GROUP BY event_type ORDER BY event_type`},
 FROM a2a_publications WHERE scope_id=? GROUP BY enabled ORDER BY enabled DESC`},
 		{"credential", `SELECT CASE enabled WHEN 1 THEN 'enabled' ELSE 'disabled' END,COUNT(*),COALESCE(SUM(length(CAST(label AS BLOB))),0),MIN(created_at)
 FROM scoped_credentials WHERE scope_id=? GROUP BY enabled ORDER BY enabled DESC`},
+		{"outputStream", `SELECT 'active',COUNT(*),COALESCE(SUM(length(CAST(name AS BLOB))),0),MIN(created_at)
+FROM output_streams WHERE scope_id=?`},
+		{"outputValue", `SELECT records.content_type,COUNT(*),COALESCE(SUM(length(CAST(records.value_json AS BLOB))+COALESCE(length(CAST(records.reference_json AS BLOB)),0)),0),MIN(records.created_at)
+FROM output_values AS records JOIN output_streams AS streams ON streams.stream_id=records.stream_id
+WHERE streams.scope_id=? GROUP BY records.content_type ORDER BY records.content_type`},
 	}
 	for _, query := range queries {
 		rows, err := tx.QueryContext(ctx, query.statement, scopeID)

--- a/bus/store.go
+++ b/bus/store.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	schemaVersion                = 7
+	schemaVersion                = 8
 	reservationTTL               = 30 * time.Second
 	messageBacklogCap            = 10000
 	activeTaskCap                = 5000
@@ -231,7 +231,48 @@ CREATE TABLE scoped_credential_grants (
 	PRIMARY KEY(credential_id, resource_type, resource_id, permission)
 );
 CREATE INDEX scoped_credential_grants_resource ON scoped_credential_grants(resource_type, resource_id, permission);
-PRAGMA user_version=7;
+CREATE TABLE output_streams (
+	stream_id TEXT PRIMARY KEY,
+	scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
+	name TEXT NOT NULL,
+	retention_limit INTEGER NOT NULL CHECK(retention_limit BETWEEN 1 AND 10000),
+	sequence INTEGER NOT NULL DEFAULT 0,
+	floor_sequence INTEGER NOT NULL DEFAULT 0,
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL,
+	UNIQUE(scope_id,name)
+);
+CREATE INDEX output_streams_scope_created ON output_streams(scope_id,created_at);
+CREATE TABLE output_stream_publishers (
+	stream_id TEXT NOT NULL REFERENCES output_streams(stream_id) ON DELETE CASCADE,
+	scope_id TEXT NOT NULL,
+	agent_id TEXT NOT NULL,
+	PRIMARY KEY(stream_id,agent_id),
+	FOREIGN KEY(scope_id,agent_id) REFERENCES agents(scope_id,agent_id)
+);
+CREATE TABLE output_values (
+	stream_id TEXT NOT NULL REFERENCES output_streams(stream_id) ON DELETE CASCADE,
+	sequence INTEGER NOT NULL,
+	producer_type TEXT NOT NULL CHECK(producer_type IN ('agent','principal')),
+	producer_id TEXT NOT NULL,
+	content_type TEXT NOT NULL CHECK(content_type IN ('text/plain','application/json')),
+	value_json TEXT NOT NULL,
+	reference_json TEXT,
+	created_at INTEGER NOT NULL,
+	PRIMARY KEY(stream_id,sequence)
+);
+CREATE INDEX output_values_stream_created ON output_values(stream_id,created_at);
+CREATE TABLE output_rate_usage (
+	scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
+	principal_type TEXT NOT NULL,
+	principal_id TEXT NOT NULL,
+	window_start INTEGER NOT NULL,
+	publish_count INTEGER NOT NULL DEFAULT 0,
+	read_count INTEGER NOT NULL DEFAULT 0,
+	PRIMARY KEY(scope_id,principal_type,principal_id,window_start)
+);
+CREATE INDEX output_rate_usage_window ON output_rate_usage(window_start);
+PRAGMA user_version=8;
 COMMIT;`)
 	return err
 }

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -75,7 +75,7 @@ func TestMCPStdioBridgeForwardsDaemonTools(t *testing.T) {
 	defer session.Close()
 
 	tools, err := session.ListTools(ctx, nil)
-	if err != nil || len(tools.Tools) != 13 {
+	if err != nil || len(tools.Tools) != 14 {
 		t.Fatalf("unexpected forwarded tools: %d, %v; stderr: %s", len(tools.Tools), err, stderr.String())
 	}
 	directClient := mcp.NewClient(&mcp.Implementation{Name: "direct-test", Version: "1"}, nil)

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -226,6 +226,50 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		return result, err
 	}
 
+	var outputStream bus.OutputStream
+	if err := record.check("addressable-output-streams", func() error {
+		stream, err := owner.CreateOutputStream(ctx, bus.CreateOutputStreamInput{
+			Name: "build-status", RetentionLimit: 2, PublisherAgentIDs: []string{"reviewer"},
+		})
+		if err != nil || stream.ID == "" || stream.RetentionLimit != 2 {
+			return fmt.Errorf("unexpected output stream: %#v, %v", stream, err)
+		}
+		outputStream = stream
+		reader, err := owner.CreateOutputPrincipal(ctx, bus.CreateOutputPrincipalInput{
+			StreamID: stream.ID, Label: "Dashboard", Permissions: []bus.OutputPermission{bus.OutputRead},
+		})
+		if err != nil || reader.Credential == "" {
+			return fmt.Errorf("unexpected output reader: %#v, %v", reader, err)
+		}
+		for _, text := range []string{"queued", "building", "ready"} {
+			if _, err := reviewer.PublishOutput(ctx, stream.ID, bus.PublishOutputInput{ContentType: bus.OutputText, Value: text}); err != nil {
+				return err
+			}
+		}
+		outputReader := bus.Client{Address: options.Address, Token: reader.Credential}
+		latest, err := outputReader.LatestOutput(ctx, stream.ID)
+		if err != nil || latest == nil || latest.Sequence != 3 || latest.Value != "ready" {
+			return fmt.Errorf("unexpected latest output: %#v, %v", latest, err)
+		}
+		history, err := outputReader.OutputHistory(ctx, stream.ID, 1, 10)
+		if err != nil || history.ResyncRequired || len(history.Values) != 2 {
+			return fmt.Errorf("unexpected output history: %#v, %v", history, err)
+		}
+		stale, err := outputReader.OutputHistory(ctx, stream.ID, 0, 10)
+		if err != nil || !stale.ResyncRequired || stale.MinimumCursor != 1 {
+			return fmt.Errorf("unexpected stale output cursor: %#v, %v", stale, err)
+		}
+		if _, err := outputReader.PublishOutput(ctx, stream.ID, bus.PublishOutputInput{ContentType: bus.OutputText, Value: "denied"}); requireCode(err, bus.CodeUnauthenticated) != nil {
+			return fmt.Errorf("read credential published output: %v", err)
+		}
+		if _, err := planner.PublishOutput(ctx, stream.ID, bus.PublishOutputInput{ContentType: bus.OutputText, Value: "denied"}); requireCode(err, bus.CodePermissionDenied) != nil {
+			return fmt.Errorf("unapproved agent published output: %v", err)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
 	if err := record.check("presence-and-discovery", func() error {
 		if _, err := planner.Heartbeat(ctx, bus.HeartbeatInput{Lifecycle: bus.LifecycleReady, Ready: true, LeaseMS: 30000}); err != nil {
 			return err
@@ -586,7 +630,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		if err != nil {
 			return err
 		}
-		if len(tools.Tools) != 13 {
+		if len(tools.Tools) != 14 {
 			return fmt.Errorf("unexpected MCP tool count: %d", len(tools.Tools))
 		}
 		peers, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "list_peers", Arguments: map[string]any{}})
@@ -600,7 +644,16 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 		if err != nil {
 			return err
 		}
-		return requireStructuredArray(tasks, "tasks")
+		if err := requireStructuredArray(tasks, "tasks"); err != nil {
+			return err
+		}
+		published, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "publish_output", Arguments: map[string]any{
+			"streamId": outputStream.ID, "contentType": "text/plain", "value": "published through MCP",
+		}})
+		if err != nil || published.IsError {
+			return fmt.Errorf("MCP publish_output failed: %#v, %v", published, err)
+		}
+		return nil
 	}); err != nil {
 		return result, err
 	}

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -8,8 +8,9 @@ Use the narrowest credential for each operation:
 
 - admin token for scope creation and daemon shutdown;
 - scope token for agent registration, peer links, Agent Card publications and remote principals, project task management, event streams, storage controls, and human escalation resolution;
-- agent token for heartbeat, discovery, messages, tasks, and escalation creation.
-- scoped A2A credential for one published A2A interface only.
+- agent token for heartbeat, discovery, messages, tasks, and escalation creation;
+- scoped A2A credential for one published A2A interface only;
+- scoped output credential for read or publish access to one output stream.
 
 Keep admin and scope tokens outside model context. A managed session gives the harness only its execution-bound agent token.
 
@@ -57,6 +58,21 @@ progress, err := agent.AddTaskProgress(ctx, taskID, bus.AddTaskProgressInput{
     Kind: "progress",
     Text: "Retry behavior is implemented.",
 })
+
+stream, err := owner.CreateOutputStream(ctx, bus.CreateOutputStreamInput{
+    Name:              "site-preview",
+    PublisherAgentIDs: []string{"reviewer"},
+})
+value, err := agent.PublishOutput(ctx, stream.ID, bus.PublishOutputInput{
+    ContentType: bus.OutputJSON,
+    Value:       map[string]any{"status": "ready", "url": "https://example.test/preview"},
+})
+reader, err := owner.CreateOutputPrincipal(ctx, bus.CreateOutputPrincipalInput{
+    StreamID:    stream.ID,
+    Label:       "Preview page",
+    Permissions: []bus.OutputPermission{bus.OutputRead},
+})
+latest, err := (bus.Client{Address: address, Token: reader.Credential}).LatestOutput(ctx, stream.ID)
 ```
 
 Every Go call accepts a context. The default HTTP client has a 30-second timeout. Supply `Client.HTTP` to set a different transport or timeout.
@@ -72,7 +88,7 @@ npm install @october-dev/october-bus@next
 ```
 
 ```ts
-import { OctoberBusAgentSession, OctoberBusScopeClient } from '@october-dev/october-bus'
+import { OctoberBusAgentSession, OctoberBusOutputClient, OctoberBusScopeClient } from '@october-dev/october-bus'
 
 const session = await OctoberBusAgentSession.start({
   address,
@@ -105,6 +121,22 @@ await session.client.addTaskProgress(taskId, {
   kind: 'progress',
   text: 'Retry behavior is implemented.'
 })
+
+const stream = await owner.createOutputStream({
+  name: 'site-preview',
+  publisherAgentIds: ['reviewer']
+})
+await session.client.publishOutput(stream.id, {
+  contentType: 'application/json',
+  value: { status: 'ready', url: 'https://example.test/preview' }
+})
+const reader = await owner.createOutputPrincipal({
+  streamId: stream.id,
+  label: 'Preview page',
+  permissions: ['read']
+})
+const outputs = new OctoberBusOutputClient(address, reader.credential)
+const latest = await outputs.latest(stream.id)
 ```
 
 Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argument. Inbox and event operations support bounded waits up to 25 seconds. The default request timeout is 30 seconds.
@@ -112,6 +144,10 @@ Each TypeScript operation accepts an optional final `{ timeoutMs, signal }` argu
 Persist an event batch's `nextRevision` only after applying the whole batch. If `resyncRequired` is true, rebuild from the resource APIs before saving the returned cursor. Event envelopes contain state metadata but not message, task, progress, or escalation contents.
 
 Store a remote principal credential when it is created. It cannot be retrieved later. Rotation returns a replacement and invalidates the previous value immediately. Principal lists never include credentials.
+
+Output history is independent of the scope event stream. Use `nextSequence` to continue an ordered read. If `resyncRequired` is true, read the latest value and resume from its sequence. Scope events include output metadata but never the published value or reference.
+
+The [live output page](../examples/output-stream) shows how a browser can display a coding agent's latest value with a read-only credential.
 
 Prefer bounded inbox waiting for efficient pull delivery. `pollInbox` provides an async iterator over repeated bounded waits. Use `withClaimedTask` to release a task if work or completion fails. Keep the managed session alive while holding a claim.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,7 +30,7 @@ The bridge reads `OCTOBER_BUS_ADDRESS` and `OCTOBER_BUS_AGENT_TOKEN`, discovers 
 Agents can inspect the durable delivery state of a message they sent or
 received without opening SQLite or writing a client program. The command
 requires the agent credential and never reveals message bodies or shared
-context — only the receipt.
+context, only the receipt.
 
 ```bash
 october-bus message receipt <message-id> [--json] [--address <addr>]
@@ -93,6 +93,23 @@ Pass `--yes` to remove the reported records in one transaction. Only terminal me
 Pruning scope events can make an old event cursor incomplete. Event clients receive `resyncRequired` and must rebuild their projection from the resource APIs before continuing.
 
 Agent Card publications and remote principals are configuration records and are not removed by retention. Disable a publication to stop serving its public card and reject its principals. Disable an individual principal to suspend only that caller.
+
+Output streams apply their own bounded retention on every publication. The default is 1,000 values and the owner can select 1 through 10,000 when creating a stream. Removing a stream also removes its values and scoped principals.
+
+Browser output access is disabled unless the request origin is explicitly configured. Set a comma-separated exact allowlist before starting the daemon:
+
+```sh
+OCTOBER_BUS_ALLOWED_ORIGINS=http://127.0.0.1:8080,https://dashboard.example october-bus start
+```
+
+PowerShell uses the same setting:
+
+```powershell
+$env:OCTOBER_BUS_ALLOWED_ORIGINS = "http://127.0.0.1:8080,https://dashboard.example"
+october-bus start
+```
+
+The Bus never accepts output credentials in query strings. A server-to-server request without an `Origin` header is not affected by browser CORS configuration.
 
 Choose a cutoff older than the longest client retry window you support. Removing a message also removes its idempotency-key binding.
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -25,6 +25,9 @@ Adapters and harnesses remain responsible for their own model access, files, too
 | Replaced or stale process | Agent authority is bound to the current execution and renewable lease |
 | Peer-name spoofing | Programmatic routing uses byte-exact agent IDs before unique exact display names |
 | Duplicate work from retries | Idempotency keys are permanent per sender and bound to the original content |
+| External output reader gains Bus authority | Output credentials are bound to one stream and explicit read or publish permissions |
+| Browser reads output from an untrusted site | Output CORS headers require an exact configured origin |
+| Output publisher exhausts local storage | Streams enforce bounded retention, payload limits, and per-principal rate limits |
 | Concurrent inbox consumers | Short reservations serialize delivery attempts and support redelivery |
 | Message or task flood | Per-scope and per-agent limits return explicit backpressure |
 | Agent resolves its own escalation | Only scope authority can resolve human escalation |

--- a/examples/output-stream/README.md
+++ b/examples/output-stream/README.md
@@ -1,0 +1,16 @@
+# Live output stream example
+
+This page reads ordered coding-agent output without registering as an agent.
+
+1. Create an output stream and a read-only output principal with a Go or TypeScript client.
+2. Start October Bus with this page's exact origin in `OCTOBER_BUS_ALLOWED_ORIGINS`.
+3. Serve this directory with any static web server.
+4. Open the page and enter the Bus address, stream ID, and read credential.
+
+For a server on port 8080, start the Bus with:
+
+```sh
+OCTOBER_BUS_ALLOWED_ORIGINS=http://127.0.0.1:8080 october-bus start
+```
+
+The page sends the credential only in the `Authorization` header. It does not put it in the URL or save it in browser storage.

--- a/examples/output-stream/index.html
+++ b/examples/output-stream/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>October Bus live output</title>
+    <style>
+      :root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      body { max-width: 760px; margin: 4rem auto; padding: 0 1rem; background: #0b1017; color: #e8edf4; }
+      form { display: grid; gap: 0.75rem; }
+      label { display: grid; gap: 0.35rem; }
+      input, button { font: inherit; padding: 0.7rem; border: 1px solid #344153; border-radius: 6px; background: #111925; color: inherit; }
+      button { cursor: pointer; background: #1769e0; border-color: #1769e0; }
+      pre { min-height: 10rem; padding: 1rem; overflow: auto; border: 1px solid #344153; border-radius: 6px; background: #111925; white-space: pre-wrap; }
+      #status { color: #9fb0c5; }
+    </style>
+  </head>
+  <body>
+    <h1>Live agent output</h1>
+    <form id="connection">
+      <label>Bus address <input id="address" value="http://127.0.0.1:4765" required></label>
+      <label>Stream ID <input id="stream" required></label>
+      <label>Read credential <input id="credential" type="password" autocomplete="off" required></label>
+      <button type="submit">Follow output</button>
+    </form>
+    <p id="status">Not connected</p>
+    <pre id="output">Waiting for a stream.</pre>
+    <script type="module">
+      const form = document.querySelector('#connection')
+      const status = document.querySelector('#status')
+      const output = document.querySelector('#output')
+      let timer
+
+      async function refresh(address, stream, credential) {
+        const response = await fetch(`${address.replace(/\/$/, '')}/outputs/${encodeURIComponent(stream)}/latest`, {
+          headers: { authorization: `Bearer ${credential}` }
+        })
+        const payload = await response.json()
+        if (!response.ok || !payload.ok) throw new Error(payload.error?.message ?? `HTTP ${response.status}`)
+        status.textContent = payload.result ? `Sequence ${payload.result.sequence}` : 'No output yet'
+        output.textContent = payload.result ? JSON.stringify(payload.result, null, 2) : 'Waiting for the first value.'
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault()
+        clearInterval(timer)
+        const address = document.querySelector('#address').value
+        const stream = document.querySelector('#stream').value
+        const credential = document.querySelector('#credential').value
+        const run = () => refresh(address, stream, credential).catch((error) => {
+          status.textContent = 'Disconnected'
+          output.textContent = error.message
+        })
+        await run()
+        timer = setInterval(run, 2000)
+      })
+    </script>
+  </body>
+</html>

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -19,7 +19,7 @@ npm install @october-dev/october-bus@next
 Start the daemon, create a scope with the October Bus CLI, and set the returned token as `OCTOBER_BUS_SCOPE_TOKEN`.
 
 ```ts
-import { OctoberBusClient, OctoberBusScopeClient } from '@october-dev/october-bus'
+import { OctoberBusClient, OctoberBusOutputClient, OctoberBusScopeClient } from '@october-dev/october-bus'
 
 const address = 'http://127.0.0.1:4765'
 const scope = new OctoberBusScopeClient(address, process.env.OCTOBER_BUS_SCOPE_TOKEN!)
@@ -50,6 +50,22 @@ const issued = await scope.createA2APrincipal({
   label: 'CI reviewer'
 })
 // Store issued.credential securely. It cannot be retrieved later.
+
+const outputStream = await scope.createOutputStream({
+  name: 'site-preview',
+  publisherAgentIds: ['reviewer']
+})
+await reviewer.publishOutput(outputStream.id, {
+  contentType: 'application/json',
+  value: { status: 'ready', url: 'https://example.test/preview' }
+})
+const outputReader = await scope.createOutputPrincipal({
+  streamId: outputStream.id,
+  label: 'Preview page',
+  permissions: ['read']
+})
+const outputs = new OctoberBusOutputClient(address, outputReader.credential)
+const latestOutput = await outputs.latest(outputStream.id)
 
 const dryRun = await scope.pruneScope({ before: '2026-08-01T00:00:00Z' })
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.9",
+  "version": "0.1.0-next.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.9",
+      "version": "0.1.0-next.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.9",
+  "version": "0.1.0-next.10",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -14,14 +14,22 @@ import type {
   CreateScopeInput,
   CreateScopeResult,
   CreateA2APrincipalInput,
+  CreateOutputPrincipalInput,
+  CreateOutputStreamInput,
   DeliveryReceipt,
   EventBatch,
   HumanEscalation,
   InboxReservation,
   IssuedA2APrincipal,
+  IssuedOutputPrincipal,
+  OutputHistory,
+  OutputPrincipal,
+  OutputStream,
+  OutputValue,
   PruneScopeInput,
   PruneScopeResult,
   PublishAgentCardInput,
+  PublishOutputInput,
   RegisterAgentInput,
   RegisterAgentResult,
   SendMessageInput,
@@ -56,6 +64,11 @@ export interface EventOptions extends OperationOptions {
   after?: number
   limit?: number
   waitMs?: number
+}
+
+export interface OutputHistoryOptions extends OperationOptions {
+  after?: number
+  limit?: number
 }
 
 async function request<T>(
@@ -286,6 +299,111 @@ export class OctoberBusScopeClient {
     )
   }
 
+  createOutputStream(input: CreateOutputStreamInput, options?: OperationOptions): Promise<OutputStream> {
+    return request(this.address, this.scopeToken, 'POST', '/v1/output-streams', input, options)
+  }
+
+  listOutputStreams(options?: OperationOptions): Promise<OutputStream[]> {
+    return request(this.address, this.scopeToken, 'GET', '/v1/output-streams', undefined, options)
+  }
+
+  outputStream(streamId: string, options?: OperationOptions): Promise<OutputStream> {
+    return request(
+      this.address,
+      this.scopeToken,
+      'GET',
+      `/v1/output-streams/${encodeURIComponent(streamId)}`,
+      undefined,
+      options
+    )
+  }
+
+  async removeOutputStream(streamId: string, options?: OperationOptions): Promise<void> {
+    await request(
+      this.address,
+      this.scopeToken,
+      'DELETE',
+      `/v1/output-streams/${encodeURIComponent(streamId)}`,
+      undefined,
+      options
+    )
+  }
+
+  setOutputPublisher(
+    streamId: string,
+    agentId: string,
+    allowed: boolean,
+    options?: OperationOptions
+  ): Promise<OutputStream> {
+    return request(
+      this.address,
+      this.scopeToken,
+      allowed ? 'PUT' : 'DELETE',
+      `/v1/output-streams/${encodeURIComponent(streamId)}/publishers/${encodeURIComponent(agentId)}`,
+      undefined,
+      options
+    )
+  }
+
+  createOutputPrincipal(input: CreateOutputPrincipalInput, options?: OperationOptions): Promise<IssuedOutputPrincipal> {
+    return request(this.address, this.scopeToken, 'POST', '/v1/output-principals', input, options)
+  }
+
+  listOutputPrincipals(options?: OperationOptions): Promise<OutputPrincipal[]> {
+    return request(this.address, this.scopeToken, 'GET', '/v1/output-principals', undefined, options)
+  }
+
+  rotateOutputPrincipal(principalId: string, options?: OperationOptions): Promise<IssuedOutputPrincipal> {
+    return request(
+      this.address,
+      this.scopeToken,
+      'POST',
+      `/v1/output-principals/${encodeURIComponent(principalId)}/rotate`,
+      {},
+      options
+    )
+  }
+
+  setOutputPrincipalEnabled(
+    principalId: string,
+    enabled: boolean,
+    options?: OperationOptions
+  ): Promise<OutputPrincipal> {
+    const action = enabled ? 'enable' : 'disable'
+    return request(
+      this.address,
+      this.scopeToken,
+      'POST',
+      `/v1/output-principals/${encodeURIComponent(principalId)}/${action}`,
+      {},
+      options
+    )
+  }
+
+  latestOutput(streamId: string, options?: OperationOptions): Promise<OutputValue | null> {
+    return request(
+      this.address,
+      this.scopeToken,
+      'GET',
+      `/outputs/${encodeURIComponent(streamId)}/latest`,
+      undefined,
+      options
+    )
+  }
+
+  outputHistory(streamId: string, options: OutputHistoryOptions = {}): Promise<OutputHistory> {
+    const { after = 0, limit = 50, ...operationOptions } = options
+    const query = new URLSearchParams({ after: String(after), limit: String(limit) })
+    return request(
+      this.address,
+      this.scopeToken,
+      'GET',
+      `/outputs/${encodeURIComponent(streamId)}/values?${query}`,
+      undefined,
+      operationOptions
+    )
+  }
+
   listEscalations(options?: OperationOptions): Promise<HumanEscalation[]> {
     return request(this.address, this.scopeToken, 'GET', '/v1/scope/escalations', undefined, options)
   }
@@ -313,6 +431,17 @@ export class OctoberBusClient {
 
   listPeers(options?: OperationOptions): Promise<Agent[]> {
     return request(this.address, this.agentToken, 'GET', '/v1/peers', undefined, options)
+  }
+
+  publishOutput(streamId: string, input: PublishOutputInput, options?: OperationOptions): Promise<OutputValue> {
+    return request(
+      this.address,
+      this.agentToken,
+      'POST',
+      `/outputs/${encodeURIComponent(streamId)}/values`,
+      input,
+      options
+    )
   }
 
   sendMessage(input: SendMessageInput, options?: OperationOptions): Promise<DeliveryReceipt> {
@@ -430,5 +559,47 @@ export class OctoberBusClient {
 
   mcpEndpoint(): { url: string; headers: Record<string, string> } {
     return { url: `${this.address}/mcp`, headers: { Authorization: `Bearer ${this.agentToken}` } }
+  }
+}
+
+export class OctoberBusOutputClient {
+  constructor(
+    readonly address: string,
+    private readonly credential: string
+  ) {}
+
+  publish(streamId: string, input: PublishOutputInput, options?: OperationOptions): Promise<OutputValue> {
+    return request(
+      this.address,
+      this.credential,
+      'POST',
+      `/outputs/${encodeURIComponent(streamId)}/values`,
+      input,
+      options
+    )
+  }
+
+  latest(streamId: string, options?: OperationOptions): Promise<OutputValue | null> {
+    return request(
+      this.address,
+      this.credential,
+      'GET',
+      `/outputs/${encodeURIComponent(streamId)}/latest`,
+      undefined,
+      options
+    )
+  }
+
+  history(streamId: string, options: OutputHistoryOptions = {}): Promise<OutputHistory> {
+    const { after = 0, limit = 50, ...operationOptions } = options
+    const query = new URLSearchParams({ after: String(after), limit: String(limit) })
+    return request(
+      this.address,
+      this.credential,
+      'GET',
+      `/outputs/${encodeURIComponent(streamId)}/values?${query}`,
+      undefined,
+      operationOptions
+    )
   }
 }

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -158,6 +158,80 @@ export interface IssuedA2APrincipal {
   credential: string
 }
 
+export type OutputContentType = 'text/plain' | 'application/json'
+export type OutputPermission = 'read' | 'publish'
+
+export interface OutputReference {
+  uri: string
+  title?: string
+}
+
+export interface OutputStream {
+  id: string
+  scopeId: ScopeId
+  name: string
+  retentionLimit: number
+  currentSequence: number
+  minimumCursor: number
+  publisherAgentIds: AgentId[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateOutputStreamInput {
+  name: string
+  retentionLimit?: number
+  publisherAgentIds?: AgentId[]
+}
+
+export interface PublishOutputInput {
+  contentType: OutputContentType
+  value: unknown
+  reference?: OutputReference
+}
+
+export interface OutputValue {
+  streamId: string
+  sequence: number
+  producerType: 'agent' | 'principal'
+  producerId: string
+  contentType: OutputContentType
+  value: unknown
+  reference?: OutputReference
+  createdAt: string
+}
+
+export interface OutputHistory {
+  streamId: string
+  values: OutputValue[]
+  nextSequence: number
+  currentSequence: number
+  minimumCursor: number
+  resyncRequired: boolean
+}
+
+export interface OutputPrincipal {
+  id: string
+  scopeId: ScopeId
+  streamId: string
+  label: string
+  permissions: OutputPermission[]
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateOutputPrincipalInput {
+  streamId: string
+  label: string
+  permissions: OutputPermission[]
+}
+
+export interface IssuedOutputPrincipal {
+  principal: OutputPrincipal
+  credential: string
+}
+
 export interface HumanEscalation {
   id: string
   scopeId: ScopeId
@@ -214,7 +288,16 @@ export interface AddTaskProgressInput {
 }
 
 export interface StorageRecordSummary {
-  recordType: 'message' | 'task' | 'taskProgress' | 'escalation' | 'event' | 'a2aPublication' | 'credential'
+  recordType:
+    | 'message'
+    | 'task'
+    | 'taskProgress'
+    | 'escalation'
+    | 'event'
+    | 'a2aPublication'
+    | 'credential'
+    | 'outputStream'
+    | 'outputValue'
   state: string
   count: number
   estimatedBytes: number

--- a/sdk/typescript/test/integration.mjs
+++ b/sdk/typescript/test/integration.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import {
   OctoberBusAdminClient,
   OctoberBusAgentSession,
+  OctoberBusOutputClient,
   OctoberBusScopeClient,
   newIdempotencyKey,
   withClaimedTask
@@ -109,6 +110,30 @@ try {
   await reviewerSession.setState('ready', true)
   const planner = plannerSession.client
   const reviewer = reviewerSession.client
+  const outputStream = await owner.createOutputStream({
+    name: 'site-preview',
+    retentionLimit: 2,
+    publisherAgentIds: ['reviewer']
+  })
+  const outputReader = await owner.createOutputPrincipal({
+    streamId: outputStream.id,
+    label: 'Preview page',
+    permissions: ['read']
+  })
+  await reviewer.publishOutput(outputStream.id, {
+    contentType: 'text/plain',
+    value: 'building'
+  })
+  await reviewer.publishOutput(outputStream.id, {
+    contentType: 'application/json',
+    value: { status: 'ready', url: 'https://example.test/preview' }
+  })
+  const outputs = new OctoberBusOutputClient(run.address, outputReader.credential)
+  assert.deepEqual((await outputs.latest(outputStream.id)).value, {
+    status: 'ready',
+    url: 'https://example.test/preview'
+  })
+  assert.equal((await outputs.history(outputStream.id)).values.length, 2)
   const initialEvents = await owner.events({ limit: 100 })
   assert.equal(initialEvents.events.length > 0, true)
   assert.equal(initialEvents.resyncRequired, false)
@@ -160,6 +185,12 @@ try {
   assert.equal(progress[0].text, 'Review started')
   const storage = await owner.storageSummary()
   assert.equal(storage.records.some((record) => record.recordType === 'task' && record.state === 'done'), true)
+  assert.equal(
+    storage.records
+      .filter((record) => record.recordType === 'outputValue')
+      .reduce((count, record) => count + record.count, 0),
+    2
+  )
   const before = new Date(Date.now() + 60_000).toISOString()
   const dryRun = await owner.pruneScope({ before })
   assert.equal(dryRun.dryRun, true)

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -138,7 +138,7 @@ Retention MUST support a dry run and report exact record counts. The reference C
 
 Scope authority MAY follow a durable event log to update external projections. Each event has an opaque ID and a scope-local, monotonically increasing revision. Clients resume by requesting events after the last revision they committed.
 
-Events describe state changes without carrying protected record content. Message bodies and context, task titles, descriptions and progress text, escalation questions and answers, and credentials MUST NOT appear in an event envelope.
+Events describe state changes without carrying protected record content. Message bodies and context, task titles, descriptions and progress text, escalation questions and answers, output values and references, and credentials MUST NOT appear in an event envelope.
 
 Protocol 0.1 defines these event types:
 
@@ -149,6 +149,7 @@ Protocol 0.1 defines these event types:
 - `escalation.created` and `escalation.resolved`
 - `a2a.publication_created`, `a2a.publication_enabled`, and `a2a.publication_disabled`
 - `credential.created`, `credential.rotated`, `credential.enabled`, and `credential.disabled`
+- `output.stream_created`, `output.stream_removed`, `output.publisher_added`, `output.publisher_removed`, and `output.published`
 
 Each listed transition event MUST be committed atomically with the transition it describes. Retrying an idempotent operation that made no new state change MUST NOT append another event. A heartbeat that only renews a lease does not append a lifecycle event.
 
@@ -172,6 +173,20 @@ Rotating a principal invalidates its previous credential immediately without cha
 
 A scoped A2A credential grants no access to the Bus HTTP API, MCP endpoint, scope authority, agent authority, other publications, or daemon administration. Implementations MUST store a one-way digest instead of the plaintext credential and compare presented credentials in constant time.
 
+## Output streams
+
+A scope owner MAY create a named output stream for values consumed by websites, dashboards, automations, and other tools. A stream has an opaque ID, a scope-unique name, a retention limit, a monotonically increasing sequence, and an explicit set of agent publishers.
+
+An authorized agent or scoped output principal MAY publish `text/plain` or `application/json` values. Each value records its sequence, producer type, producer ID, content type, creation time, and an optional absolute URI reference. Text values are limited to 64 KiB. Encoded JSON values are limited to 256 KiB. References contain no fetched content and do not expand authority.
+
+The latest value and ordered history are readable with scope authority or a scoped output principal with `read` permission. A principal can hold `read`, `publish`, or both permissions for exactly one stream. The credential has no access to messages, context, tasks, agents, MCP, administration, or another stream.
+
+Output principal credentials follow the same one-time issuance, secure digest storage, rotation, and enable or disable rules as scoped A2A credentials. Listing principals never returns their credentials. Removing a stream also removes its values and principals.
+
+History cursors use stream sequence numbers. When bounded retention removes values required by an old cursor, the result sets `resyncRequired` and supplies the current sequence. Output values are retained independently of the scope event log. Each publication also appends a metadata-only `output.published` event so scope event followers can react without receiving the output value itself.
+
+The reference runtime retains 1,000 values by default and permits a configured limit from 1 through 10,000. It limits each publishing identity to 120 publications per minute and each scoped reader to 600 reads per minute. Scope-owner reads are not rate limited. A scope can contain at most 1,000 output streams and a stream can authorize at most 128 agent publishers.
+
 ## Human escalation
 
 An agent MAY create an escalation with a question and either no options or two to four options. Creating an escalation does not grant the agent permission or answer the question.
@@ -183,9 +198,10 @@ Only scope authority resolves escalations. Agent authority can create and read e
 | Credential | Allowed operations |
 | --- | --- |
 | Admin token | Create a scope and request local daemon shutdown |
-| Scope token | Register and list agents, create peer links, manage Agent Card publications and their remote principals, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
-| Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, create and read escalations |
+| Scope token | Register and list agents, create peer links, manage Agent Card publications and remote principals, manage output streams and readers, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
+| Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, publish to explicitly allowed output streams, create and read escalations |
 | Scoped A2A credential | Invoke one published A2A agent interface when that operation is supported |
+| Scoped output credential | Read or publish one output stream according to its explicit permissions |
 
 Tokens are bearer credentials. Implementations MUST compare them safely, MUST NOT log them, and MUST reject empty credentials. Agent tokens MUST stop working after lease expiry or execution replacement.
 

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -73,6 +73,20 @@ Failures use:
 | `POST` | `/v1/a2a/principals/{principalId}/rotate` | Scope | Principal and replacement credential |
 | `POST` | `/v1/a2a/principals/{principalId}/enable` | Scope | Enabled principal |
 | `POST` | `/v1/a2a/principals/{principalId}/disable` | Scope | Disabled principal |
+| `POST` | `/v1/output-streams` | Scope | New output stream |
+| `GET` | `/v1/output-streams` | Scope | Output streams in the scope |
+| `GET` | `/v1/output-streams/{streamId}` | Scope | Output stream metadata |
+| `DELETE` | `/v1/output-streams/{streamId}` | Scope | Removed output stream, values, and principals |
+| `PUT` | `/v1/output-streams/{streamId}/publishers/{agentId}` | Scope | Authorized agent publisher |
+| `DELETE` | `/v1/output-streams/{streamId}/publishers/{agentId}` | Scope | Removed agent publisher |
+| `POST` | `/v1/output-principals` | Scope | New output principal and one-time credential |
+| `GET` | `/v1/output-principals` | Scope | Output principals without credentials |
+| `POST` | `/v1/output-principals/{principalId}/rotate` | Scope | Principal and replacement credential |
+| `POST` | `/v1/output-principals/{principalId}/enable` | Scope | Enabled output principal |
+| `POST` | `/v1/output-principals/{principalId}/disable` | Scope | Disabled output principal |
+| `POST` | `/outputs/{streamId}/values` | Agent or scoped publish | Published output value |
+| `GET` | `/outputs/{streamId}/values` | Scope or scoped read | Ordered output history |
+| `GET` | `/outputs/{streamId}/latest` | Scope or scoped read | Latest output value or `null` |
 | `GET` | `/a2a/agents/{publicationId}/.well-known/agent-card.json` | None | Enabled A2A Agent Card |
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
 
@@ -82,13 +96,17 @@ Failures use:
 
 `POST /v1/scope/storage/prune` requires an RFC 3339 `before` timestamp. Omitted or false `execute` performs a dry run. `execute=true` removes the reported terminal records in one transaction.
 
-`GET /v1/events?after=0&limit=50&waitMs=25000` returns events after the supplied scope revision. The limit is 1 through 100 and the bounded wait is 0 through 25000 milliseconds. The default cursor is 0, the default limit is 50, and the default wait returns immediately. Event envelopes contain identifiers and state metadata, not message bodies, task text, progress text, escalation questions, answers, or credentials.
+`GET /v1/events?after=0&limit=50&waitMs=25000` returns events after the supplied scope revision. The limit is 1 through 100 and the bounded wait is 0 through 25000 milliseconds. The default cursor is 0, the default limit is 50, and the default wait returns immediately. Event envelopes contain identifiers and state metadata, not message bodies, task text, progress text, escalation questions, answers, output values, references, or credentials.
 
 Clients resume from `nextRevision`. `minimumCursor` is the oldest cursor that can still produce a complete continuation. A batch with `resyncRequired: true` means retention removed events needed by the supplied cursor. The client must rebuild its projection from the resource APIs and resume from the returned `nextRevision`.
 
 Agent Card publications are absent by default. A scope owner publishes one registered agent by sending its exact `agentId`. The returned opaque publication ID and URLs remain stable while the publication is disabled and re-enabled. Public card requests for unknown and disabled IDs return the same `NOT_FOUND` response. Card and interface URLs come from the runtime's trusted address configuration, never the request `Host` header.
 
 `POST /v1/a2a/principals` accepts a publication ID and label. Create and rotate responses are the only responses that contain the bearer credential. List, enable, and disable responses return principal metadata only. A principal credential is restricted to its publication and cannot authenticate to any `/v1` or `/mcp` operation.
+
+`POST /outputs/{streamId}/values` accepts `contentType`, `value`, and an optional URI reference. Agent credentials require an explicit publisher grant. Scoped output credentials require `publish` permission. `GET /outputs/{streamId}/values?after=0&limit=50` returns ordered values after the cursor. The limit is 1 through 100. Clients use `nextSequence` as their next cursor and rebuild from the latest value when `resyncRequired` is true.
+
+Output credentials are bearer credentials and MUST be sent in the `Authorization` header. Credentials in query strings are not accepted. Browser CORS policy is deployment configuration rather than part of the protocol.
 
 Request and result shapes are defined in [protocol.schema.json](schemas/protocol.schema.json). Consumers can reference individual definitions with a fragment such as:
 

--- a/spec/0.1/mcp.md
+++ b/spec/0.1/mcp.md
@@ -21,6 +21,7 @@ The reference CLI can forward this same MCP surface over stdio with `october-bus
 | `add_task_progress` | Append progress, a note, or a blocker to a claimed task |
 | `list_task_progress` | Read the ordered progress history for a task |
 | `list_tasks` | List shared tasks and optionally return only ready work |
+| `publish_output` | Publish text or JSON to an explicitly authorized output stream |
 | `ask_user` | Create a human escalation |
 | `get_node_status` | Read the current identity, lease, and lifecycle |
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -410,12 +410,155 @@
         "credential": { "type": "string", "minLength": 1 }
       }
     },
+    "outputContentType": {
+      "type": "string",
+      "enum": ["text/plain", "application/json"]
+    },
+    "outputPermission": {
+      "type": "string",
+      "enum": ["read", "publish"]
+    },
+    "outputReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri"],
+      "properties": {
+        "uri": { "type": "string", "format": "uri", "minLength": 1, "maxLength": 4096 },
+        "title": { "type": "string", "minLength": 1, "maxLength": 512 }
+      }
+    },
+    "outputStream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "scopeId", "name", "retentionLimit", "currentSequence", "minimumCursor", "publisherAgentIds", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "scopeId": { "$ref": "#/$defs/identifier" },
+        "name": { "$ref": "#/$defs/identifier" },
+        "retentionLimit": { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "currentSequence": { "type": "integer", "minimum": 0 },
+        "minimumCursor": { "type": "integer", "minimum": 0 },
+        "publisherAgentIds": {
+          "type": "array",
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "createOutputStreamInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "retentionLimit": { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "publisherAgentIds": {
+          "type": "array",
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" }
+        }
+      }
+    },
+    "publishOutputInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contentType", "value"],
+      "properties": {
+        "contentType": { "$ref": "#/$defs/outputContentType" },
+        "value": { "not": { "type": "null" } },
+        "reference": { "$ref": "#/$defs/outputReference" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "contentType": { "const": "text/plain" } } },
+          "then": { "properties": { "value": { "type": "string", "maxLength": 65536 } } }
+        }
+      ]
+    },
+    "outputValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["streamId", "sequence", "producerType", "producerId", "contentType", "value", "createdAt"],
+      "properties": {
+        "streamId": { "$ref": "#/$defs/identifier" },
+        "sequence": { "type": "integer", "minimum": 1 },
+        "producerType": { "type": "string", "enum": ["agent", "principal"] },
+        "producerId": { "$ref": "#/$defs/identifier" },
+        "contentType": { "$ref": "#/$defs/outputContentType" },
+        "value": { "not": { "type": "null" } },
+        "reference": { "$ref": "#/$defs/outputReference" },
+        "createdAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "outputHistory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["streamId", "values", "nextSequence", "currentSequence", "minimumCursor", "resyncRequired"],
+      "properties": {
+        "streamId": { "$ref": "#/$defs/identifier" },
+        "values": { "type": "array", "maxItems": 100, "items": { "$ref": "#/$defs/outputValue" } },
+        "nextSequence": { "type": "integer", "minimum": 0 },
+        "currentSequence": { "type": "integer", "minimum": 0 },
+        "minimumCursor": { "type": "integer", "minimum": 0 },
+        "resyncRequired": { "type": "boolean" }
+      }
+    },
+    "outputPrincipal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "scopeId", "streamId", "label", "permissions", "enabled", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "scopeId": { "$ref": "#/$defs/identifier" },
+        "streamId": { "$ref": "#/$defs/identifier" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "permissions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/outputPermission" }
+        },
+        "enabled": { "type": "boolean" },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "createOutputPrincipalInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["streamId", "label", "permissions"],
+      "properties": {
+        "streamId": { "$ref": "#/$defs/identifier" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "permissions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/outputPermission" }
+        }
+      }
+    },
+    "issuedOutputPrincipal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principal", "credential"],
+      "properties": {
+        "principal": { "$ref": "#/$defs/outputPrincipal" },
+        "credential": { "type": "string", "minLength": 1 }
+      }
+    },
     "storageRecordSummary": {
       "type": "object",
       "additionalProperties": false,
       "required": ["recordType", "state", "count", "estimatedBytes"],
       "properties": {
-        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event", "a2aPublication", "credential"] },
+        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event", "a2aPublication", "credential", "outputStream", "outputValue"] },
         "state": { "type": "string", "minLength": 1 },
         "count": { "type": "integer", "minimum": 0 },
         "estimatedBytes": { "type": "integer", "minimum": 0 },

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -175,6 +175,36 @@ func TestProtocolSchemas(t *testing.T) {
 	createPrincipal := resolvedSchema(t, path, "createA2APrincipalInput")
 	requireValid(t, createPrincipal, map[string]any{"publicationId": "pub_123", "label": "Review service"})
 	requireInvalid(t, createPrincipal, map[string]any{"publicationId": "pub_123", "label": ""})
+	outputStream := resolvedSchema(t, path, "outputStream")
+	requireValid(t, outputStream, map[string]any{
+		"id": "out_123", "scopeId": "scope", "name": "site-preview", "retentionLimit": float64(1000),
+		"currentSequence": float64(1), "minimumCursor": float64(0), "publisherAgentIds": []any{"reviewer"},
+		"createdAt": "2026-09-02T00:00:00Z", "updatedAt": "2026-09-02T00:00:01Z",
+	})
+	publishOutput := resolvedSchema(t, path, "publishOutputInput")
+	requireValid(t, publishOutput, map[string]any{
+		"contentType": "application/json", "value": map[string]any{"status": "ready"},
+		"reference": map[string]any{"uri": "https://example.test/preview", "title": "Preview"},
+	})
+	requireValid(t, publishOutput, map[string]any{"contentType": "text/plain", "value": "building"})
+	requireInvalid(t, publishOutput, map[string]any{"contentType": "text/plain", "value": map[string]any{"status": "wrong"}})
+	outputHistory := resolvedSchema(t, path, "outputHistory")
+	requireValid(t, outputHistory, map[string]any{
+		"streamId": "out_123", "values": []any{map[string]any{
+			"streamId": "out_123", "sequence": float64(1), "producerType": "agent", "producerId": "reviewer",
+			"contentType": "text/plain", "value": "ready", "createdAt": "2026-09-02T00:00:01Z",
+		}},
+		"nextSequence": float64(1), "currentSequence": float64(1), "minimumCursor": float64(0), "resyncRequired": false,
+	})
+	outputPrincipal := resolvedSchema(t, path, "issuedOutputPrincipal")
+	requireValid(t, outputPrincipal, map[string]any{
+		"principal": map[string]any{
+			"id": "cred_456", "scopeId": "scope", "streamId": "out_123", "label": "Dashboard",
+			"permissions": []any{"read"}, "enabled": true,
+			"createdAt": "2026-09-02T00:00:00Z", "updatedAt": "2026-09-02T00:00:00Z",
+		},
+		"credential": "cred_456.secret",
+	})
 
 	prune := resolvedSchema(t, path, "pruneScopeInput")
 	requireValid(t, prune, map[string]any{"before": "2026-08-01T00:00:00Z"})
@@ -291,8 +321,32 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	requireValid(t, resolvedSchema(t, path, "issuedA2APrincipal"), jsonValue(t, principal))
+	outputStream, err := owner.CreateOutputStream(ctx, bus.CreateOutputStreamInput{
+		Name: "site-preview", PublisherAgentIDs: []string{"reviewer"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireValid(t, resolvedSchema(t, path, "outputStream"), jsonValue(t, outputStream))
+	outputPrincipal, err := owner.CreateOutputPrincipal(ctx, bus.CreateOutputPrincipalInput{
+		StreamID: outputStream.ID, Label: "Dashboard", Permissions: []bus.OutputPermission{bus.OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireValid(t, resolvedSchema(t, path, "issuedOutputPrincipal"), jsonValue(t, outputPrincipal))
 	planner := bus.Client{Address: address, Token: plannerRegistration.AgentToken}
 	reviewer := bus.Client{Address: address, Token: reviewerRegistration.AgentToken}
+	output, err := reviewer.PublishOutput(ctx, outputStream.ID, bus.PublishOutputInput{ContentType: bus.OutputText, Value: "ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireValid(t, resolvedSchema(t, path, "outputValue"), jsonValue(t, output))
+	history, err := (bus.Client{Address: address, Token: outputPrincipal.Credential}).OutputHistory(ctx, outputStream.ID, 0, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireValid(t, resolvedSchema(t, path, "outputHistory"), jsonValue(t, history))
 	agent, err := planner.Heartbeat(ctx, bus.HeartbeatInput{Lifecycle: bus.LifecycleReady, Ready: true})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- add durable, named output streams with bounded ordered history
- authorize agent publishers and issue narrow read or publish credentials for external tools
- expose latest and history APIs with exact-origin browser controls and per-principal rate limits
- add Go, TypeScript, HTTP, and MCP support plus a live browser example
- include output metadata in scope events without exposing published values

## Validation

- Go race tests and vet
- TypeScript typecheck, build, error tests, and Go to TypeScript integration
- local runtime conformance: 21/21
- Linux and Windows cross-builds

Closes #66