### PR TITLE
Add portable scope archives

### DIFF
--- a/bus/archive.go
+++ b/bus/archive.go
@@ -1,0 +1,1053 @@
+package bus
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const (
+	ScopeArchiveFormat  = "october-bus.scope"
+	ScopeArchiveVersion = 1
+)
+
+type ScopeArchive struct {
+	Format                string                 `json:"format"`
+	Version               int                    `json:"version"`
+	ExportedAt            string                 `json:"exportedAt"`
+	Scope                 ArchivedScope          `json:"scope"`
+	Agents                []ArchivedAgent        `json:"agents"`
+	Links                 []ArchivedPeerLink     `json:"links"`
+	Messages              []ArchivedMessage      `json:"messages"`
+	Tasks                 []ArchivedTask         `json:"tasks"`
+	TaskProgress          []ArchivedTaskProgress `json:"taskProgress"`
+	Escalations           []ArchivedEscalation   `json:"escalations"`
+	AgentCardPublications []ArchivedAgentCard    `json:"agentCardPublications"`
+	OutputStreams         []ArchivedOutputStream `json:"outputStreams"`
+	OutputValues          []ArchivedOutputValue  `json:"outputValues"`
+}
+
+type ArchivedScope struct {
+	ID        string `json:"id"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type ArchivedAgent struct {
+	ID           string            `json:"id"`
+	DisplayName  string            `json:"displayName"`
+	Capabilities []AgentCapability `json:"capabilities"`
+	RegisteredAt string            `json:"registeredAt"`
+	UpdatedAt    string            `json:"updatedAt"`
+}
+
+type ArchivedPeerLink struct {
+	Left      string `json:"left"`
+	Right     string `json:"right"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type ArchivedMessage struct {
+	ID                string        `json:"id"`
+	From              string        `json:"from"`
+	To                string        `json:"to"`
+	Mode              MessageMode   `json:"mode"`
+	Body              string        `json:"body"`
+	Context           []ContextItem `json:"context"`
+	ResponseTo        string        `json:"responseTo,omitempty"`
+	IdempotencyKey    string        `json:"idempotencyKey,omitempty"`
+	State             DeliveryState `json:"state"`
+	CreatedAt         string        `json:"createdAt"`
+	ExpiresAt         string        `json:"expiresAt,omitempty"`
+	DeliveredAt       string        `json:"deliveredAt,omitempty"`
+	AcknowledgedAt    string        `json:"acknowledgedAt,omitempty"`
+	RepliedAt         string        `json:"repliedAt,omitempty"`
+	ResponseMessageID string        `json:"responseMessageId,omitempty"`
+}
+
+type ArchivedTask struct {
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	Description  string   `json:"description"`
+	CreatedBy    *string  `json:"createdBy"`
+	ClaimedBy    string   `json:"claimedBy,omitempty"`
+	Status       string   `json:"status"`
+	Dependencies []string `json:"dependencies"`
+	Note         string   `json:"note,omitempty"`
+	CreatedAt    string   `json:"createdAt"`
+	UpdatedAt    string   `json:"updatedAt"`
+}
+
+type ArchivedTaskProgress struct {
+	TaskID    string `json:"taskId"`
+	Sequence  int64  `json:"sequence"`
+	AgentID   string `json:"agentId"`
+	Kind      string `json:"kind"`
+	Text      string `json:"text"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type ArchivedEscalation struct {
+	ID         string   `json:"id"`
+	AgentID    string   `json:"agentId"`
+	Question   string   `json:"question"`
+	Options    []string `json:"options"`
+	Status     string   `json:"status"`
+	Answer     string   `json:"answer,omitempty"`
+	CreatedAt  string   `json:"createdAt"`
+	ResolvedAt string   `json:"resolvedAt,omitempty"`
+}
+
+type ArchivedAgentCard struct {
+	ID        string `json:"id"`
+	AgentID   string `json:"agentId"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type ArchivedOutputStream struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	RetentionLimit    int      `json:"retentionLimit"`
+	CurrentSequence   int64    `json:"currentSequence"`
+	MinimumCursor     int64    `json:"minimumCursor"`
+	PublisherAgentIDs []string `json:"publisherAgentIds"`
+	CreatedAt         string   `json:"createdAt"`
+	UpdatedAt         string   `json:"updatedAt"`
+}
+
+type ArchivedOutputValue struct {
+	StreamID     string            `json:"streamId"`
+	Sequence     int64             `json:"sequence"`
+	ProducerType string            `json:"producerType"`
+	ProducerID   string            `json:"producerId"`
+	ContentType  OutputContentType `json:"contentType"`
+	Value        any               `json:"value"`
+	Reference    *OutputReference  `json:"reference,omitempty"`
+	CreatedAt    string            `json:"createdAt"`
+}
+
+type ImportScopeResult struct {
+	ScopeID    string `json:"scopeId"`
+	ScopeToken string `json:"scopeToken,omitempty"`
+	Imported   bool   `json:"imported"`
+}
+
+func archiveTime(value string, required bool) (int64, error) {
+	if value == "" && !required {
+		return 0, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return 0, Errorf(CodeInvalidArgument, "Archive contains an invalid timestamp")
+	}
+	return parsed.UnixMilli(), nil
+}
+
+func queryArchivedAgents(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedAgent, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT agent_id,display_name,capabilities_json,registered_at,updated_at FROM agents WHERE scope_id=? ORDER BY agent_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedAgent{}
+	for rows.Next() {
+		var value ArchivedAgent
+		var capabilities string
+		var registeredAt, updatedAt int64
+		if err := rows.Scan(&value.ID, &value.DisplayName, &capabilities, &registeredAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(capabilities), &value.Capabilities); err != nil {
+			return nil, err
+		}
+		if value.Capabilities == nil {
+			value.Capabilities = []AgentCapability{}
+		}
+		value.RegisteredAt, value.UpdatedAt = instant(registeredAt), instant(updatedAt)
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedLinks(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedPeerLink, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT left_agent,right_agent,created_at FROM peer_links WHERE scope_id=? ORDER BY left_agent,right_agent`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedPeerLink{}
+	for rows.Next() {
+		var value ArchivedPeerLink
+		var createdAt int64
+		if err := rows.Scan(&value.Left, &value.Right, &createdAt); err != nil {
+			return nil, err
+		}
+		value.CreatedAt = instant(createdAt)
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedMessages(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedMessage, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_agent,to_agent,mode,body,context_json,response_to,idempotency_key,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id FROM messages WHERE scope_id=? ORDER BY created_at,message_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedMessage{}
+	for rows.Next() {
+		var value ArchivedMessage
+		var contextJSON string
+		var responseTo, idempotencyKey, responseMessageID sql.NullString
+		var createdAt int64
+		var expiresAt, deliveredAt, acknowledgedAt, repliedAt sql.NullInt64
+		if err := rows.Scan(&value.ID, &value.From, &value.To, &value.Mode, &value.Body, &contextJSON, &responseTo, &idempotencyKey, &value.State, &createdAt, &expiresAt, &deliveredAt, &acknowledgedAt, &repliedAt, &responseMessageID); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(contextJSON), &value.Context); err != nil {
+			return nil, err
+		}
+		if value.Context == nil {
+			value.Context = []ContextItem{}
+		}
+		value.ResponseTo, value.IdempotencyKey, value.ResponseMessageID = responseTo.String, idempotencyKey.String, responseMessageID.String
+		value.CreatedAt, value.ExpiresAt = instant(createdAt), instant(expiresAt.Int64)
+		value.DeliveredAt, value.AcknowledgedAt = instant(deliveredAt.Int64), instant(acknowledgedAt.Int64)
+		value.RepliedAt = instant(repliedAt.Int64)
+		if value.State == DeliveryReserved {
+			value.State = DeliveryQueued
+			if deliveredAt.Valid {
+				value.State = DeliveryDelivered
+			}
+		}
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedTasks(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedTask, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT task_id,title,description,created_by,claimed_by,status,dependencies_json,note,created_at,updated_at FROM tasks WHERE scope_id=? ORDER BY created_at,task_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedTask{}
+	for rows.Next() {
+		var value ArchivedTask
+		var createdBy, claimedBy, note sql.NullString
+		var dependencies string
+		var createdAt, updatedAt int64
+		if err := rows.Scan(&value.ID, &value.Title, &value.Description, &createdBy, &claimedBy, &value.Status, &dependencies, &note, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(dependencies), &value.Dependencies); err != nil {
+			return nil, err
+		}
+		if value.Dependencies == nil {
+			value.Dependencies = []string{}
+		}
+		if createdBy.Valid {
+			value.CreatedBy = &createdBy.String
+		}
+		value.ClaimedBy, value.Note = claimedBy.String, note.String
+		if value.Status == "claimed" {
+			value.Status, value.ClaimedBy = "open", ""
+		}
+		value.CreatedAt, value.UpdatedAt = instant(createdAt), instant(updatedAt)
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedTaskProgress(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedTaskProgress, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT task_id,sequence,agent_id,kind,text,created_at FROM task_progress WHERE scope_id=? ORDER BY task_id,sequence`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedTaskProgress{}
+	for rows.Next() {
+		var value ArchivedTaskProgress
+		var createdAt int64
+		if err := rows.Scan(&value.TaskID, &value.Sequence, &value.AgentID, &value.Kind, &value.Text, &createdAt); err != nil {
+			return nil, err
+		}
+		value.CreatedAt = instant(createdAt)
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedEscalations(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedEscalation, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT escalation_id,agent_id,question,options_json,status,answer,created_at,resolved_at FROM escalations WHERE scope_id=? ORDER BY created_at,escalation_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedEscalation{}
+	for rows.Next() {
+		var value ArchivedEscalation
+		var options string
+		var answer sql.NullString
+		var createdAt int64
+		var resolvedAt sql.NullInt64
+		if err := rows.Scan(&value.ID, &value.AgentID, &value.Question, &options, &value.Status, &answer, &createdAt, &resolvedAt); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(options), &value.Options); err != nil {
+			return nil, err
+		}
+		if value.Options == nil {
+			value.Options = []string{}
+		}
+		value.Answer, value.CreatedAt, value.ResolvedAt = answer.String, instant(createdAt), instant(resolvedAt.Int64)
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedAgentCards(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedAgentCard, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT publication_id,agent_id,created_at,updated_at FROM a2a_publications WHERE scope_id=? ORDER BY created_at,publication_id`, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	values := []ArchivedAgentCard{}
+	for rows.Next() {
+		var value ArchivedAgentCard
+		var createdAt, updatedAt int64
+		if err := rows.Scan(&value.ID, &value.AgentID, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		value.CreatedAt, value.UpdatedAt = instant(createdAt), instant(updatedAt)
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func queryArchivedOutputs(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedOutputStream, []ArchivedOutputValue, error) {
+	publishers, err := outputPublishers(ctx, tx, scopeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT `+outputStreamColumns+` FROM output_streams WHERE scope_id=? ORDER BY created_at,stream_id`, scopeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	streams := []ArchivedOutputStream{}
+	for rows.Next() {
+		record, err := scanOutputStream(rows)
+		if err != nil {
+			rows.Close()
+			return nil, nil, err
+		}
+		streams = append(streams, ArchivedOutputStream{ID: record.ID, Name: record.Name, RetentionLimit: record.RetentionLimit, CurrentSequence: record.CurrentSequence, MinimumCursor: record.MinimumCursor, PublisherAgentIDs: publishers[record.ID], CreatedAt: instant(record.CreatedAt), UpdatedAt: instant(record.UpdatedAt)})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, nil, err
+	}
+	rows.Close()
+	valueRows, err := tx.QueryContext(ctx, `SELECT values_.stream_id,values_.sequence,values_.producer_type,values_.producer_id,values_.content_type,values_.value_json,values_.reference_json,values_.created_at FROM output_values AS values_ JOIN output_streams AS streams ON streams.stream_id=values_.stream_id WHERE streams.scope_id=? ORDER BY values_.stream_id,values_.sequence`, scopeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer valueRows.Close()
+	values := []ArchivedOutputValue{}
+	for valueRows.Next() {
+		value, err := scanOutputValue(valueRows)
+		if err != nil {
+			return nil, nil, err
+		}
+		values = append(values, ArchivedOutputValue{StreamID: value.StreamID, Sequence: value.Sequence, ProducerType: value.ProducerType, ProducerID: value.ProducerID, ContentType: value.ContentType, Value: value.Value, Reference: value.Reference, CreatedAt: value.CreatedAt})
+	}
+	return streams, values, valueRows.Err()
+}
+
+func (s *Store) ExportScope(ctx context.Context, scopeID string) (ScopeArchive, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ScopeArchive{}, err
+	}
+	defer tx.Rollback()
+	var createdAt int64
+	if err := tx.QueryRowContext(ctx, `SELECT created_at FROM scopes WHERE scope_id=?`, scopeID).Scan(&createdAt); errors.Is(err, sql.ErrNoRows) {
+		return ScopeArchive{}, Errorf(CodeNotFound, "Scope "+scopeID+" was not found")
+	} else if err != nil {
+		return ScopeArchive{}, err
+	}
+	var active int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM agents WHERE scope_id=? AND lifecycle!='offline' AND lease_expires_at>?`, scopeID, nowMillis()).Scan(&active); err != nil {
+		return ScopeArchive{}, err
+	}
+	if active != 0 {
+		return ScopeArchive{}, Errorf(CodeConflict, "Scope must have no active agent executions before export")
+	}
+	if err := expireMessages(ctx, tx, scopeID, nowMillis()); err != nil {
+		return ScopeArchive{}, err
+	}
+	archive := ScopeArchive{Format: ScopeArchiveFormat, Version: ScopeArchiveVersion, ExportedAt: instant(nowMillis()), Scope: ArchivedScope{ID: scopeID, CreatedAt: instant(createdAt)}}
+	if archive.Agents, err = queryArchivedAgents(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.Links, err = queryArchivedLinks(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.Messages, err = queryArchivedMessages(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.Tasks, err = queryArchivedTasks(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.TaskProgress, err = queryArchivedTaskProgress(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.Escalations, err = queryArchivedEscalations(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.AgentCardPublications, err = queryArchivedAgentCards(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	if archive.OutputStreams, archive.OutputValues, err = queryArchivedOutputs(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
+	return archive, tx.Commit()
+}
+
+func archiveDigest(archive ScopeArchive) (string, error) {
+	data, err := json.Marshal(archive)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func requireArchiveID(value, field string) error {
+	if err := validateIdentity(value, field, false); err != nil {
+		return Errorf(CodeInvalidArgument, "Archive "+field+" is invalid")
+	}
+	return nil
+}
+
+func validateArchive(archive *ScopeArchive) error {
+	if archive.Format != ScopeArchiveFormat {
+		return Errorf(CodeInvalidArgument, "Archive format is not supported")
+	}
+	if archive.Version != ScopeArchiveVersion {
+		return Errorf(CodeInvalidArgument, "Archive version is not supported")
+	}
+	if _, err := archiveTime(archive.ExportedAt, true); err != nil {
+		return err
+	}
+	if err := requireArchiveID(archive.Scope.ID, "scope.id"); err != nil {
+		return err
+	}
+	if _, err := archiveTime(archive.Scope.CreatedAt, true); err != nil {
+		return err
+	}
+	if archive.Agents == nil || archive.Links == nil || archive.Messages == nil || archive.Tasks == nil || archive.TaskProgress == nil || archive.Escalations == nil || archive.AgentCardPublications == nil || archive.OutputStreams == nil || archive.OutputValues == nil {
+		return Errorf(CodeInvalidArgument, "Archive record collections are required")
+	}
+	agents := map[string]bool{}
+	for i := range archive.Agents {
+		agent := &archive.Agents[i]
+		if err := requireArchiveID(agent.ID, "agent.id"); err != nil {
+			return err
+		}
+		if agents[agent.ID] {
+			return Errorf(CodeInvalidArgument, "Archive contains a duplicate agent id")
+		}
+		agents[agent.ID] = true
+		if agent.Capabilities == nil {
+			return Errorf(CodeInvalidArgument, "Archive agent capabilities are required")
+		}
+		if err := validateText(agent.DisplayName, "displayName", 256, false); err != nil {
+			return err
+		}
+		if err := validateCapabilities(agent.Capabilities); err != nil {
+			return err
+		}
+		if _, err := archiveTime(agent.RegisteredAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(agent.UpdatedAt, true); err != nil {
+			return err
+		}
+	}
+	links := map[string]bool{}
+	for _, link := range archive.Links {
+		if !agents[link.Left] || !agents[link.Right] || link.Left >= link.Right {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid peer link")
+		}
+		key := link.Left + "\x00" + link.Right
+		if links[key] {
+			return Errorf(CodeInvalidArgument, "Archive contains a duplicate peer link")
+		}
+		links[key] = true
+		if _, err := archiveTime(link.CreatedAt, true); err != nil {
+			return err
+		}
+	}
+	messages := map[string]*ArchivedMessage{}
+	idempotencyKeys := map[string]bool{}
+	activeMessages := 0
+	for i := range archive.Messages {
+		message := &archive.Messages[i]
+		if err := requireArchiveID(message.ID, "message.id"); err != nil {
+			return err
+		}
+		if messages[message.ID] != nil {
+			return Errorf(CodeInvalidArgument, "Archive contains a duplicate message id")
+		}
+		messages[message.ID] = message
+		if !agents[message.From] || !agents[message.To] {
+			return Errorf(CodeInvalidArgument, "Archive message refers to an unknown agent")
+		}
+		if err := validateMessageMode(message.Mode); err != nil {
+			return err
+		}
+		if err := validateText(message.Body, "body", 65536, false); err != nil {
+			return err
+		}
+		if err := validateContext(message.Context); err != nil {
+			return err
+		}
+		if message.Context == nil {
+			return Errorf(CodeInvalidArgument, "Archive message context is required")
+		}
+		if err := validateText(message.IdempotencyKey, "idempotencyKey", 256, true); err != nil {
+			return err
+		}
+		if message.IdempotencyKey != "" {
+			key := message.From + "\x00" + message.IdempotencyKey
+			if idempotencyKeys[key] {
+				return Errorf(CodeInvalidArgument, "Archive contains a duplicate message idempotency key")
+			}
+			idempotencyKeys[key] = true
+		}
+		if message.State != DeliveryQueued && message.State != DeliveryDelivered && message.State != DeliveryAcknowledged && message.State != DeliveryExpired {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid message state")
+		}
+		if message.State != DeliveryAcknowledged && message.State != DeliveryExpired {
+			activeMessages++
+		}
+		if _, err := archiveTime(message.CreatedAt, true); err != nil {
+			return err
+		}
+		for _, value := range []string{message.ExpiresAt, message.DeliveredAt, message.AcknowledgedAt, message.RepliedAt} {
+			if _, err := archiveTime(value, false); err != nil {
+				return err
+			}
+		}
+	}
+	if activeMessages > messageBacklogCap {
+		return Errorf(CodeInvalidArgument, "Archive message backlog exceeds the scope limit")
+	}
+	for _, message := range archive.Messages {
+		if message.Mode == MessageResponse {
+			request := messages[message.ResponseTo]
+			if request == nil || request.Mode != MessageRequest || request.From != message.To || request.To != message.From || request.ResponseMessageID != message.ID || request.RepliedAt == "" {
+				return Errorf(CodeInvalidArgument, "Archive contains an invalid response correlation")
+			}
+		} else if message.ResponseTo != "" {
+			return Errorf(CodeInvalidArgument, "Archive contains responseTo on a non-response message")
+		}
+		if message.Mode != MessageRequest && (message.ResponseMessageID != "" || message.RepliedAt != "") {
+			return Errorf(CodeInvalidArgument, "Archive contains reply state on a non-request message")
+		}
+		if message.ResponseMessageID != "" {
+			response := messages[message.ResponseMessageID]
+			if message.Mode != MessageRequest || response == nil || response.ResponseTo != message.ID || message.RepliedAt == "" {
+				return Errorf(CodeInvalidArgument, "Archive contains an invalid response message id")
+			}
+		} else if message.RepliedAt != "" {
+			return Errorf(CodeInvalidArgument, "Archive contains a reply timestamp without a response")
+		}
+		switch message.State {
+		case DeliveryQueued:
+			if message.DeliveredAt != "" || message.AcknowledgedAt != "" {
+				return Errorf(CodeInvalidArgument, "Archive queued message contains delivery timestamps")
+			}
+		case DeliveryDelivered:
+			if message.DeliveredAt == "" || message.AcknowledgedAt != "" {
+				return Errorf(CodeInvalidArgument, "Archive delivered message timestamps are invalid")
+			}
+		case DeliveryAcknowledged:
+			if message.DeliveredAt == "" || message.AcknowledgedAt == "" {
+				return Errorf(CodeInvalidArgument, "Archive acknowledged message timestamps are invalid")
+			}
+		case DeliveryExpired:
+			if message.ExpiresAt == "" || message.AcknowledgedAt != "" {
+				return Errorf(CodeInvalidArgument, "Archive expired message timestamps are invalid")
+			}
+		}
+	}
+	tasks := map[string]*ArchivedTask{}
+	activeTasks := 0
+	for i := range archive.Tasks {
+		task := &archive.Tasks[i]
+		if err := requireArchiveID(task.ID, "task.id"); err != nil {
+			return err
+		}
+		if tasks[task.ID] != nil {
+			return Errorf(CodeInvalidArgument, "Archive contains a duplicate task id")
+		}
+		tasks[task.ID] = task
+		if task.Dependencies == nil {
+			return Errorf(CodeInvalidArgument, "Archive task dependencies are required")
+		}
+		if err := validateText(task.Title, "title", 256, false); err != nil {
+			return err
+		}
+		if err := validateText(task.Description, "description", 16384, true); err != nil {
+			return err
+		}
+		if task.Status != "open" && task.Status != "done" {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid task status")
+		}
+		if task.Status == "open" {
+			activeTasks++
+		}
+		if task.CreatedBy != nil && !agents[*task.CreatedBy] {
+			return Errorf(CodeInvalidArgument, "Archive task creator is unknown")
+		}
+		if task.Status == "done" && !agents[task.ClaimedBy] {
+			return Errorf(CodeInvalidArgument, "Archive completed task owner is unknown")
+		}
+		if task.Status == "open" && task.ClaimedBy != "" {
+			return Errorf(CodeInvalidArgument, "Archive open task has an owner")
+		}
+		if _, err := archiveTime(task.CreatedAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(task.UpdatedAt, true); err != nil {
+			return err
+		}
+	}
+	if activeTasks > activeTaskCap {
+		return Errorf(CodeInvalidArgument, "Archive active tasks exceed the scope limit")
+	}
+	for _, task := range archive.Tasks {
+		seenDependencies := map[string]bool{}
+		for _, dependency := range task.Dependencies {
+			if dependency == task.ID || tasks[dependency] == nil || seenDependencies[dependency] {
+				return Errorf(CodeInvalidArgument, "Archive task dependency is invalid")
+			}
+			seenDependencies[dependency] = true
+		}
+	}
+	visiting, visited := map[string]bool{}, map[string]bool{}
+	var visitTask func(string) bool
+	visitTask = func(taskID string) bool {
+		if visiting[taskID] {
+			return false
+		}
+		if visited[taskID] {
+			return true
+		}
+		visiting[taskID] = true
+		for _, dependency := range tasks[taskID].Dependencies {
+			if !visitTask(dependency) {
+				return false
+			}
+		}
+		delete(visiting, taskID)
+		visited[taskID] = true
+		return true
+	}
+	for taskID := range tasks {
+		if !visitTask(taskID) {
+			return Errorf(CodeInvalidArgument, "Archive task dependencies contain a cycle")
+		}
+	}
+	progressKeys := map[string]bool{}
+	progressCount := map[string]int{}
+	progressBytes := map[string]int{}
+	progressMaximum := map[string]int64{}
+	for _, progress := range archive.TaskProgress {
+		if tasks[progress.TaskID] == nil || !agents[progress.AgentID] || progress.Sequence < 1 {
+			return Errorf(CodeInvalidArgument, "Archive contains invalid task progress")
+		}
+		key := fmt.Sprintf("%s:%d", progress.TaskID, progress.Sequence)
+		if progressKeys[key] {
+			return Errorf(CodeInvalidArgument, "Archive contains duplicate task progress")
+		}
+		progressKeys[key] = true
+		progressCount[progress.TaskID]++
+		progressBytes[progress.TaskID] += len(progress.Text)
+		if progress.Sequence > progressMaximum[progress.TaskID] {
+			progressMaximum[progress.TaskID] = progress.Sequence
+		}
+		if progressCount[progress.TaskID] > maxTaskProgressEvents || progressBytes[progress.TaskID] > maxTaskProgressBytes {
+			return Errorf(CodeInvalidArgument, "Archive task progress exceeds the task limit")
+		}
+		if progress.Kind != "progress" && progress.Kind != "note" && progress.Kind != "blocker" {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid task progress kind")
+		}
+		if err := validateText(progress.Text, "text", 4000, false); err != nil {
+			return err
+		}
+		if _, err := archiveTime(progress.CreatedAt, true); err != nil {
+			return err
+		}
+	}
+	for taskID, count := range progressCount {
+		if progressMaximum[taskID] != int64(count) {
+			return Errorf(CodeInvalidArgument, "Archive task progress sequence has a gap")
+		}
+	}
+	escalations := map[string]bool{}
+	pendingEscalations := 0
+	pendingByAgent := map[string]int{}
+	for _, escalation := range archive.Escalations {
+		if err := requireArchiveID(escalation.ID, "escalation.id"); err != nil {
+			return err
+		}
+		if escalations[escalation.ID] || !agents[escalation.AgentID] {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid escalation")
+		}
+		escalations[escalation.ID] = true
+		if escalation.Options == nil {
+			return Errorf(CodeInvalidArgument, "Archive escalation options are required")
+		}
+		if err := validateText(escalation.Question, "question", 4000, false); err != nil {
+			return err
+		}
+		if len(escalation.Options) == 1 || len(escalation.Options) > 4 {
+			return Errorf(CodeInvalidArgument, "Archive escalation options are invalid")
+		}
+		for _, option := range escalation.Options {
+			if err := validateText(option, "options", 256, false); err != nil {
+				return err
+			}
+		}
+		if escalation.Status != "pending" && escalation.Status != "resolved" && escalation.Status != "cancelled" {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid escalation status")
+		}
+		if escalation.Status == "pending" {
+			pendingEscalations++
+			pendingByAgent[escalation.AgentID]++
+			if pendingByAgent[escalation.AgentID] > pendingEscalationCapPerAgent {
+				return Errorf(CodeInvalidArgument, "Archive pending escalations exceed the agent limit")
+			}
+		}
+		if escalation.Status == "resolved" && escalation.ResolvedAt == "" {
+			return Errorf(CodeInvalidArgument, "Archive resolved escalation has no resolvedAt")
+		}
+		if escalation.Answer != "" {
+			if err := validateText(escalation.Answer, "answer", 16384, false); err != nil {
+				return err
+			}
+		}
+		if _, err := archiveTime(escalation.CreatedAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(escalation.ResolvedAt, false); err != nil {
+			return err
+		}
+	}
+	if pendingEscalations > pendingEscalationCapPerScope {
+		return Errorf(CodeInvalidArgument, "Archive pending escalations exceed the scope limit")
+	}
+	publications := map[string]bool{}
+	publishedAgents := map[string]bool{}
+	for _, publication := range archive.AgentCardPublications {
+		if err := requireArchiveID(publication.ID, "publication.id"); err != nil {
+			return err
+		}
+		if publications[publication.ID] || !agents[publication.AgentID] || publishedAgents[publication.AgentID] {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid Agent Card publication")
+		}
+		publications[publication.ID] = true
+		publishedAgents[publication.AgentID] = true
+		if _, err := archiveTime(publication.CreatedAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(publication.UpdatedAt, true); err != nil {
+			return err
+		}
+	}
+	streams := map[string]*ArchivedOutputStream{}
+	streamNames := map[string]bool{}
+	if len(archive.OutputStreams) > maxOutputStreams {
+		return Errorf(CodeInvalidArgument, "Archive output streams exceed the scope limit")
+	}
+	for i := range archive.OutputStreams {
+		stream := &archive.OutputStreams[i]
+		if err := requireArchiveID(stream.ID, "outputStream.id"); err != nil {
+			return err
+		}
+		if streams[stream.ID] != nil || streamNames[stream.Name] || stream.RetentionLimit < 1 || stream.RetentionLimit > maxOutputRetention || stream.MinimumCursor < 0 || stream.CurrentSequence < stream.MinimumCursor {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid output stream")
+		}
+		streams[stream.ID] = stream
+		streamNames[stream.Name] = true
+		if stream.PublisherAgentIDs == nil || len(stream.PublisherAgentIDs) > maxOutputPublishers {
+			return Errorf(CodeInvalidArgument, "Archive output publishers are invalid")
+		}
+		if err := validateIdentity(stream.Name, "outputStream.name", false); err != nil {
+			return err
+		}
+		seenPublishers := map[string]bool{}
+		for _, publisher := range stream.PublisherAgentIDs {
+			if !agents[publisher] || seenPublishers[publisher] {
+				return Errorf(CodeInvalidArgument, "Archive output publisher is unknown")
+			}
+			seenPublishers[publisher] = true
+		}
+		if _, err := archiveTime(stream.CreatedAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(stream.UpdatedAt, true); err != nil {
+			return err
+		}
+	}
+	outputKeys := map[string]bool{}
+	outputCounts := map[string]int{}
+	for _, value := range archive.OutputValues {
+		stream := streams[value.StreamID]
+		if stream == nil || value.Sequence <= stream.MinimumCursor || value.Sequence > stream.CurrentSequence || (value.ProducerType != "agent" && value.ProducerType != "principal") {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid output value")
+		}
+		outputCounts[value.StreamID]++
+		if outputCounts[value.StreamID] > stream.RetentionLimit {
+			return Errorf(CodeInvalidArgument, "Archive output history exceeds its retention limit")
+		}
+		if value.ProducerType == "agent" && !agents[value.ProducerID] {
+			return Errorf(CodeInvalidArgument, "Archive output producer is unknown")
+		}
+		if err := requireArchiveID(value.ProducerID, "outputValue.producerId"); err != nil {
+			return err
+		}
+		if value.ContentType != OutputText && value.ContentType != OutputJSON {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid output content type")
+		}
+		if _, _, err := validatePublishOutput(PublishOutputInput{ContentType: value.ContentType, Value: value.Value, Reference: value.Reference}); err != nil {
+			return err
+		}
+		key := fmt.Sprintf("%s:%d", value.StreamID, value.Sequence)
+		if outputKeys[key] {
+			return Errorf(CodeInvalidArgument, "Archive contains a duplicate output sequence")
+		}
+		outputKeys[key] = true
+		if _, err := archiveTime(value.CreatedAt, true); err != nil {
+			return err
+		}
+	}
+	for streamID, stream := range streams {
+		if int64(outputCounts[streamID]) != stream.CurrentSequence-stream.MinimumCursor {
+			return Errorf(CodeInvalidArgument, "Archive output history sequence has a gap")
+		}
+	}
+	return nil
+}
+
+func insertArchive(ctx context.Context, tx *sql.Tx, archive ScopeArchive, digest, tokenHash string, importedAt int64) error {
+	createdAt, _ := archiveTime(archive.Scope.CreatedAt, true)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO scopes(scope_id,token_hash,created_at) VALUES(?,?,?)`, archive.Scope.ID, tokenHash, createdAt); err != nil {
+		return err
+	}
+	for _, agent := range archive.Agents {
+		capabilities, _ := jsonValue(agent.Capabilities)
+		registeredAt, _ := archiveTime(agent.RegisteredAt, true)
+		updatedAt, _ := archiveTime(agent.UpdatedAt, true)
+		executionID, err := randomID("exec_")
+		if err != nil {
+			return err
+		}
+		dormantToken, err := randomValue(32)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO agents(scope_id,agent_id,display_name,capabilities_json,execution_id,token_hash,lifecycle,ready,lease_expires_at,registered_at,updated_at) VALUES(?,?,?,?,?,?,'offline',0,0,?,?)`, archive.Scope.ID, agent.ID, agent.DisplayName, capabilities, executionID, tokenDigest(dormantToken), registeredAt, updatedAt); err != nil {
+			return err
+		}
+	}
+	for _, link := range archive.Links {
+		created, _ := archiveTime(link.CreatedAt, true)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO peer_links(scope_id,left_agent,right_agent,created_at) VALUES(?,?,?,?)`, archive.Scope.ID, link.Left, link.Right, created); err != nil {
+			return err
+		}
+	}
+	messages := append([]ArchivedMessage(nil), archive.Messages...)
+	sort.SliceStable(messages, func(i, j int) bool { return messages[i].CreatedAt < messages[j].CreatedAt })
+	for _, message := range messages {
+		contextJSON, _ := jsonValue(message.Context)
+		created, _ := archiveTime(message.CreatedAt, true)
+		expires, _ := archiveTime(message.ExpiresAt, false)
+		delivered, _ := archiveTime(message.DeliveredAt, false)
+		acknowledged, _ := archiveTime(message.AcknowledgedAt, false)
+		replied, _ := archiveTime(message.RepliedAt, false)
+		expiresIn := int64(0)
+		if expires > created {
+			expiresIn = expires - created
+		}
+		requestHash := messageRequestHash(SendMessageInput{To: message.To, Body: message.Body, ResponseTo: message.ResponseTo, ExpiresInMS: expiresIn}, message.Mode, contextJSON)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO messages(message_id,scope_id,from_agent,to_agent,mode,body,context_json,response_to,idempotency_key,request_hash,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id) VALUES(?,?,?,?,?,?,?,NULL,?,?,?,?,?,?,?,?,?)`, message.ID, archive.Scope.ID, message.From, message.To, message.Mode, message.Body, contextJSON, nullableString(message.IdempotencyKey), requestHash, message.State, created, nullableInt64(expires), nullableInt64(delivered), nullableInt64(acknowledged), nullableInt64(replied), nullableString(message.ResponseMessageID)); err != nil {
+			return err
+		}
+	}
+	for _, message := range messages {
+		if message.ResponseTo == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE messages SET response_to=? WHERE message_id=?`, message.ResponseTo, message.ID); err != nil {
+			return err
+		}
+	}
+	for _, task := range archive.Tasks {
+		dependencies, _ := jsonValue(task.Dependencies)
+		created, _ := archiveTime(task.CreatedAt, true)
+		updated, _ := archiveTime(task.UpdatedAt, true)
+		var claimedBy, execution any
+		if task.Status == "done" {
+			claimedBy, execution = task.ClaimedBy, "imported"
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO tasks(task_id,scope_id,title,description,created_by,claimed_by,claimed_execution_id,status,dependencies_json,note,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`, task.ID, archive.Scope.ID, task.Title, task.Description, nullableStringPtr(task.CreatedBy), claimedBy, execution, task.Status, dependencies, nullableString(task.Note), created, updated); err != nil {
+			return err
+		}
+	}
+	for _, progress := range archive.TaskProgress {
+		created, _ := archiveTime(progress.CreatedAt, true)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO task_progress(task_id,scope_id,sequence,agent_id,execution_id,kind,text,created_at) VALUES(?,?,?,?,?,?,?,?)`, progress.TaskID, archive.Scope.ID, progress.Sequence, progress.AgentID, "imported", progress.Kind, progress.Text, created); err != nil {
+			return err
+		}
+	}
+	for _, escalation := range archive.Escalations {
+		options, _ := jsonValue(escalation.Options)
+		created, _ := archiveTime(escalation.CreatedAt, true)
+		resolved, _ := archiveTime(escalation.ResolvedAt, false)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO escalations(escalation_id,scope_id,agent_id,question,options_json,status,answer,created_at,resolved_at) VALUES(?,?,?,?,?,?,?,?,?)`, escalation.ID, archive.Scope.ID, escalation.AgentID, escalation.Question, options, escalation.Status, nullableString(escalation.Answer), created, nullableInt64(resolved)); err != nil {
+			return err
+		}
+	}
+	for _, publication := range archive.AgentCardPublications {
+		created, _ := archiveTime(publication.CreatedAt, true)
+		updated, _ := archiveTime(publication.UpdatedAt, true)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO a2a_publications(publication_id,scope_id,agent_id,enabled,created_at,updated_at) VALUES(?,?,?,0,?,?)`, publication.ID, archive.Scope.ID, publication.AgentID, created, updated); err != nil {
+			return err
+		}
+	}
+	for _, stream := range archive.OutputStreams {
+		created, _ := archiveTime(stream.CreatedAt, true)
+		updated, _ := archiveTime(stream.UpdatedAt, true)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO output_streams(stream_id,scope_id,name,retention_limit,sequence,floor_sequence,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?)`, stream.ID, archive.Scope.ID, stream.Name, stream.RetentionLimit, stream.CurrentSequence, stream.MinimumCursor, created, updated); err != nil {
+			return err
+		}
+		for _, publisher := range stream.PublisherAgentIDs {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO output_stream_publishers(stream_id,scope_id,agent_id) VALUES(?,?,?)`, stream.ID, archive.Scope.ID, publisher); err != nil {
+				return err
+			}
+		}
+	}
+	for _, value := range archive.OutputValues {
+		valueJSON, err := jsonValue(value.Value)
+		if err != nil {
+			return err
+		}
+		var reference any
+		if value.Reference != nil {
+			reference, err = jsonValue(value.Reference)
+			if err != nil {
+				return err
+			}
+		}
+		created, _ := archiveTime(value.CreatedAt, true)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO output_values(stream_id,sequence,producer_type,producer_id,content_type,value_json,reference_json,created_at) VALUES(?,?,?,?,?,?,?,?)`, value.StreamID, value.Sequence, value.ProducerType, value.ProducerID, value.ContentType, valueJSON, reference, created); err != nil {
+			return err
+		}
+	}
+	if err := appendEvent(ctx, tx, archive.Scope.ID, "scope.imported", digest, eventAttributes("archiveVersion", fmt.Sprintf("%d", archive.Version)), importedAt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func nullableInt64(value int64) any {
+	if value == 0 {
+		return nil
+	}
+	return value
+}
+func nullableStringPtr(value *string) any {
+	if value == nil || *value == "" {
+		return nil
+	}
+	return *value
+}
+
+func (s *Store) ImportScope(ctx context.Context, archive ScopeArchive) (ImportScopeResult, error) {
+	if err := validateArchive(&archive); err != nil {
+		return ImportScopeResult{}, err
+	}
+	digest, err := archiveDigest(archive)
+	if err != nil {
+		return ImportScopeResult{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return ImportScopeResult{}, err
+	}
+	defer tx.Rollback()
+	existingScope, err := importedArchiveScope(ctx, tx, digest)
+	if err != nil {
+		return ImportScopeResult{}, err
+	}
+	if existingScope != "" {
+		return ImportScopeResult{ScopeID: existingScope, Imported: false}, tx.Commit()
+	}
+	var found int
+	err = tx.QueryRowContext(ctx, `SELECT 1 FROM scopes WHERE scope_id=?`, archive.Scope.ID).Scan(&found)
+	if err == nil {
+		return ImportScopeResult{}, Errorf(CodeConflict, "Scope "+archive.Scope.ID+" already exists")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return ImportScopeResult{}, err
+	}
+	token, err := randomValue(32)
+	if err != nil {
+		return ImportScopeResult{}, err
+	}
+	now := nowMillis()
+	if err := insertArchive(ctx, tx, archive, digest, tokenDigest(token), now); err != nil {
+		if isSQLiteConstraint(err) {
+			return ImportScopeResult{}, Errorf(CodeInvalidArgument, "Archive contains conflicting records")
+		}
+		return ImportScopeResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ImportScopeResult{}, err
+	}
+	return ImportScopeResult{ScopeID: archive.Scope.ID, ScopeToken: token, Imported: true}, nil
+}
+
+func importedArchiveScope(ctx context.Context, tx *sql.Tx, digest string) (string, error) {
+	var scopeID string
+	err := tx.QueryRowContext(ctx, `SELECT scope_id FROM events WHERE event_type='scope.imported' AND subject_id=?`, digest).Scan(&scopeID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return scopeID, err
+}
+
+func (r *Runtime) ExportScope(ctx context.Context, scopeID string) (ScopeArchive, error) {
+	if err := validateIdentity(scopeID, "scopeId", false); err != nil {
+		return ScopeArchive{}, err
+	}
+	return r.store.ExportScope(ctx, scopeID)
+}
+
+func (r *Runtime) ImportScope(ctx context.Context, archive ScopeArchive) (ImportScopeResult, error) {
+	result, err := r.store.ImportScope(ctx, archive)
+	if err == nil && result.Imported {
+		r.notifyScope(result.ScopeID)
+	}
+	return result, err
+}

--- a/bus/archive_routes_test.go
+++ b/bus/archive_routes_test.go
@@ -1,0 +1,80 @@
+package bus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func archiveRequest(t *testing.T, server *Server, method, path, token string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var encoded []byte
+	var err error
+	if body != nil {
+		encoded, err = json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := httptest.NewRequest(method, path, bytes.NewReader(encoded))
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	return response
+}
+
+func TestPortableScopeArchiveAdminRoutes(t *testing.T) {
+	ctx := context.Background()
+	source := setupAgents(t, ":memory:")
+	defer source.runtime.Close()
+	server := NewServer(source.runtime, ServerOptions{AdminToken: "source-admin"})
+
+	unauthorized := archiveRequest(t, server, http.MethodGet, "/v1/admin/scopes/test/export", "", nil)
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected unauthorized status: %d", unauthorized.Code)
+	}
+	active := archiveRequest(t, server, http.MethodGet, "/v1/admin/scopes/test/export", "source-admin", nil)
+	if active.Code != http.StatusConflict {
+		t.Fatalf("unexpected active export status: %d %s", active.Code, active.Body.String())
+	}
+	offlineAgents(t, source)
+	exported := archiveRequest(t, server, http.MethodGet, "/v1/admin/scopes/test/export", "source-admin", nil)
+	if exported.Code != http.StatusOK {
+		t.Fatalf("unexpected export status: %d %s", exported.Code, exported.Body.String())
+	}
+	var exportEnvelope responseEnvelope[ScopeArchive]
+	if err := json.NewDecoder(exported.Body).Decode(&exportEnvelope); err != nil || !exportEnvelope.OK {
+		t.Fatalf("could not decode export: %#v, %v", exportEnvelope, err)
+	}
+
+	targetRuntime, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer targetRuntime.Close()
+	target := NewServer(targetRuntime, ServerOptions{AdminToken: "target-admin"})
+	imported := archiveRequest(t, target, http.MethodPost, "/v1/admin/scopes/import", "target-admin", exportEnvelope.Result)
+	if imported.Code != http.StatusCreated {
+		t.Fatalf("unexpected import status: %d %s", imported.Code, imported.Body.String())
+	}
+	var importEnvelope responseEnvelope[ImportScopeResult]
+	if err := json.NewDecoder(imported.Body).Decode(&importEnvelope); err != nil || !importEnvelope.OK || !importEnvelope.Result.Imported || importEnvelope.Result.ScopeToken == "" {
+		t.Fatalf("could not decode import: %#v, %v", importEnvelope, err)
+	}
+	retry := archiveRequest(t, target, http.MethodPost, "/v1/admin/scopes/import", "target-admin", exportEnvelope.Result)
+	if retry.Code != http.StatusOK {
+		t.Fatalf("unexpected retry status: %d %s", retry.Code, retry.Body.String())
+	}
+	importEnvelope = responseEnvelope[ImportScopeResult]{}
+	if err := json.NewDecoder(retry.Body).Decode(&importEnvelope); err != nil || importEnvelope.Result.Imported || importEnvelope.Result.ScopeToken != "" {
+		t.Fatalf("unexpected retry result: %#v, %v", importEnvelope, err)
+	}
+	if _, err := targetRuntime.ListAgents(ctx, importEnvelope.Result.ScopeToken); err == nil {
+		t.Fatal("retry unexpectedly returned reusable authority")
+	}
+}

--- a/bus/archive_test.go
+++ b/bus/archive_test.go
@@ -1,0 +1,238 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func offlineAgents(t *testing.T, agents testAgents) {
+	t.Helper()
+	ctx := context.Background()
+	for _, token := range []string{agents.plannerToken, agents.reviewerToken} {
+		if _, err := agents.runtime.Heartbeat(ctx, token, HeartbeatInput{Lifecycle: LifecycleOffline, Ready: false}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPortableScopeArchiveRoundTripAndRetry(t *testing.T) {
+	ctx := context.Background()
+	source := setupAgents(t, ":memory:")
+	defer source.runtime.Close()
+
+	request, err := source.runtime.SendMessage(ctx, source.plannerToken, SendMessageInput{
+		To: "reviewer", Mode: MessageRequest, Body: "Review this", IdempotencyKey: "review-archive",
+		Context: []ContextItem{{Kind: "text", Title: "Patch", Text: "bounded context"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := source.runtime.ReserveInbox(ctx, source.reviewerToken, 10, 0)
+	if err != nil || reservation == nil {
+		t.Fatalf("unexpected reservation: %#v, %v", reservation, err)
+	}
+	if _, err := source.runtime.CommitInbox(ctx, source.reviewerToken, reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.AcknowledgeMessages(ctx, source.reviewerToken, []string{request.MessageID}); err != nil {
+		t.Fatal(err)
+	}
+	reply, err := source.runtime.SendMessage(ctx, source.reviewerToken, SendMessageInput{To: "planner", Mode: MessageResponse, ResponseTo: request.MessageID, Body: "Looks good"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := source.runtime.AddTask(ctx, source.plannerToken, AddTaskInput{Title: "Review archive", Description: "Check restored state"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.ClaimTask(ctx, source.reviewerToken, task.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.AddTaskProgress(ctx, source.reviewerToken, task.ID, AddTaskProgressInput{Kind: "progress", Text: "Reviewed"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.CompleteTask(ctx, source.reviewerToken, task.ID, "Complete"); err != nil {
+		t.Fatal(err)
+	}
+	escalation, err := source.runtime.AskHuman(ctx, source.plannerToken, AskHumanInput{Question: "Ship?", Options: []string{"yes", "no"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.ResolveEscalation(ctx, source.scope.ScopeToken, escalation.ID, "yes"); err != nil {
+		t.Fatal(err)
+	}
+	publication, err := source.runtime.CreateAgentCardPublication(ctx, source.scope.ScopeToken, PublishAgentCardInput{AgentID: "reviewer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2aPrincipal, err := source.runtime.CreateA2APrincipal(ctx, source.scope.ScopeToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Remote caller"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := source.runtime.CreateOutputStream(ctx, source.scope.ScopeToken, CreateOutputStreamInput{Name: "preview", RetentionLimit: 10, PublisherAgentIDs: []string{"reviewer"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.PublishOutput(ctx, source.reviewerToken, stream.ID, PublishOutputInput{ContentType: OutputJSON, Value: map[string]any{"status": "ready"}}); err != nil {
+		t.Fatal(err)
+	}
+	outputPrincipal, err := source.runtime.CreateOutputPrincipal(ctx, source.scope.ScopeToken, CreateOutputPrincipalInput{StreamID: stream.ID, Label: "Viewer", Permissions: []OutputPermission{OutputRead}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingMessage, err := source.runtime.SendMessage(ctx, source.plannerToken, SendMessageInput{To: "reviewer", Body: "Reserved during export"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingReservation, err := source.runtime.ReserveInbox(ctx, source.reviewerToken, 10, 0)
+	if err != nil || pendingReservation == nil {
+		t.Fatalf("unexpected pending reservation: %#v, %v", pendingReservation, err)
+	}
+	pendingTask, err := source.runtime.AddTask(ctx, source.plannerToken, AddTaskInput{Title: "Continue after restore"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.runtime.ClaimTask(ctx, source.reviewerToken, pendingTask.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := source.runtime.ExportScope(ctx, source.scope.ScopeID); err == nil {
+		t.Fatal("active scope was exported")
+	} else {
+		requireCode(t, err, CodeConflict)
+	}
+	offlineAgents(t, source)
+	archive, err := source.runtime.ExportScope(ctx, source.scope.ScopeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{source.scope.ScopeToken, source.plannerToken, source.reviewerToken, a2aPrincipal.Credential, a2aPrincipal.Principal.ID, outputPrincipal.Credential, outputPrincipal.Principal.ID, source.planner.ExecutionID, source.reviewer.ExecutionID} {
+		if strings.Contains(string(encoded), secret) {
+			t.Fatalf("archive exposed credential or execution authority %q", secret)
+		}
+	}
+	archivedMessages := map[string]ArchivedMessage{}
+	for _, message := range archive.Messages {
+		archivedMessages[message.ID] = message
+	}
+	if len(archive.Messages) != 3 || archivedMessages[request.MessageID].ResponseMessageID != reply.MessageID || archivedMessages[reply.MessageID].ResponseTo != request.MessageID {
+		t.Fatalf("messages were not preserved: %#v", archive.Messages)
+	}
+	if archivedMessages[pendingMessage.MessageID].State != DeliveryQueued {
+		t.Fatalf("active reservation was not made portable: %#v", archivedMessages[pendingMessage.MessageID])
+	}
+	archivedTasks := map[string]ArchivedTask{}
+	for _, archivedTask := range archive.Tasks {
+		archivedTasks[archivedTask.ID] = archivedTask
+	}
+	if len(archive.Tasks) != 2 || archivedTasks[pendingTask.ID].Status != "open" || archivedTasks[pendingTask.ID].ClaimedBy != "" {
+		t.Fatalf("active task claim was not made portable: %#v", archive.Tasks)
+	}
+	if len(archive.AgentCardPublications) != 1 || len(archive.OutputStreams) != 1 || len(archive.OutputValues) != 1 {
+		t.Fatalf("configuration and output history were not preserved: %#v", archive)
+	}
+
+	destination, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+	imported, err := destination.ImportScope(ctx, archive)
+	if err != nil || !imported.Imported || imported.ScopeToken == "" || imported.ScopeID != source.scope.ScopeID {
+		t.Fatalf("unexpected import result: %#v, %v", imported, err)
+	}
+	retry, err := destination.ImportScope(ctx, archive)
+	if err != nil || retry.Imported || retry.ScopeID != imported.ScopeID || retry.ScopeToken != "" {
+		t.Fatalf("archive retry was not idempotent: %#v, %v", retry, err)
+	}
+	agents, err := destination.ListAgents(ctx, imported.ScopeToken)
+	if err != nil || len(agents) != 2 || agents[0].Lifecycle != LifecycleOffline || agents[0].Reachable {
+		t.Fatalf("agents were not restored offline: %#v, %v", agents, err)
+	}
+	if _, err := destination.ListAgents(ctx, source.scope.ScopeToken); err == nil {
+		t.Fatal("source scope token worked after import")
+	}
+	events, err := destination.Events(ctx, imported.ScopeToken, 0, 10, 0)
+	if err != nil || len(events.Events) != 1 || events.Events[0].Type != "scope.imported" {
+		t.Fatalf("import did not start a fresh event history: %#v, %v", events, err)
+	}
+	registered, err := destination.RegisterAgent(ctx, imported.ScopeToken, RegisterAgentInput{ID: "planner", DisplayName: "Planner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registered.ExecutionID == source.planner.ExecutionID {
+		t.Fatal("source execution authority survived import")
+	}
+	receipt, err := destination.Receipt(ctx, registered.AgentToken, request.MessageID)
+	if err != nil || receipt.State != DeliveryAcknowledged || receipt.ResponseMessageID != reply.MessageID {
+		t.Fatalf("message state was not restored: %#v, %v", receipt, err)
+	}
+	tasks, err := destination.ListTasks(ctx, imported.ScopeToken, false)
+	restoredTasks := map[string]Task{}
+	for _, restoredTask := range tasks {
+		restoredTasks[restoredTask.ID] = restoredTask
+	}
+	restoredDone := restoredTasks[task.ID]
+	if err != nil || len(tasks) != 2 || restoredDone.Status != "done" || len(restoredDone.RecentProgress) != 1 || restoredDone.RecentProgress[0].ExecutionID != "imported" || restoredTasks[pendingTask.ID].Status != "open" {
+		t.Fatalf("task state was not restored: %#v, %v", tasks, err)
+	}
+	pendingReceipt, err := destination.Receipt(ctx, registered.AgentToken, pendingMessage.MessageID)
+	if err != nil || pendingReceipt.State != DeliveryQueued {
+		t.Fatalf("reserved message was not restored as queued: %#v, %v", pendingReceipt, err)
+	}
+	escalations, err := destination.ListEscalations(ctx, imported.ScopeToken)
+	if err != nil || len(escalations) != 1 || escalations[0].Answer != "yes" {
+		t.Fatalf("escalation was not restored: %#v, %v", escalations, err)
+	}
+	publications, err := destination.ListAgentCardPublications(ctx, imported.ScopeToken)
+	if err != nil || len(publications) != 1 || publications[0].Enabled {
+		t.Fatalf("Agent Card was not restored disabled: %#v, %v", publications, err)
+	}
+	latest, err := destination.LatestOutput(ctx, imported.ScopeToken, stream.ID)
+	if err != nil || latest == nil || latest.Sequence != 1 {
+		t.Fatalf("output state was not restored: %#v, %v", latest, err)
+	}
+	if _, err := destination.LatestOutput(ctx, outputPrincipal.Credential, stream.ID); err == nil {
+		t.Fatal("source scoped credential worked after import")
+	}
+	if _, err := destination.PruneScope(ctx, imported.ScopeToken, PruneScopeInput{Before: "2100-01-01T00:00:00Z", Execute: true}); err != nil {
+		t.Fatal(err)
+	}
+	retryAfterRetention, err := destination.ImportScope(ctx, archive)
+	if err != nil || retryAfterRetention.Imported || retryAfterRetention.ScopeID != imported.ScopeID {
+		t.Fatalf("archive retry lost idempotency after retention: %#v, %v", retryAfterRetention, err)
+	}
+}
+
+func TestPortableScopeArchiveRejectsMalformedInputAtomically(t *testing.T) {
+	ctx := context.Background()
+	source := setupAgents(t, ":memory:")
+	defer source.runtime.Close()
+	offlineAgents(t, source)
+	archive, err := source.runtime.ExportScope(ctx, source.scope.ScopeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive.Scope.ID = "broken"
+	archive.Messages = append(archive.Messages, ArchivedMessage{ID: "msg_bad", From: "planner", To: "missing", Mode: MessageNotify, Body: "bad", Context: []ContextItem{}, State: DeliveryQueued, CreatedAt: archive.ExportedAt})
+	destination, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+	_, err = destination.ImportScope(ctx, archive)
+	requireCode(t, err, CodeInvalidArgument)
+	var count int
+	if err := destination.store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM scopes`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("malformed import applied partial state: %d, %v", count, err)
+	}
+	archive.Version = ScopeArchiveVersion + 1
+	_, err = destination.ImportScope(ctx, archive)
+	requireCode(t, err, CodeInvalidArgument)
+}

--- a/bus/client.go
+++ b/bus/client.go
@@ -100,6 +100,14 @@ func (c Client) Shutdown(ctx context.Context) error {
 	return err
 }
 
+func (c Client) ExportScope(ctx context.Context, scopeID string) (ScopeArchive, error) {
+	return request[ScopeArchive](ctx, c, http.MethodGet, "/v1/admin/scopes/"+url.PathEscape(scopeID)+"/export", nil)
+}
+
+func (c Client) ImportScope(ctx context.Context, archive ScopeArchive) (ImportScopeResult, error) {
+	return request[ImportScopeResult](ctx, c, http.MethodPost, "/v1/admin/scopes/import", archive)
+}
+
 func (c Client) RegisterAgent(ctx context.Context, input RegisterAgentInput) (RegisterAgentResult, error) {
 	return request[RegisterAgentResult](ctx, c, http.MethodPost, "/v1/agents", input)
 }

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -61,6 +61,12 @@ func (s *Server) newRouter() http.Handler {
 	registerRoute(router, "/v1/admin/shutdown",
 		routeMethod{http.MethodPost, s.shutdownServer},
 	)
+	registerRoute(router, "/v1/admin/scopes/import",
+		routeMethod{http.MethodPost, s.importScope},
+	)
+	registerRoute(router, "/v1/admin/scopes/{scopeId}/export",
+		routeMethod{http.MethodGet, s.exportScope},
+	)
 	registerRoute(router, "/v1/scopes",
 		routeMethod{http.MethodPost, s.createScope},
 	)
@@ -276,6 +282,38 @@ func (s *Server) createScope(response http.ResponseWriter, request *http.Request
 		return err
 	}
 	writeResult(response, http.StatusCreated, result)
+	return nil
+}
+
+func (s *Server) exportScope(response http.ResponseWriter, request *http.Request) error {
+	if err := s.requireAdmin(request); err != nil {
+		return err
+	}
+	result, err := s.runtime.ExportScope(request.Context(), request.PathValue("scopeId"))
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, result)
+	return nil
+}
+
+func (s *Server) importScope(response http.ResponseWriter, request *http.Request) error {
+	if err := s.requireAdmin(request); err != nil {
+		return err
+	}
+	var archive ScopeArchive
+	if err := decodeArchiveBody(response, request, &archive); err != nil {
+		return err
+	}
+	result, err := s.runtime.ImportScope(request.Context(), archive)
+	if err != nil {
+		return err
+	}
+	status := http.StatusOK
+	if result.Imported {
+		status = http.StatusCreated
+	}
+	writeResult(response, status, result)
 	return nil
 }
 

--- a/bus/server.go
+++ b/bus/server.go
@@ -15,7 +15,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const maxBodyBytes = 1024 * 1024
+const (
+	maxBodyBytes        = 1024 * 1024
+	maxArchiveBodyBytes = 64 * 1024 * 1024
+)
 
 type ServerOptions struct {
 	Host           string
@@ -154,13 +157,21 @@ func (s *Server) requireAdmin(request *http.Request) error {
 }
 
 func decodeBody(response http.ResponseWriter, request *http.Request, target any) error {
-	request.Body = http.MaxBytesReader(response, request.Body, maxBodyBytes)
+	return decodeBoundedBody(response, request, target, maxBodyBytes, "1 MiB")
+}
+
+func decodeArchiveBody(response http.ResponseWriter, request *http.Request, target any) error {
+	return decodeBoundedBody(response, request, target, maxArchiveBodyBytes, "64 MiB")
+}
+
+func decodeBoundedBody(response http.ResponseWriter, request *http.Request, target any, limit int64, limitName string) error {
+	request.Body = http.MaxBytesReader(response, request.Body, limit)
 	decoder := json.NewDecoder(request.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			return Errorf(CodeInvalidArgument, "Request body exceeds 1 MiB")
+			return Errorf(CodeInvalidArgument, "Request body exceeds "+limitName)
 		}
 		if errors.Is(err, io.EOF) {
 			return nil

--- a/bus/storage.go
+++ b/bus/storage.go
@@ -244,7 +244,7 @@ func (s *Store) PruneScope(ctx context.Context, scopeID string, before int64, ex
 		eventFloor = currentFloor
 	}
 	var eventCount int64
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE scope_id=? AND revision<=?`, scopeID, eventFloor).Scan(&eventCount); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM events WHERE scope_id=? AND revision<=? AND event_type!='scope.imported'`, scopeID, eventFloor).Scan(&eventCount); err != nil {
 		return PruneScopeResult{}, err
 	}
 	var taskProgressCount int64
@@ -289,7 +289,7 @@ func (s *Store) PruneScope(ctx context.Context, scopeID string, before int64, ex
 			}
 		}
 		if eventCount > 0 {
-			if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE scope_id=? AND revision<=?`, scopeID, eventFloor); err != nil {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE scope_id=? AND revision<=? AND event_type!='scope.imported'`, scopeID, eventFloor); err != nil {
 				return PruneScopeResult{}, err
 			}
 			if _, err := tx.ExecContext(ctx, `UPDATE scopes SET event_floor_revision=MAX(event_floor_revision,?) WHERE scope_id=?`, eventFloor, scopeID); err != nil {

--- a/cmd/october-bus/main.go
+++ b/cmd/october-bus/main.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -25,6 +27,8 @@ Usage:
   october-bus status
   october-bus doctor [--json]
   october-bus scope create [scope-id]
+  october-bus scope export --id <scope-id> --output <path> [--address <addr>]
+  october-bus scope import --input <path> [--address <addr>]
   october-bus scope storage [--json] [--address <addr>]
   october-bus scope prune --before <timestamp> [--yes] [--json] [--address <addr>]
   october-bus message receipt <message-id> [--json] [--address <addr>]
@@ -232,6 +236,130 @@ func createScope(id string) error {
 		return err
 	}
 	fmt.Println(string(encoded))
+	return nil
+}
+
+func adminClient(explicitAddress string) (bus.Client, error) {
+	if token := os.Getenv("OCTOBER_BUS_ADMIN_TOKEN"); token != "" {
+		address, err := resolveBusAddress(explicitAddress)
+		if err != nil {
+			return bus.Client{}, err
+		}
+		return bus.Client{Address: address, Token: token, HTTP: &http.Client{Timeout: 2 * time.Minute}}, nil
+	}
+	paths, err := bus.DefaultDaemonPaths()
+	if err != nil {
+		return bus.Client{}, err
+	}
+	run, err := bus.ReadRunFile(paths.RunFile)
+	if err != nil {
+		return bus.Client{}, err
+	}
+	if explicitAddress != "" && explicitAddress != run.Address {
+		return bus.Client{}, errors.New("OCTOBER_BUS_ADMIN_TOKEN is required for a remote daemon")
+	}
+	return bus.Client{Address: run.Address, Token: run.AdminToken, HTTP: &http.Client{Timeout: 2 * time.Minute}}, nil
+}
+
+func exportScope(args []string) error {
+	flags := flag.NewFlagSet("scope export", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	scopeID := flags.String("id", "", "scope id to export")
+	output := flags.String("output", "", "archive output path")
+	address := flags.String("address", "", "October Bus address")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 || *scopeID == "" || *output == "" {
+		return errors.New("scope export requires --id and --output")
+	}
+	client, err := adminClient(*address)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	archive, err := client.ExportScope(ctx, *scopeID)
+	if err != nil {
+		return fmt.Errorf("could not export scope: %w", err)
+	}
+	data, err := json.MarshalIndent(archive, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	file, err := os.OpenFile(*output, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("could not create archive: %w", err)
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			_ = os.Remove(*output)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return fmt.Errorf("could not write archive: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	complete = true
+	fmt.Printf("Exported scope %s to %s\n", archive.Scope.ID, *output)
+	return nil
+}
+
+func importScope(args []string) error {
+	flags := flag.NewFlagSet("scope import", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	input := flags.String("input", "", "archive input path")
+	address := flags.String("address", "", "October Bus address")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 || *input == "" {
+		return errors.New("scope import requires --input")
+	}
+	file, err := os.Open(*input)
+	if err != nil {
+		return fmt.Errorf("could not open archive: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("could not inspect archive: %w", err)
+	}
+	if info.Size() > 64*1024*1024 {
+		return errors.New("archive exceeds 64 MiB")
+	}
+	var archive bus.ScopeArchive
+	decoder := json.NewDecoder(io.LimitReader(file, 64*1024*1024))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&archive); err != nil {
+		return fmt.Errorf("could not read archive: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("archive must contain one JSON value")
+	}
+	client, err := adminClient(*address)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result, err := client.ImportScope(ctx, archive)
+	if err != nil {
+		return fmt.Errorf("could not import scope: %w", err)
+	}
+	encoded, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(encoded))
+	if !result.Imported {
+		fmt.Fprintln(os.Stderr, "Archive was already imported. The original scope token is not returned again.")
+	}
 	return nil
 }
 
@@ -804,6 +932,12 @@ func run() error {
 		}
 		if len(args) >= 2 && args[1] == "storage" {
 			return scopeStorage(args[2:])
+		}
+		if len(args) >= 2 && args[1] == "export" {
+			return exportScope(args[2:])
+		}
+		if len(args) >= 2 && args[1] == "import" {
+			return importScope(args[2:])
 		}
 		if len(args) >= 2 && args[1] == "prune" {
 			return scopePrune(args[2:])

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -125,6 +125,32 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 	}
 	owner := bus.Client{Address: options.Address, Token: scope.ScopeToken}
 
+	if err := record.check("portable-scope-archive", func() error {
+		archive := bus.ScopeArchive{
+			Format: bus.ScopeArchiveFormat, Version: bus.ScopeArchiveVersion,
+			ExportedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			Scope:      bus.ArchivedScope{ID: scopeID + "-archive", CreatedAt: time.Now().UTC().Format(time.RFC3339Nano)},
+			Agents:     []bus.ArchivedAgent{}, Links: []bus.ArchivedPeerLink{}, Messages: []bus.ArchivedMessage{},
+			Tasks: []bus.ArchivedTask{}, TaskProgress: []bus.ArchivedTaskProgress{}, Escalations: []bus.ArchivedEscalation{},
+			AgentCardPublications: []bus.ArchivedAgentCard{}, OutputStreams: []bus.ArchivedOutputStream{}, OutputValues: []bus.ArchivedOutputValue{},
+		}
+		imported, err := admin.ImportScope(ctx, archive)
+		if err != nil || !imported.Imported || imported.ScopeID != archive.Scope.ID || imported.ScopeToken == "" {
+			return fmt.Errorf("unexpected archive import: %#v, %v", imported, err)
+		}
+		retry, err := admin.ImportScope(ctx, archive)
+		if err != nil || retry.Imported || retry.ScopeID != imported.ScopeID || retry.ScopeToken != "" {
+			return fmt.Errorf("archive retry was not idempotent: %#v, %v", retry, err)
+		}
+		exported, err := admin.ExportScope(ctx, imported.ScopeID)
+		if err != nil || exported.Scope.ID != imported.ScopeID || exported.Format != bus.ScopeArchiveFormat || exported.Version != bus.ScopeArchiveVersion {
+			return fmt.Errorf("unexpected archive export: %#v, %v", exported, err)
+		}
+		return nil
+	}); err != nil {
+		return result, err
+	}
+
 	var plannerRegistration, reviewerRegistration bus.RegisterAgentResult
 	if err := record.check("registration-and-peer-link", func() error {
 		var err error

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -6,7 +6,7 @@ October Bus currently ships a Go client in this module and a TypeScript client o
 
 Use the narrowest credential for each operation:
 
-- admin token for scope creation and daemon shutdown;
+- admin token for scope creation, portable import and export, and daemon shutdown;
 - scope token for agent registration, peer links, Agent Card publications and remote principals, project task management, event streams, storage controls, and human escalation resolution;
 - agent token for heartbeat, discovery, messages, tasks, and escalation creation;
 - scoped A2A credential for one published A2A interface only;

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -34,7 +34,7 @@ october-bus-conformance \
   --format text
 ```
 
-The runner gives the adapter an execution-bound agent credential and keeps registration and heartbeat outside the MCP process. Admin and scope credentials are removed from the adapter environment. The profile checks identity, heartbeat, exact peer discovery, durable messaging, acknowledgements, requests, replies, idempotency, bounded context, shared tasks, human escalation, execution replacement, clean shutdown, and lease-expiry recovery.
+The runner gives the adapter an execution-bound agent credential and keeps registration and heartbeat outside the MCP process. Admin and scope credentials are removed from the adapter environment. The local runtime profile checks portable scope archives, identity, heartbeat, exact peer discovery, durable messaging, acknowledgements, requests, replies, idempotency, bounded context, shared tasks, human escalation, execution replacement, clean shutdown, and lease-expiry recovery.
 
 The lease-expiry check takes about 30 seconds. Increase `--timeout` if the host is slow.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,6 +113,26 @@ The Bus never accepts output credentials in query strings. A server-to-server re
 
 Choose a cutoff older than the longest client retry window you support. Removing a message also removes its idempotency-key binding.
 
+## Backup, restore, and migration
+
+Stop or disconnect every agent in a scope before exporting it:
+
+```bash
+october-bus scope export --id my-project --output my-project.bus.json
+```
+
+Archive files contain message bodies, context, task details, escalation answers, and output values. They do not contain reusable Bus credentials, but they can still hold sensitive project data. The CLI creates a new archive with user-only permissions and refuses to overwrite an existing file.
+
+Import the archive into another compatible runtime:
+
+```bash
+october-bus scope import --input my-project.bus.json
+```
+
+The command prints the new scope token only on the first successful import. Store it securely. Imported agents are offline, active task claims are open, and Agent Card publications are disabled. Register agents again and review publications before enabling them.
+
+For a remote runtime, set `OCTOBER_BUS_ADMIN_TOKEN` and pass `--address`. Importing the exact same archive again is safe and does not duplicate state.
+
 ## Default paths
 
 | Platform | Data directory | Runtime directory |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -41,6 +41,8 @@ The runtime and data directories request owner-only permissions where the operat
 
 Do not place scope or admin credentials in model context. Give a harness only its execution-bound agent token when possible.
 
+Portable archives exclude reusable credentials and execution authority. They still contain collaboration content such as messages, context, tasks, escalation answers, and output values. Store and transfer them as sensitive project data.
+
 ## Untrusted content
 
 Messages, task text, display names, file paths, and URLs are untrusted input. Adapters must treat them as data, not instructions that bypass the harness permission system. A file or URL reference does not prove that the resource is safe or accessible.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -6,6 +6,8 @@ The Bus daemon is distributed separately as a native executable.
 
 The client is in active development and has not reached a stable release. Before 1.0, its API, schemas, and protocol behavior may change between releases.
 
+`OctoberBusAdminClient` can export and import versioned portable scope archives. Archives preserve durable collaboration state but exclude credentials, leases, and active execution authority.
+
 ## Install
 
 Install the current prerelease from the `next` tag:

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.10",
+  "version": "0.1.0-next.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.10",
+      "version": "0.1.0-next.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.10",
+  "version": "0.1.0-next.11",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -32,9 +32,11 @@ import type {
   PublishOutputInput,
   RegisterAgentInput,
   RegisterAgentResult,
+  ScopeArchive,
   SendMessageInput,
   StorageSummary,
-  TaskProgress
+  TaskProgress,
+  ImportScopeResult
 } from './protocol.js'
 
 interface Success<T> {
@@ -153,6 +155,21 @@ export class OctoberBusAdminClient {
 
   createScope(input: CreateScopeInput = {}, options?: OperationOptions): Promise<CreateScopeResult> {
     return request(this.address, this.adminToken, 'POST', '/v1/scopes', input, options)
+  }
+
+  exportScope(scopeId: string, options?: OperationOptions): Promise<ScopeArchive> {
+    return request(
+      this.address,
+      this.adminToken,
+      'GET',
+      `/v1/admin/scopes/${encodeURIComponent(scopeId)}/export`,
+      undefined,
+      options
+    )
+  }
+
+  importScope(archive: ScopeArchive, options?: OperationOptions): Promise<ImportScopeResult> {
+    return request(this.address, this.adminToken, 'POST', '/v1/admin/scopes/import', archive, options)
   }
 
   async shutdown(options?: OperationOptions): Promise<void> {

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -232,6 +232,127 @@ export interface IssuedOutputPrincipal {
   credential: string
 }
 
+export interface ArchivedScope {
+  id: ScopeId
+  createdAt: string
+}
+
+export interface ArchivedAgent {
+  id: AgentId
+  displayName: string
+  capabilities: AgentCapability[]
+  registeredAt: string
+  updatedAt: string
+}
+
+export interface ArchivedPeerLink {
+  left: AgentId
+  right: AgentId
+  createdAt: string
+}
+
+export interface ArchivedMessage {
+  id: MessageId
+  from: AgentId
+  to: AgentId
+  mode: MessageMode
+  body: string
+  context: ContextItem[]
+  responseTo?: MessageId
+  idempotencyKey?: string
+  state: Exclude<DeliveryState, 'reserved'>
+  createdAt: string
+  expiresAt?: string
+  deliveredAt?: string
+  acknowledgedAt?: string
+  repliedAt?: string
+  responseMessageId?: MessageId
+}
+
+export interface ArchivedTask {
+  id: TaskId
+  title: string
+  description: string
+  createdBy: AgentId | null
+  claimedBy?: AgentId
+  status: Exclude<TaskStatus, 'claimed'>
+  dependencies: TaskId[]
+  note?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ArchivedTaskProgress {
+  taskId: TaskId
+  sequence: number
+  agentId: AgentId
+  kind: TaskProgressKind
+  text: string
+  createdAt: string
+}
+
+export interface ArchivedEscalation {
+  id: string
+  agentId: AgentId
+  question: string
+  options: string[]
+  status: 'pending' | 'resolved' | 'cancelled'
+  answer?: string
+  createdAt: string
+  resolvedAt?: string
+}
+
+export interface ArchivedAgentCard {
+  id: string
+  agentId: AgentId
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ArchivedOutputStream {
+  id: string
+  name: string
+  retentionLimit: number
+  currentSequence: number
+  minimumCursor: number
+  publisherAgentIds: AgentId[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ArchivedOutputValue {
+  streamId: string
+  sequence: number
+  producerType: 'agent' | 'principal'
+  producerId: string
+  contentType: OutputContentType
+  value: unknown
+  reference?: OutputReference
+  createdAt: string
+}
+
+export interface ScopeArchive {
+  format: 'october-bus.scope'
+  version: 1
+  exportedAt: string
+  scope: ArchivedScope
+  agents: ArchivedAgent[]
+  links: ArchivedPeerLink[]
+  messages: ArchivedMessage[]
+  tasks: ArchivedTask[]
+  taskProgress: ArchivedTaskProgress[]
+  escalations: ArchivedEscalation[]
+  agentCardPublications: ArchivedAgentCard[]
+  outputStreams: ArchivedOutputStream[]
+  outputValues: ArchivedOutputValue[]
+}
+
+export interface ImportScopeResult {
+  scopeId: ScopeId
+  scopeToken?: string
+  imported: boolean
+}
+
 export interface HumanEscalation {
   id: string
   scopeId: ScopeId

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -13,7 +13,8 @@ scope
 ├── authorized peer links
 ├── durable messages and receipts
 ├── shared tasks and dependencies
-└── human escalations
+├── human escalations
+└── portable durable state
 ```
 
 ### Scope
@@ -126,6 +127,10 @@ The claimant MUST keep its execution lease current. When an execution expires or
 
 The reference runtime limits a scope to 5,000 tasks that are not done.
 
+## Portable scope state
+
+Compatible implementations MAY export and import durable scope state using the versioned [portable archive format](archives.md). Archives preserve accepted work and stable resource IDs while excluding credentials, leases, reservations, execution authority, and host evidence.
+
 ## Storage and retention
 
 Accepted work is retained indefinitely by default. Scope authority MAY inspect record counts, estimated payload bytes, and oldest state timestamps without reading record content.
@@ -150,6 +155,7 @@ Protocol 0.1 defines these event types:
 - `a2a.publication_created`, `a2a.publication_enabled`, and `a2a.publication_disabled`
 - `credential.created`, `credential.rotated`, `credential.enabled`, and `credential.disabled`
 - `output.stream_created`, `output.stream_removed`, `output.publisher_added`, `output.publisher_removed`, and `output.published`
+- `scope.imported`
 
 Each listed transition event MUST be committed atomically with the transition it describes. Retrying an idempotent operation that made no new state change MUST NOT append another event. A heartbeat that only renews a lease does not append a lifecycle event.
 
@@ -197,7 +203,7 @@ Only scope authority resolves escalations. Agent authority can create and read e
 
 | Credential | Allowed operations |
 | --- | --- |
-| Admin token | Create a scope and request local daemon shutdown |
+| Admin token | Create, export, and import scopes and request local daemon shutdown |
 | Scope token | Register and list agents, create peer links, manage Agent Card publications and remote principals, manage output streams and readers, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
 | Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, publish to explicitly allowed output streams, create and read escalations |
 | Scoped A2A credential | Invoke one published A2A agent interface when that operation is supported |

--- a/spec/0.1/archives.md
+++ b/spec/0.1/archives.md
@@ -1,0 +1,42 @@
+# Portable scope archives
+
+Portable scope archives move durable collaboration state between compatible October Bus implementations. The archive format is JSON and is defined by [scope-archive.schema.json](schemas/scope-archive.schema.json).
+
+An archive preserves:
+
+- the scope ID and creation time;
+- stable agent identities, capabilities, and peer links;
+- messages, context, correlations, idempotency keys, receipts, and terminal delivery state;
+- shared tasks, dependencies, ownership of completed tasks, and progress history;
+- human escalations and answers;
+- Agent Card publication identities;
+- output streams, publisher assignments, retained values, and cursors.
+
+An archive never contains scope tokens, agent tokens, scoped credentials, credential hashes, execution IDs, leases, reservations, rate-limit counters, or host process evidence.
+
+## Safe restore state
+
+Export requires every current agent execution to be offline, expired, or otherwise stopped. A reservation is stored as `queued` when it has never been delivered and `delivered` when it represents a redelivery. A claimed task is stored as `open`. These rules prevent an execution lease or transient claim from moving to another runtime.
+
+Imported agents are offline and receive no usable agent credential. Registering an imported agent creates a new execution and credential. Imported Agent Card publications are disabled. Their owner can review and enable them after restore.
+
+The event log is local projection history and is not portable. Import creates a new event stream containing one `scope.imported` event. Event consumers must rebuild their projection from the restored resources.
+
+Scoped A2A and output principals are not portable. Create new principals after import. Output values written by an old principal retain its opaque producer ID as historical attribution, but that ID grants no authority.
+
+## Atomic and idempotent import
+
+An implementation must validate the complete archive before applying it. Unsupported versions, unknown fields, broken references, malformed values, and conflicting IDs must fail without changing durable state.
+
+Import is atomic. Retrying the exact same archive returns the existing scope without adding records. The new scope token is returned only when the import is first applied. Operators must save it immediately.
+
+The reference runtime retains the metadata-only import marker so retries remain idempotent after normal event retention.
+
+The initial archive identifier is:
+
+```text
+format: october-bus.scope
+version: 1
+```
+
+New archive versions require an explicit reader implementation. Readers must reject versions they do not support.

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -7,7 +7,7 @@ The reference transport is JSON over HTTP. The local runtime listens on loopback
 - Base URL example: `http://127.0.0.1:4765`
 - Authenticated requests use `Authorization: Bearer <token>`.
 - Request bodies contain one JSON value and reject unknown fields.
-- Request bodies are limited to 1 MiB.
+- Request bodies are limited to 1 MiB. Scope archive imports are limited to 64 MiB.
 - Responses set `Content-Type: application/json` and `Cache-Control: no-store`.
 - Identifiers in paths are URL-escaped.
 
@@ -38,6 +38,8 @@ Failures use:
 | --- | --- | --- | --- |
 | `GET` | `/health` | None | Runtime health and protocol version |
 | `POST` | `/v1/admin/shutdown` | Admin | Accepted shutdown request |
+| `GET` | `/v1/admin/scopes/{scopeId}/export` | Admin | Portable scope archive |
+| `POST` | `/v1/admin/scopes/import` | Admin | Imported scope and one-time scope token |
 | `POST` | `/v1/scopes` | Admin | New scope ID and scope token |
 | `POST` | `/v1/agents` | Scope | New execution identity, lease, and agent token |
 | `GET` | `/v1/agents` | Scope | Agents in the scope |
@@ -107,6 +109,8 @@ Agent Card publications are absent by default. A scope owner publishes one regis
 `POST /outputs/{streamId}/values` accepts `contentType`, `value`, and an optional URI reference. Agent credentials require an explicit publisher grant. Scoped output credentials require `publish` permission. `GET /outputs/{streamId}/values?after=0&limit=50` returns ordered values after the cursor. The limit is 1 through 100. Clients use `nextSequence` as their next cursor and rebuild from the latest value when `resyncRequired` is true.
 
 Output credentials are bearer credentials and MUST be sent in the `Authorization` header. Credentials in query strings are not accepted. Browser CORS policy is deployment configuration rather than part of the protocol.
+
+Scope export and import use the archive rules in [archives.md](archives.md). Export rejects a scope with an active agent execution. Import validates and applies the full archive in one transaction. A successful retry returns `imported=false` and does not return the original one-time scope token again.
 
 Request and result shapes are defined in [protocol.schema.json](schemas/protocol.schema.json). Consumers can reference individual definitions with a fragment such as:
 

--- a/spec/0.1/schemas/scope-archive.schema.json
+++ b/spec/0.1/schemas/scope-archive.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/october-dev/october-bus/spec/0.1/schemas/scope-archive.schema.json",
+  "title": "October Bus portable scope archive 1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "version", "exportedAt", "scope", "agents", "links", "messages", "tasks", "taskProgress", "escalations", "agentCardPublications", "outputStreams", "outputValues"],
+  "properties": {
+    "format": { "const": "october-bus.scope" },
+    "version": { "const": 1 },
+    "exportedAt": { "$ref": "#/$defs/instant" },
+    "scope": { "$ref": "#/$defs/scope" },
+    "agents": { "type": "array", "items": { "$ref": "#/$defs/agent" } },
+    "links": { "type": "array", "items": { "$ref": "#/$defs/link" } },
+    "messages": { "type": "array", "items": { "$ref": "#/$defs/message" } },
+    "tasks": { "type": "array", "items": { "$ref": "#/$defs/task" } },
+    "taskProgress": { "type": "array", "items": { "$ref": "#/$defs/taskProgress" } },
+    "escalations": { "type": "array", "items": { "$ref": "#/$defs/escalation" } },
+    "agentCardPublications": { "type": "array", "items": { "$ref": "#/$defs/agentCard" } },
+    "outputStreams": { "type": "array", "items": { "$ref": "#/$defs/outputStream" } },
+    "outputValues": { "type": "array", "items": { "$ref": "#/$defs/outputValue" } }
+  },
+  "$defs": {
+    "identifier": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$" },
+    "instant": { "type": "string", "format": "date-time" },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "description": { "type": "string", "maxLength": 512 }
+      }
+    },
+    "contextItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "title"],
+      "properties": {
+        "kind": { "type": "string", "enum": ["text", "file", "url", "reference"] },
+        "title": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "text": { "type": "string", "maxLength": 65536 },
+        "uri": { "type": "string", "maxLength": 4096 },
+        "mediaType": { "type": "string" }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "createdAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "createdAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "displayName", "capabilities", "registeredAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "displayName": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "capabilities": { "type": "array", "maxItems": 64, "items": { "$ref": "#/$defs/capability" } },
+        "registeredAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["left", "right", "createdAt"],
+      "properties": {
+        "left": { "$ref": "#/$defs/identifier" },
+        "right": { "$ref": "#/$defs/identifier" },
+        "createdAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "message": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "from", "to", "mode", "body", "context", "state", "createdAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "from": { "$ref": "#/$defs/identifier" },
+        "to": { "$ref": "#/$defs/identifier" },
+        "mode": { "type": "string", "enum": ["notify", "request", "response"] },
+        "body": { "type": "string", "minLength": 1, "maxLength": 65536 },
+        "context": { "type": "array", "maxItems": 32, "items": { "$ref": "#/$defs/contextItem" } },
+        "responseTo": { "$ref": "#/$defs/identifier" },
+        "idempotencyKey": { "type": "string", "maxLength": 256 },
+        "state": { "type": "string", "enum": ["queued", "delivered", "acknowledged", "expired"] },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "expiresAt": { "$ref": "#/$defs/instant" },
+        "deliveredAt": { "$ref": "#/$defs/instant" },
+        "acknowledgedAt": { "$ref": "#/$defs/instant" },
+        "repliedAt": { "$ref": "#/$defs/instant" },
+        "responseMessageId": { "$ref": "#/$defs/identifier" }
+      },
+      "allOf": [
+        { "if": { "properties": { "mode": { "const": "response" } }, "required": ["mode"] }, "then": { "required": ["responseTo"] } },
+        { "if": { "properties": { "mode": { "enum": ["notify", "request"] } }, "required": ["mode"] }, "then": { "not": { "required": ["responseTo"] } } }
+      ]
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "description", "createdBy", "status", "dependencies", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "title": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "description": { "type": "string", "maxLength": 16384 },
+        "createdBy": { "oneOf": [{ "$ref": "#/$defs/identifier" }, { "type": "null" }] },
+        "claimedBy": { "$ref": "#/$defs/identifier" },
+        "status": { "type": "string", "enum": ["open", "done"] },
+        "dependencies": { "type": "array", "maxItems": 128, "items": { "$ref": "#/$defs/identifier" } },
+        "note": { "type": "string", "maxLength": 16384 },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      },
+      "allOf": [
+        { "if": { "properties": { "status": { "const": "done" } }, "required": ["status"] }, "then": { "required": ["claimedBy"] } },
+        { "if": { "properties": { "status": { "const": "open" } }, "required": ["status"] }, "then": { "not": { "required": ["claimedBy"] } } }
+      ]
+    },
+    "taskProgress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["taskId", "sequence", "agentId", "kind", "text", "createdAt"],
+      "properties": {
+        "taskId": { "$ref": "#/$defs/identifier" },
+        "sequence": { "type": "integer", "minimum": 1 },
+        "agentId": { "$ref": "#/$defs/identifier" },
+        "kind": { "type": "string", "enum": ["progress", "note", "blocker"] },
+        "text": { "type": "string", "minLength": 1, "maxLength": 4000 },
+        "createdAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "escalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "agentId", "question", "options", "status", "createdAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "agentId": { "$ref": "#/$defs/identifier" },
+        "question": { "type": "string", "minLength": 1, "maxLength": 4000 },
+        "options": { "type": "array", "maxItems": 4, "items": { "type": "string", "minLength": 1, "maxLength": 256 } },
+        "status": { "type": "string", "enum": ["pending", "resolved", "cancelled"] },
+        "answer": { "type": "string" },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "resolvedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "agentCard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "agentId", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "agentId": { "$ref": "#/$defs/identifier" },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "outputStream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "retentionLimit", "currentSequence", "minimumCursor", "publisherAgentIds", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "name": { "$ref": "#/$defs/identifier" },
+        "retentionLimit": { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "currentSequence": { "type": "integer", "minimum": 0 },
+        "minimumCursor": { "type": "integer", "minimum": 0 },
+        "publisherAgentIds": { "type": "array", "maxItems": 128, "items": { "$ref": "#/$defs/identifier" } },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "outputReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri"],
+      "properties": {
+        "uri": { "type": "string", "format": "uri", "maxLength": 4096 },
+        "title": { "type": "string", "maxLength": 512 }
+      }
+    },
+    "outputValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["streamId", "sequence", "producerType", "producerId", "contentType", "value", "createdAt"],
+      "properties": {
+        "streamId": { "$ref": "#/$defs/identifier" },
+        "sequence": { "type": "integer", "minimum": 1 },
+        "producerType": { "type": "string", "enum": ["agent", "principal"] },
+        "producerId": { "$ref": "#/$defs/identifier" },
+        "contentType": { "type": "string", "enum": ["text/plain", "application/json"] },
+        "value": {},
+        "reference": { "$ref": "#/$defs/outputReference" },
+        "createdAt": { "$ref": "#/$defs/instant" }
+      }
+    }
+  }
+}

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -211,6 +211,32 @@ func TestProtocolSchemas(t *testing.T) {
 	requireValid(t, prune, map[string]any{"before": "2026-08-01T00:00:00Z", "execute": true})
 }
 
+func TestPortableScopeArchiveSchema(t *testing.T) {
+	schema := resolvedSchema(t, filepath.Join("0.1", "schemas", "scope-archive.schema.json"), "")
+	archive := bus.ScopeArchive{
+		Format: bus.ScopeArchiveFormat, Version: bus.ScopeArchiveVersion,
+		ExportedAt: "2026-09-02T00:00:00Z",
+		Scope:      bus.ArchivedScope{ID: "project", CreatedAt: "2026-09-01T00:00:00Z"},
+		Agents: []bus.ArchivedAgent{{
+			ID: "reviewer", DisplayName: "Reviewer", Capabilities: []bus.AgentCapability{{Name: "review"}},
+			RegisteredAt: "2026-09-01T00:00:00Z", UpdatedAt: "2026-09-01T00:00:01Z",
+		}},
+		Links:                 []bus.ArchivedPeerLink{},
+		Messages:              []bus.ArchivedMessage{},
+		Tasks:                 []bus.ArchivedTask{},
+		TaskProgress:          []bus.ArchivedTaskProgress{},
+		Escalations:           []bus.ArchivedEscalation{},
+		AgentCardPublications: []bus.ArchivedAgentCard{},
+		OutputStreams:         []bus.ArchivedOutputStream{},
+		OutputValues:          []bus.ArchivedOutputValue{},
+	}
+	value := jsonValue(t, archive)
+	requireValid(t, schema, value)
+	object := value.(map[string]any)
+	object["scopeToken"] = "must-not-be-portable"
+	requireInvalid(t, schema, object)
+}
+
 func TestAdapterManifestsMatchSchema(t *testing.T) {
 	schema := resolvedSchema(t, filepath.Join("0.1", "schemas", "adapter-manifest.schema.json"), "")
 	paths, err := filepath.Glob(filepath.Join("..", "adapters", "*", "adapter.json"))


### PR DESCRIPTION
## Summary

- add a versioned JSON archive for durable scope state
- exclude credentials, leases, reservations, and execution authority
- restore transient work into safe offline and open states
- add atomic retry-safe import with admin API, CLI, Go, and TypeScript support
- document backup, restore, migration, and archive security
- add archive coverage to the local runtime conformance profile

Closes #29