### PR TITLE
Add durable A2A task correlations

### DIFF
--- a/bus/a2a_tasks.go
+++ b/bus/a2a_tasks.go
@@ -1,0 +1,318 @@
+package bus
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+)
+
+const a2aTaskColumns = `task_id,context_id,principal_id,publication_id,target_agent_id,state,created_at,updated_at`
+
+type a2aTaskQuery interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func scanA2ATask(row rowScanner) (A2ATaskCorrelation, error) {
+	var task A2ATaskCorrelation
+	var createdAt, updatedAt int64
+	err := row.Scan(&task.ID, &task.ContextID, &task.PrincipalID, &task.PublicationID, &task.TargetAgentID, &task.State, &createdAt, &updatedAt)
+	task.CreatedAt, task.UpdatedAt = instant(createdAt), instant(updatedAt)
+	task.Messages = []A2AMessageCorrelation{}
+	return task, err
+}
+
+func loadA2ATask(ctx context.Context, query a2aTaskQuery, principalID, taskID string) (A2ATaskCorrelation, error) {
+	task, err := scanA2ATask(query.QueryRowContext(ctx, `SELECT `+a2aTaskColumns+` FROM a2a_tasks WHERE principal_id=? AND task_id=?`, principalID, taskID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return A2ATaskCorrelation{}, Errorf(CodeNotFound, "A2A task was not found")
+	}
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	rows, err := query.QueryContext(ctx, `SELECT client_message_id,bus_request_message_id,bus_response_message_id,created_at,updated_at FROM a2a_message_correlations WHERE principal_id=? AND task_id=? ORDER BY created_at,client_message_id`, principalID, taskID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var correlation A2AMessageCorrelation
+		var responseID sql.NullString
+		var createdAt, updatedAt int64
+		if err := rows.Scan(&correlation.ClientMessageID, &correlation.BusRequestMessageID, &responseID, &createdAt, &updatedAt); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		correlation.BusResponseMessageID = responseID.String
+		correlation.CreatedAt, correlation.UpdatedAt = instant(createdAt), instant(updatedAt)
+		task.Messages = append(task.Messages, correlation)
+	}
+	return task, rows.Err()
+}
+
+func transitionA2ATaskForMessage(ctx context.Context, tx *sql.Tx, scopeID, messageID string, next func(A2ATaskState) (A2ATaskState, bool), now int64) error {
+	var taskID, publicationID string
+	var current A2ATaskState
+	err := tx.QueryRowContext(ctx, `SELECT tasks.task_id,tasks.publication_id,tasks.state FROM a2a_tasks AS tasks JOIN a2a_message_correlations AS correlations ON correlations.task_id=tasks.task_id WHERE tasks.scope_id=? AND correlations.bus_request_message_id=?`, scopeID, messageID).Scan(&taskID, &publicationID, &current)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	state, changed := next(current)
+	if !changed || state == current {
+		return nil
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE a2a_tasks SET state=?,updated_at=? WHERE scope_id=? AND task_id=? AND state=?`, state, now, scopeID, taskID, current)
+	if err != nil {
+		return err
+	}
+	count, _ := result.RowsAffected()
+	if count != 1 {
+		return Errorf(CodeConflict, "A2A task changed concurrently")
+	}
+	return appendEvent(ctx, tx, scopeID, "a2a.task_state_changed", taskID, eventAttributes("publicationId", publicationID, "state", string(state)), now)
+}
+
+func a2aMessageRequestHash(input AcceptA2AMessageInput) string {
+	data, _ := json.Marshal(input)
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func (s *Store) AcceptA2AMessage(ctx context.Context, principal A2APrincipal, input AcceptA2AMessageInput) (A2ATaskCorrelation, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	defer tx.Rollback()
+	requestHash := a2aMessageRequestHash(input)
+	var existingTaskID, existingHash string
+	err = tx.QueryRowContext(ctx, `SELECT task_id,request_hash FROM a2a_message_correlations WHERE principal_id=? AND client_message_id=?`, principal.ID, input.ClientMessageID).Scan(&existingTaskID, &existingHash)
+	if err == nil {
+		if existingHash != requestHash {
+			return A2ATaskCorrelation{}, Errorf(CodeConflict, "A2A client message ID was already used with different content")
+		}
+		task, err := loadA2ATask(ctx, tx, principal.ID, existingTaskID)
+		if err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		return task, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return A2ATaskCorrelation{}, err
+	}
+	var targetAgentID string
+	err = tx.QueryRowContext(ctx, `SELECT agent_id FROM a2a_publications WHERE scope_id=? AND publication_id=? AND enabled=1`, principal.ScopeID, principal.PublicationID).Scan(&targetAgentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return A2ATaskCorrelation{}, Errorf(CodeUnauthenticated, "Invalid scoped credential")
+	}
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	now := nowMillis()
+	taskID := input.TaskID
+	contextID := input.ContextID
+	if taskID == "" {
+		taskID, err = randomID("a2at_")
+		if err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		if contextID == "" {
+			contextID, err = randomID("a2ac_")
+			if err != nil {
+				return A2ATaskCorrelation{}, err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO a2a_tasks(task_id,scope_id,context_id,principal_id,publication_id,target_agent_id,state,created_at,updated_at) VALUES(?,?,?,?,?,?,'submitted',?,?)`,
+			taskID, principal.ScopeID, contextID, principal.ID, principal.PublicationID, targetAgentID, now, now); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		if err := appendEvent(ctx, tx, principal.ScopeID, "a2a.task_created", taskID, eventAttributes("publicationId", principal.PublicationID, "agentId", targetAgentID, "state", string(A2ATaskSubmitted)), now); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+	} else {
+		var storedContextID, storedPublicationID, storedTargetAgentID string
+		var state A2ATaskState
+		err := tx.QueryRowContext(ctx, `SELECT context_id,publication_id,target_agent_id,state FROM a2a_tasks WHERE principal_id=? AND task_id=?`, principal.ID, taskID).Scan(&storedContextID, &storedPublicationID, &storedTargetAgentID, &state)
+		if errors.Is(err, sql.ErrNoRows) {
+			return A2ATaskCorrelation{}, Errorf(CodeNotFound, "A2A task was not found")
+		}
+		if err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		if storedPublicationID != principal.PublicationID || storedTargetAgentID != targetAgentID {
+			return A2ATaskCorrelation{}, Errorf(CodeNotFound, "A2A task was not found")
+		}
+		if a2aTaskTerminal(state) {
+			return A2ATaskCorrelation{}, Errorf(CodeConflict, "A2A task is already terminal")
+		}
+		if state != A2ATaskInputRequired {
+			return A2ATaskCorrelation{}, Errorf(CodeConflict, "A2A task is not waiting for input")
+		}
+		if contextID != "" && contextID != storedContextID {
+			return A2ATaskCorrelation{}, Errorf(CodeConflict, "A2A context ID does not match the task")
+		}
+		contextID = storedContextID
+		if _, err := tx.ExecContext(ctx, `UPDATE a2a_tasks SET state='working',updated_at=? WHERE principal_id=? AND task_id=? AND state='input-required'`, now, principal.ID, taskID); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		if err := appendEvent(ctx, tx, principal.ScopeID, "a2a.task_state_changed", taskID, eventAttributes("publicationId", principal.PublicationID, "state", string(A2ATaskWorking)), now); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+	}
+	message, err := sendMessageTx(ctx, tx, principal.ScopeID, MessageParticipantA2APrincipal, principal.ID, SendMessageInput{
+		To: targetAgentID, Body: input.Body, Mode: MessageRequest, IdempotencyKey: input.ClientMessageID, Context: []ContextItem{},
+	})
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO a2a_message_correlations(principal_id,client_message_id,task_id,request_hash,bus_request_message_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?)`,
+		principal.ID, input.ClientMessageID, taskID, requestHash, message.ID, now, now); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE a2a_tasks SET updated_at=? WHERE principal_id=? AND task_id=?`, now, principal.ID, taskID); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := appendEvent(ctx, tx, principal.ScopeID, "a2a.message_accepted", taskID, eventAttributes("publicationId", principal.PublicationID, "agentId", targetAgentID, "busMessageId", message.ID), now); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	task, err := loadA2ATask(ctx, tx, principal.ID, taskID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	return task, nil
+}
+
+func (s *Store) A2ATask(ctx context.Context, principal A2APrincipal, taskID string) (A2ATaskCorrelation, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	defer tx.Rollback()
+	if err := expireMessages(ctx, tx, principal.ScopeID, nowMillis()); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	task, err := loadA2ATask(ctx, tx, principal.ID, taskID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	return task, nil
+}
+
+func a2aTaskTerminal(state A2ATaskState) bool {
+	switch state {
+	case A2ATaskCompleted, A2ATaskFailed, A2ATaskCanceled, A2ATaskRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func validA2ATaskState(state A2ATaskState) bool {
+	switch state {
+	case A2ATaskSubmitted, A2ATaskWorking, A2ATaskInputRequired, A2ATaskCompleted, A2ATaskFailed, A2ATaskCanceled, A2ATaskRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func validA2ATaskTransition(from, to A2ATaskState) bool {
+	if from == to {
+		return true
+	}
+	if a2aTaskTerminal(from) {
+		return false
+	}
+	switch from {
+	case A2ATaskSubmitted:
+		return to == A2ATaskWorking || to == A2ATaskInputRequired || a2aTaskTerminal(to)
+	case A2ATaskWorking:
+		return to == A2ATaskInputRequired || a2aTaskTerminal(to)
+	case A2ATaskInputRequired:
+		return to == A2ATaskWorking || a2aTaskTerminal(to)
+	default:
+		return false
+	}
+}
+
+func (s *Store) SetA2ATaskState(ctx context.Context, principal A2APrincipal, taskID string, state A2ATaskState) (A2ATaskCorrelation, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	defer tx.Rollback()
+	task, err := loadA2ATask(ctx, tx, principal.ID, taskID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if !validA2ATaskTransition(task.State, state) {
+		return A2ATaskCorrelation{}, Errorf(CodeConflict, "A2A task state transition is invalid")
+	}
+	if task.State != state {
+		now := nowMillis()
+		if _, err := tx.ExecContext(ctx, `UPDATE a2a_tasks SET state=?,updated_at=? WHERE principal_id=? AND task_id=?`, state, now, principal.ID, taskID); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+		if err := appendEvent(ctx, tx, principal.ScopeID, "a2a.task_state_changed", taskID, eventAttributes("publicationId", principal.PublicationID, "state", string(state)), now); err != nil {
+			return A2ATaskCorrelation{}, err
+		}
+	}
+	task, err = loadA2ATask(ctx, tx, principal.ID, taskID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	return task, nil
+}
+
+func (r *Runtime) AcceptA2AMessage(ctx context.Context, credential, publicationID string, input AcceptA2AMessageInput) (A2ATaskCorrelation, error) {
+	principal, err := r.AuthenticateA2APrincipal(ctx, credential, publicationID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := validateIdentity(input.TaskID, "taskId", true); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := validateIdentity(input.ContextID, "contextId", true); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := validateIdentity(input.ClientMessageID, "clientMessageId", false); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := validateText(input.Body, "body", 65536, false); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	task, err := r.store.AcceptA2AMessage(ctx, principal, input)
+	if err == nil {
+		r.signals.notify(signalKey{scopeID: principal.ScopeID, consumerID: task.TargetAgentID})
+		r.notifyScope(principal.ScopeID)
+	}
+	return task, err
+}
+
+func (r *Runtime) A2ATask(ctx context.Context, credential, publicationID, taskID string) (A2ATaskCorrelation, error) {
+	principal, err := r.AuthenticateA2APrincipal(ctx, credential, publicationID)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if err := validateIdentity(taskID, "taskId", false); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	return r.store.A2ATask(ctx, principal, taskID)
+}

--- a/bus/a2a_tasks_test.go
+++ b/bus/a2a_tasks_test.go
@@ -1,0 +1,152 @@
+package bus
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func setupA2APrincipal(t *testing.T, agents testAgents) (agentCardPublication, IssuedA2APrincipal) {
+	t.Helper()
+	ctx := context.Background()
+	publication, err := agents.runtime.CreateAgentCardPublication(ctx, agents.scope.ScopeToken, PublishAgentCardInput{AgentID: agents.reviewer.AgentID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal, err := agents.runtime.CreateA2APrincipal(ctx, agents.scope.ScopeToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Remote caller"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return publication, principal
+}
+
+func TestA2ATaskCorrelationIsDurableAndIdempotent(t *testing.T) {
+	database := filepath.Join(t.TempDir(), "bus.db")
+	agents := setupAgents(t, database)
+	ctx := context.Background()
+	publication, issued := setupA2APrincipal(t, agents)
+	input := AcceptA2AMessageInput{ClientMessageID: "remote-message-1", Body: "Review this change"}
+	task, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.ID == "" || task.ContextID == "" || task.State != A2ATaskSubmitted || task.PrincipalID != issued.Principal.ID || len(task.Messages) != 1 {
+		t.Fatalf("unexpected A2A task: %#v", task)
+	}
+	correlation := task.Messages[0]
+	if correlation.ClientMessageID != input.ClientMessageID || correlation.BusRequestMessageID == "" || correlation.BusResponseMessageID != "" {
+		t.Fatalf("unexpected message correlation: %#v", correlation)
+	}
+	retry, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, input)
+	if err != nil || retry.ID != task.ID || retry.Messages[0].BusRequestMessageID != correlation.BusRequestMessageID {
+		t.Fatalf("idempotent retry created different work: %#v, %v", retry, err)
+	}
+	input.Body = "Review something else"
+	_, err = agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, input)
+	requireCode(t, err, CodeConflict)
+	if err := agents.runtime.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := Open(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restarted.Close()
+	stored, err := restarted.A2ATask(ctx, issued.Credential, publication.ID, task.ID)
+	if err != nil || stored.ID != task.ID || len(stored.Messages) != 1 || stored.Messages[0].BusRequestMessageID != correlation.BusRequestMessageID {
+		t.Fatalf("correlation did not survive restart: %#v, %v", stored, err)
+	}
+}
+
+func TestA2ATaskTracksBusDeliveryAndResponse(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, issued := setupA2APrincipal(t, agents)
+	task, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "remote-message-1", Body: "Review this change"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
+	if err != nil || reservation == nil || len(reservation.Messages) != 1 {
+		t.Fatalf("unexpected inbox: %#v, %v", reservation, err)
+	}
+	inbound := reservation.Messages[0]
+	if inbound.FromKind != MessageParticipantA2APrincipal || inbound.From != issued.Principal.ID || inbound.ToKind != MessageParticipantAgent {
+		t.Fatalf("unexpected A2A Bus message: %#v", inbound)
+	}
+	if _, err := agents.runtime.CommitInbox(ctx, agents.reviewerToken, reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+	working, err := agents.runtime.A2ATask(ctx, issued.Credential, publication.ID, task.ID)
+	if err != nil || working.State != A2ATaskWorking {
+		t.Fatalf("delivery did not advance task: %#v, %v", working, err)
+	}
+	reply, err := agents.runtime.SendMessage(ctx, agents.reviewerToken, SendMessageInput{
+		To: issued.Principal.ID, Mode: MessageResponse, ResponseTo: inbound.ID, Body: "Found one issue", IdempotencyKey: "review-reply",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply.State != DeliveryAcknowledged {
+		t.Fatalf("A2A response was not committed durably: %#v", reply)
+	}
+	completed, err := agents.runtime.A2ATask(ctx, issued.Credential, publication.ID, task.ID)
+	if err != nil || completed.State != A2ATaskCompleted || completed.Messages[0].BusResponseMessageID != reply.MessageID {
+		t.Fatalf("response did not complete task: %#v, %v", completed, err)
+	}
+}
+
+func TestA2ATaskAllowsFollowUpOnlyBeforeTerminalState(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, issued := setupA2APrincipal(t, agents)
+	task, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "turn-1", Body: "Start"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal, err := agents.runtime.AuthenticateA2APrincipal(ctx, issued.Credential, publication.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.store.SetA2ATaskState(ctx, principal, task.ID, A2ATaskInputRequired); err != nil {
+		t.Fatal(err)
+	}
+	followUp, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{
+		TaskID: task.ID, ContextID: task.ContextID, ClientMessageID: "turn-2", Body: "Here is the answer",
+	})
+	if err != nil || followUp.State != A2ATaskWorking || len(followUp.Messages) != 2 {
+		t.Fatalf("follow-up was not correlated: %#v, %v", followUp, err)
+	}
+	if _, err := agents.runtime.store.SetA2ATaskState(ctx, principal, task.ID, A2ATaskCanceled); err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{
+		TaskID: task.ID, ClientMessageID: "turn-3", Body: "Too late",
+	})
+	requireCode(t, err, CodeConflict)
+}
+
+func TestA2ATaskIsIsolatedByPrincipal(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, owner := setupA2APrincipal(t, agents)
+	other, err := agents.runtime.CreateA2APrincipal(ctx, agents.scope.ScopeToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Other caller"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := agents.runtime.AcceptA2AMessage(ctx, owner.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "private-turn", Body: "Private work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.A2ATask(ctx, other.Credential, publication.ID, task.ID)
+	requireCode(t, err, CodeNotFound)
+	otherPrincipal, err := agents.runtime.AuthenticateA2APrincipal(ctx, other.Credential, publication.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.store.SetA2ATaskState(ctx, otherPrincipal, task.ID, A2ATaskCanceled)
+	requireCode(t, err, CodeNotFound)
+}

--- a/bus/archive.go
+++ b/bus/archive.go
@@ -9,12 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
 const (
 	ScopeArchiveFormat  = "october-bus.scope"
-	ScopeArchiveVersion = 1
+	ScopeArchiveVersion = 2
 )
 
 type ScopeArchive struct {
@@ -29,6 +30,8 @@ type ScopeArchive struct {
 	TaskProgress          []ArchivedTaskProgress `json:"taskProgress"`
 	Escalations           []ArchivedEscalation   `json:"escalations"`
 	AgentCardPublications []ArchivedAgentCard    `json:"agentCardPublications"`
+	A2ATasks              []ArchivedA2ATask      `json:"a2aTasks"`
+	A2AMessages           []ArchivedA2AMessage   `json:"a2aMessages"`
 	OutputStreams         []ArchivedOutputStream `json:"outputStreams"`
 	OutputValues          []ArchivedOutputValue  `json:"outputValues"`
 }
@@ -53,21 +56,44 @@ type ArchivedPeerLink struct {
 }
 
 type ArchivedMessage struct {
-	ID                string        `json:"id"`
-	From              string        `json:"from"`
-	To                string        `json:"to"`
-	Mode              MessageMode   `json:"mode"`
-	Body              string        `json:"body"`
-	Context           []ContextItem `json:"context"`
-	ResponseTo        string        `json:"responseTo,omitempty"`
-	IdempotencyKey    string        `json:"idempotencyKey,omitempty"`
-	State             DeliveryState `json:"state"`
-	CreatedAt         string        `json:"createdAt"`
-	ExpiresAt         string        `json:"expiresAt,omitempty"`
-	DeliveredAt       string        `json:"deliveredAt,omitempty"`
-	AcknowledgedAt    string        `json:"acknowledgedAt,omitempty"`
-	RepliedAt         string        `json:"repliedAt,omitempty"`
-	ResponseMessageID string        `json:"responseMessageId,omitempty"`
+	ID                string                 `json:"id"`
+	From              string                 `json:"from"`
+	FromKind          MessageParticipantKind `json:"fromKind"`
+	To                string                 `json:"to"`
+	ToKind            MessageParticipantKind `json:"toKind"`
+	Mode              MessageMode            `json:"mode"`
+	Body              string                 `json:"body"`
+	Context           []ContextItem          `json:"context"`
+	ResponseTo        string                 `json:"responseTo,omitempty"`
+	IdempotencyKey    string                 `json:"idempotencyKey,omitempty"`
+	State             DeliveryState          `json:"state"`
+	CreatedAt         string                 `json:"createdAt"`
+	ExpiresAt         string                 `json:"expiresAt,omitempty"`
+	DeliveredAt       string                 `json:"deliveredAt,omitempty"`
+	AcknowledgedAt    string                 `json:"acknowledgedAt,omitempty"`
+	RepliedAt         string                 `json:"repliedAt,omitempty"`
+	ResponseMessageID string                 `json:"responseMessageId,omitempty"`
+}
+
+type ArchivedA2ATask struct {
+	ID            string       `json:"id"`
+	ContextID     string       `json:"contextId"`
+	PrincipalID   string       `json:"principalId"`
+	PublicationID string       `json:"publicationId"`
+	TargetAgentID string       `json:"targetAgentId"`
+	State         A2ATaskState `json:"state"`
+	CreatedAt     string       `json:"createdAt"`
+	UpdatedAt     string       `json:"updatedAt"`
+}
+
+type ArchivedA2AMessage struct {
+	PrincipalID          string `json:"principalId"`
+	ClientMessageID      string `json:"clientMessageId"`
+	TaskID               string `json:"taskId"`
+	BusRequestMessageID  string `json:"busRequestMessageId"`
+	BusResponseMessageID string `json:"busResponseMessageId,omitempty"`
+	CreatedAt            string `json:"createdAt"`
+	UpdatedAt            string `json:"updatedAt"`
 }
 
 type ArchivedTask struct {
@@ -194,8 +220,16 @@ func queryArchivedLinks(ctx context.Context, tx *sql.Tx, scopeID string) ([]Arch
 	return values, rows.Err()
 }
 
+func archivedA2APrincipalID(scopeID, principalID string) string {
+	if strings.HasPrefix(principalID, "a2ap_") {
+		return principalID
+	}
+	digest := sha256.Sum256([]byte(scopeID + "\x00" + principalID))
+	return "a2ap_" + hex.EncodeToString(digest[:16])
+}
+
 func queryArchivedMessages(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedMessage, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_agent,to_agent,mode,body,context_json,response_to,idempotency_key,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id FROM messages WHERE scope_id=? ORDER BY created_at,message_id`, scopeID)
+	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_kind,from_id,to_kind,to_id,mode,body,context_json,response_to,idempotency_key,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id FROM messages WHERE scope_id=? ORDER BY created_at,message_id`, scopeID)
 	if err != nil {
 		return nil, err
 	}
@@ -207,8 +241,14 @@ func queryArchivedMessages(ctx context.Context, tx *sql.Tx, scopeID string) ([]A
 		var responseTo, idempotencyKey, responseMessageID sql.NullString
 		var createdAt int64
 		var expiresAt, deliveredAt, acknowledgedAt, repliedAt sql.NullInt64
-		if err := rows.Scan(&value.ID, &value.From, &value.To, &value.Mode, &value.Body, &contextJSON, &responseTo, &idempotencyKey, &value.State, &createdAt, &expiresAt, &deliveredAt, &acknowledgedAt, &repliedAt, &responseMessageID); err != nil {
+		if err := rows.Scan(&value.ID, &value.FromKind, &value.From, &value.ToKind, &value.To, &value.Mode, &value.Body, &contextJSON, &responseTo, &idempotencyKey, &value.State, &createdAt, &expiresAt, &deliveredAt, &acknowledgedAt, &repliedAt, &responseMessageID); err != nil {
 			return nil, err
+		}
+		if value.FromKind == MessageParticipantA2APrincipal {
+			value.From = archivedA2APrincipalID(scopeID, value.From)
+		}
+		if value.ToKind == MessageParticipantA2APrincipal {
+			value.To = archivedA2APrincipalID(scopeID, value.To)
 		}
 		if err := json.Unmarshal([]byte(contextJSON), &value.Context); err != nil {
 			return nil, err
@@ -229,6 +269,49 @@ func queryArchivedMessages(ctx context.Context, tx *sql.Tx, scopeID string) ([]A
 		values = append(values, value)
 	}
 	return values, rows.Err()
+}
+
+func queryArchivedA2A(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedA2ATask, []ArchivedA2AMessage, error) {
+	taskRows, err := tx.QueryContext(ctx, `SELECT task_id,context_id,principal_id,publication_id,target_agent_id,state,created_at,updated_at FROM a2a_tasks WHERE scope_id=? ORDER BY created_at,task_id`, scopeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	tasks := []ArchivedA2ATask{}
+	for taskRows.Next() {
+		var task ArchivedA2ATask
+		var createdAt, updatedAt int64
+		if err := taskRows.Scan(&task.ID, &task.ContextID, &task.PrincipalID, &task.PublicationID, &task.TargetAgentID, &task.State, &createdAt, &updatedAt); err != nil {
+			taskRows.Close()
+			return nil, nil, err
+		}
+		task.PrincipalID = archivedA2APrincipalID(scopeID, task.PrincipalID)
+		task.CreatedAt, task.UpdatedAt = instant(createdAt), instant(updatedAt)
+		tasks = append(tasks, task)
+	}
+	if err := taskRows.Err(); err != nil {
+		taskRows.Close()
+		return nil, nil, err
+	}
+	taskRows.Close()
+	messageRows, err := tx.QueryContext(ctx, `SELECT correlations.principal_id,correlations.client_message_id,correlations.task_id,correlations.bus_request_message_id,correlations.bus_response_message_id,correlations.created_at,correlations.updated_at FROM a2a_message_correlations AS correlations JOIN a2a_tasks AS tasks ON tasks.task_id=correlations.task_id WHERE tasks.scope_id=? ORDER BY correlations.created_at,correlations.client_message_id`, scopeID)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer messageRows.Close()
+	messages := []ArchivedA2AMessage{}
+	for messageRows.Next() {
+		var message ArchivedA2AMessage
+		var responseID sql.NullString
+		var createdAt, updatedAt int64
+		if err := messageRows.Scan(&message.PrincipalID, &message.ClientMessageID, &message.TaskID, &message.BusRequestMessageID, &responseID, &createdAt, &updatedAt); err != nil {
+			return nil, nil, err
+		}
+		message.PrincipalID = archivedA2APrincipalID(scopeID, message.PrincipalID)
+		message.BusResponseMessageID = responseID.String
+		message.CreatedAt, message.UpdatedAt = instant(createdAt), instant(updatedAt)
+		messages = append(messages, message)
+	}
+	return tasks, messages, messageRows.Err()
 }
 
 func queryArchivedTasks(ctx context.Context, tx *sql.Tx, scopeID string) ([]ArchivedTask, error) {
@@ -414,6 +497,9 @@ func (s *Store) ExportScope(ctx context.Context, scopeID string) (ScopeArchive, 
 	if archive.AgentCardPublications, err = queryArchivedAgentCards(ctx, tx, scopeID); err != nil {
 		return ScopeArchive{}, err
 	}
+	if archive.A2ATasks, archive.A2AMessages, err = queryArchivedA2A(ctx, tx, scopeID); err != nil {
+		return ScopeArchive{}, err
+	}
 	if archive.OutputStreams, archive.OutputValues, err = queryArchivedOutputs(ctx, tx, scopeID); err != nil {
 		return ScopeArchive{}, err
 	}
@@ -452,7 +538,7 @@ func validateArchive(archive *ScopeArchive) error {
 	if _, err := archiveTime(archive.Scope.CreatedAt, true); err != nil {
 		return err
 	}
-	if archive.Agents == nil || archive.Links == nil || archive.Messages == nil || archive.Tasks == nil || archive.TaskProgress == nil || archive.Escalations == nil || archive.AgentCardPublications == nil || archive.OutputStreams == nil || archive.OutputValues == nil {
+	if archive.Agents == nil || archive.Links == nil || archive.Messages == nil || archive.Tasks == nil || archive.TaskProgress == nil || archive.Escalations == nil || archive.AgentCardPublications == nil || archive.A2ATasks == nil || archive.A2AMessages == nil || archive.OutputStreams == nil || archive.OutputValues == nil {
 		return Errorf(CodeInvalidArgument, "Archive record collections are required")
 	}
 	agents := map[string]bool{}
@@ -507,8 +593,20 @@ func validateArchive(archive *ScopeArchive) error {
 			return Errorf(CodeInvalidArgument, "Archive contains a duplicate message id")
 		}
 		messages[message.ID] = message
-		if !agents[message.From] || !agents[message.To] {
+		if err := validateMessageParticipantKind(message.FromKind); err != nil {
+			return err
+		}
+		if err := validateMessageParticipantKind(message.ToKind); err != nil {
+			return err
+		}
+		if (message.FromKind == MessageParticipantAgent && !agents[message.From]) || (message.ToKind == MessageParticipantAgent && !agents[message.To]) {
 			return Errorf(CodeInvalidArgument, "Archive message refers to an unknown agent")
+		}
+		if err := requireArchiveID(message.From, "message.from"); err != nil {
+			return err
+		}
+		if err := requireArchiveID(message.To, "message.to"); err != nil {
+			return err
 		}
 		if err := validateMessageMode(message.Mode); err != nil {
 			return err
@@ -526,7 +624,7 @@ func validateArchive(archive *ScopeArchive) error {
 			return err
 		}
 		if message.IdempotencyKey != "" {
-			key := message.From + "\x00" + message.IdempotencyKey
+			key := string(message.FromKind) + "\x00" + message.From + "\x00" + message.IdempotencyKey
 			if idempotencyKeys[key] {
 				return Errorf(CodeInvalidArgument, "Archive contains a duplicate message idempotency key")
 			}
@@ -553,7 +651,7 @@ func validateArchive(archive *ScopeArchive) error {
 	for _, message := range archive.Messages {
 		if message.Mode == MessageResponse {
 			request := messages[message.ResponseTo]
-			if request == nil || request.Mode != MessageRequest || request.From != message.To || request.To != message.From || request.ResponseMessageID != message.ID || request.RepliedAt == "" {
+			if request == nil || request.Mode != MessageRequest || request.From != message.To || request.FromKind != message.ToKind || request.To != message.From || request.ToKind != message.FromKind || request.ResponseMessageID != message.ID || request.RepliedAt == "" {
 				return Errorf(CodeInvalidArgument, "Archive contains an invalid response correlation")
 			}
 		} else if message.ResponseTo != "" {
@@ -774,6 +872,56 @@ func validateArchive(archive *ScopeArchive) error {
 			return err
 		}
 	}
+	a2aTasks := map[string]ArchivedA2ATask{}
+	for _, task := range archive.A2ATasks {
+		if err := requireArchiveID(task.ID, "a2aTask.id"); err != nil {
+			return err
+		}
+		if err := requireArchiveID(task.ContextID, "a2aTask.contextId"); err != nil {
+			return err
+		}
+		if err := requireArchiveID(task.PrincipalID, "a2aTask.principalId"); err != nil {
+			return err
+		}
+		if a2aTasks[task.ID].ID != "" || !publications[task.PublicationID] || !agents[task.TargetAgentID] || !validA2ATaskState(task.State) {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid A2A task")
+		}
+		if _, err := archiveTime(task.CreatedAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(task.UpdatedAt, true); err != nil {
+			return err
+		}
+		a2aTasks[task.ID] = task
+	}
+	a2aMessageKeys := map[string]bool{}
+	for _, correlation := range archive.A2AMessages {
+		task, ok := a2aTasks[correlation.TaskID]
+		request := messages[correlation.BusRequestMessageID]
+		if !ok || task.PrincipalID != correlation.PrincipalID || request == nil || request.Mode != MessageRequest || request.FromKind != MessageParticipantA2APrincipal || request.From != correlation.PrincipalID || request.ToKind != MessageParticipantAgent || request.To != task.TargetAgentID {
+			return Errorf(CodeInvalidArgument, "Archive contains an invalid A2A message correlation")
+		}
+		if err := requireArchiveID(correlation.ClientMessageID, "a2aMessage.clientMessageId"); err != nil {
+			return err
+		}
+		key := correlation.PrincipalID + "\x00" + correlation.ClientMessageID
+		if a2aMessageKeys[key] {
+			return Errorf(CodeInvalidArgument, "Archive contains a duplicate A2A client message id")
+		}
+		a2aMessageKeys[key] = true
+		if correlation.BusResponseMessageID != "" {
+			response := messages[correlation.BusResponseMessageID]
+			if response == nil || request.ResponseMessageID != response.ID || response.ResponseTo != request.ID {
+				return Errorf(CodeInvalidArgument, "Archive contains an invalid A2A response correlation")
+			}
+		}
+		if _, err := archiveTime(correlation.CreatedAt, true); err != nil {
+			return err
+		}
+		if _, err := archiveTime(correlation.UpdatedAt, true); err != nil {
+			return err
+		}
+	}
 	streams := map[string]*ArchivedOutputStream{}
 	streamNames := map[string]bool{}
 	if len(archive.OutputStreams) > maxOutputStreams {
@@ -890,7 +1038,7 @@ func insertArchive(ctx context.Context, tx *sql.Tx, archive ScopeArchive, digest
 			expiresIn = expires - created
 		}
 		requestHash := messageRequestHash(SendMessageInput{To: message.To, Body: message.Body, ResponseTo: message.ResponseTo, ExpiresInMS: expiresIn}, message.Mode, contextJSON)
-		if _, err := tx.ExecContext(ctx, `INSERT INTO messages(message_id,scope_id,from_agent,to_agent,mode,body,context_json,response_to,idempotency_key,request_hash,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id) VALUES(?,?,?,?,?,?,?,NULL,?,?,?,?,?,?,?,?,?)`, message.ID, archive.Scope.ID, message.From, message.To, message.Mode, message.Body, contextJSON, nullableString(message.IdempotencyKey), requestHash, message.State, created, nullableInt64(expires), nullableInt64(delivered), nullableInt64(acknowledged), nullableInt64(replied), nullableString(message.ResponseMessageID)); err != nil {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO messages(message_id,scope_id,from_kind,from_id,to_kind,to_id,mode,body,context_json,response_to,idempotency_key,request_hash,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id) VALUES(?,?,?,?,?,?,?,?,?,NULL,?,?,?,?,?,?,?,?,?)`, message.ID, archive.Scope.ID, message.FromKind, message.From, message.ToKind, message.To, message.Mode, message.Body, contextJSON, nullableString(message.IdempotencyKey), requestHash, message.State, created, nullableInt64(expires), nullableInt64(delivered), nullableInt64(acknowledged), nullableInt64(replied), nullableString(message.ResponseMessageID)); err != nil {
 			return err
 		}
 	}
@@ -932,6 +1080,21 @@ func insertArchive(ctx context.Context, tx *sql.Tx, archive ScopeArchive, digest
 		created, _ := archiveTime(publication.CreatedAt, true)
 		updated, _ := archiveTime(publication.UpdatedAt, true)
 		if _, err := tx.ExecContext(ctx, `INSERT INTO a2a_publications(publication_id,scope_id,agent_id,enabled,created_at,updated_at) VALUES(?,?,?,0,?,?)`, publication.ID, archive.Scope.ID, publication.AgentID, created, updated); err != nil {
+			return err
+		}
+	}
+	for _, task := range archive.A2ATasks {
+		created, _ := archiveTime(task.CreatedAt, true)
+		updated, _ := archiveTime(task.UpdatedAt, true)
+		if _, err := tx.ExecContext(ctx, `INSERT INTO a2a_tasks(task_id,scope_id,context_id,principal_id,publication_id,target_agent_id,state,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?)`, task.ID, archive.Scope.ID, task.ContextID, task.PrincipalID, task.PublicationID, task.TargetAgentID, task.State, created, updated); err != nil {
+			return err
+		}
+	}
+	for _, correlation := range archive.A2AMessages {
+		created, _ := archiveTime(correlation.CreatedAt, true)
+		updated, _ := archiveTime(correlation.UpdatedAt, true)
+		requestHash := a2aMessageRequestHash(AcceptA2AMessageInput{TaskID: correlation.TaskID, ClientMessageID: correlation.ClientMessageID})
+		if _, err := tx.ExecContext(ctx, `INSERT INTO a2a_message_correlations(principal_id,client_message_id,task_id,request_hash,bus_request_message_id,bus_response_message_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?)`, correlation.PrincipalID, correlation.ClientMessageID, correlation.TaskID, requestHash, correlation.BusRequestMessageID, nullableString(correlation.BusResponseMessageID), created, updated); err != nil {
 			return err
 		}
 	}

--- a/bus/archive_test.go
+++ b/bus/archive_test.go
@@ -97,6 +97,10 @@ func TestPortableScopeArchiveRoundTripAndRetry(t *testing.T) {
 	if _, err := source.runtime.ClaimTask(ctx, source.reviewerToken, pendingTask.ID); err != nil {
 		t.Fatal(err)
 	}
+	a2aTask, err := source.runtime.AcceptA2AMessage(ctx, a2aPrincipal.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "portable-turn", Body: "Review after restore"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := source.runtime.ExportScope(ctx, source.scope.ScopeID); err == nil {
 		t.Fatal("active scope was exported")
@@ -121,7 +125,7 @@ func TestPortableScopeArchiveRoundTripAndRetry(t *testing.T) {
 	for _, message := range archive.Messages {
 		archivedMessages[message.ID] = message
 	}
-	if len(archive.Messages) != 3 || archivedMessages[request.MessageID].ResponseMessageID != reply.MessageID || archivedMessages[reply.MessageID].ResponseTo != request.MessageID {
+	if len(archive.Messages) != 4 || archivedMessages[request.MessageID].ResponseMessageID != reply.MessageID || archivedMessages[reply.MessageID].ResponseTo != request.MessageID {
 		t.Fatalf("messages were not preserved: %#v", archive.Messages)
 	}
 	if archivedMessages[pendingMessage.MessageID].State != DeliveryQueued {
@@ -134,7 +138,7 @@ func TestPortableScopeArchiveRoundTripAndRetry(t *testing.T) {
 	if len(archive.Tasks) != 2 || archivedTasks[pendingTask.ID].Status != "open" || archivedTasks[pendingTask.ID].ClaimedBy != "" {
 		t.Fatalf("active task claim was not made portable: %#v", archive.Tasks)
 	}
-	if len(archive.AgentCardPublications) != 1 || len(archive.OutputStreams) != 1 || len(archive.OutputValues) != 1 {
+	if len(archive.AgentCardPublications) != 1 || len(archive.A2ATasks) != 1 || archive.A2ATasks[0].ID != a2aTask.ID || len(archive.A2AMessages) != 1 || len(archive.OutputStreams) != 1 || len(archive.OutputValues) != 1 {
 		t.Fatalf("configuration and output history were not preserved: %#v", archive)
 	}
 
@@ -168,6 +172,16 @@ func TestPortableScopeArchiveRoundTripAndRetry(t *testing.T) {
 	}
 	if registered.ExecutionID == source.planner.ExecutionID {
 		t.Fatal("source execution authority survived import")
+	}
+	var restoredA2ATasks, restoredA2AMessages int
+	if err := destination.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_tasks WHERE scope_id=?`, imported.ScopeID).Scan(&restoredA2ATasks); err != nil {
+		t.Fatal(err)
+	}
+	if err := destination.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_message_correlations`).Scan(&restoredA2AMessages); err != nil {
+		t.Fatal(err)
+	}
+	if restoredA2ATasks != 1 || restoredA2AMessages != 1 {
+		t.Fatalf("A2A correlations were not restored: tasks=%d messages=%d", restoredA2ATasks, restoredA2AMessages)
 	}
 	receipt, err := destination.Receipt(ctx, registered.AgentToken, request.MessageID)
 	if err != nil || receipt.State != DeliveryAcknowledged || receipt.ResponseMessageID != reply.MessageID {

--- a/bus/protocol.go
+++ b/bus/protocol.go
@@ -23,6 +23,13 @@ const (
 	MessageResponse MessageMode = "response"
 )
 
+type MessageParticipantKind string
+
+const (
+	MessageParticipantAgent        MessageParticipantKind = "agent"
+	MessageParticipantA2APrincipal MessageParticipantKind = "a2aPrincipal"
+)
+
 type DeliveryState string
 
 const (
@@ -65,21 +72,62 @@ type ContextItem struct {
 }
 
 type Message struct {
-	ID                string        `json:"id"`
-	ScopeID           string        `json:"scopeId"`
-	From              string        `json:"from"`
-	To                string        `json:"to"`
-	Mode              MessageMode   `json:"mode"`
-	Body              string        `json:"body"`
-	Context           []ContextItem `json:"context"`
-	ResponseTo        string        `json:"responseTo,omitempty"`
-	State             DeliveryState `json:"state"`
-	CreatedAt         string        `json:"createdAt"`
-	ExpiresAt         string        `json:"expiresAt,omitempty"`
-	DeliveredAt       string        `json:"deliveredAt,omitempty"`
-	AcknowledgedAt    string        `json:"acknowledgedAt,omitempty"`
-	RepliedAt         string        `json:"repliedAt,omitempty"`
-	ResponseMessageID string        `json:"responseMessageId,omitempty"`
+	ID                string                 `json:"id"`
+	ScopeID           string                 `json:"scopeId"`
+	From              string                 `json:"from"`
+	FromKind          MessageParticipantKind `json:"fromKind"`
+	To                string                 `json:"to"`
+	ToKind            MessageParticipantKind `json:"toKind"`
+	Mode              MessageMode            `json:"mode"`
+	Body              string                 `json:"body"`
+	Context           []ContextItem          `json:"context"`
+	ResponseTo        string                 `json:"responseTo,omitempty"`
+	State             DeliveryState          `json:"state"`
+	CreatedAt         string                 `json:"createdAt"`
+	ExpiresAt         string                 `json:"expiresAt,omitempty"`
+	DeliveredAt       string                 `json:"deliveredAt,omitempty"`
+	AcknowledgedAt    string                 `json:"acknowledgedAt,omitempty"`
+	RepliedAt         string                 `json:"repliedAt,omitempty"`
+	ResponseMessageID string                 `json:"responseMessageId,omitempty"`
+}
+
+type A2ATaskState string
+
+const (
+	A2ATaskSubmitted     A2ATaskState = "submitted"
+	A2ATaskWorking       A2ATaskState = "working"
+	A2ATaskInputRequired A2ATaskState = "input-required"
+	A2ATaskCompleted     A2ATaskState = "completed"
+	A2ATaskFailed        A2ATaskState = "failed"
+	A2ATaskCanceled      A2ATaskState = "canceled"
+	A2ATaskRejected      A2ATaskState = "rejected"
+)
+
+type A2AMessageCorrelation struct {
+	ClientMessageID      string `json:"clientMessageId"`
+	BusRequestMessageID  string `json:"busRequestMessageId"`
+	BusResponseMessageID string `json:"busResponseMessageId,omitempty"`
+	CreatedAt            string `json:"createdAt"`
+	UpdatedAt            string `json:"updatedAt"`
+}
+
+type A2ATaskCorrelation struct {
+	ID            string                  `json:"id"`
+	ContextID     string                  `json:"contextId"`
+	PrincipalID   string                  `json:"principalId"`
+	PublicationID string                  `json:"publicationId"`
+	TargetAgentID string                  `json:"targetAgentId"`
+	State         A2ATaskState            `json:"state"`
+	Messages      []A2AMessageCorrelation `json:"messages"`
+	CreatedAt     string                  `json:"createdAt"`
+	UpdatedAt     string                  `json:"updatedAt"`
+}
+
+type AcceptA2AMessageInput struct {
+	TaskID          string `json:"taskId,omitempty"`
+	ContextID       string `json:"contextId,omitempty"`
+	ClientMessageID string `json:"clientMessageId"`
+	Body            string `json:"body"`
 }
 
 type DeliveryReceipt struct {

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -464,7 +464,7 @@ func TestOlderSchemaFailsBeforeServingWork(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = Open(path)
-	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 8") {
+	if err == nil || !strings.Contains(err.Error(), "database schema 1 does not match 9") {
 		t.Fatalf("older schema did not fail clearly: %v", err)
 	}
 }

--- a/bus/storage.go
+++ b/bus/storage.go
@@ -40,6 +40,10 @@ FROM escalations WHERE scope_id=? GROUP BY status ORDER BY status`},
 FROM events WHERE scope_id=? GROUP BY event_type ORDER BY event_type`},
 		{"a2aPublication", `SELECT CASE enabled WHEN 1 THEN 'enabled' ELSE 'disabled' END,COUNT(*),0,MIN(created_at)
 FROM a2a_publications WHERE scope_id=? GROUP BY enabled ORDER BY enabled DESC`},
+		{"a2aTask", `SELECT state,COUNT(*),COALESCE(SUM(length(CAST(context_id AS BLOB))),0),MIN(created_at)
+FROM a2a_tasks WHERE scope_id=? GROUP BY state ORDER BY state`},
+		{"a2aMessage", `SELECT 'correlated',COUNT(*),COALESCE(SUM(length(CAST(client_message_id AS BLOB))),0),MIN(records.created_at)
+FROM a2a_message_correlations AS records JOIN a2a_tasks AS tasks ON tasks.task_id=records.task_id WHERE tasks.scope_id=? HAVING COUNT(*)>0`},
 		{"credential", `SELECT CASE enabled WHEN 1 THEN 'enabled' ELSE 'disabled' END,COUNT(*),COALESCE(SUM(length(CAST(label AS BLOB))),0),MIN(created_at)
 FROM scoped_credentials WHERE scope_id=? GROUP BY enabled ORDER BY enabled DESC`},
 		{"outputStream", `SELECT 'active',COUNT(*),COALESCE(SUM(length(CAST(name AS BLOB))),0),MIN(created_at)

--- a/bus/store.go
+++ b/bus/store.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	schemaVersion                = 8
+	schemaVersion                = 9
 	reservationTTL               = 30 * time.Second
 	messageBacklogCap            = 10000
 	activeTaskCap                = 5000
@@ -115,8 +115,10 @@ CREATE TABLE peer_links (
 CREATE TABLE messages (
   message_id TEXT PRIMARY KEY,
   scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
-  from_agent TEXT NOT NULL,
-  to_agent TEXT NOT NULL,
+  from_kind TEXT NOT NULL CHECK(from_kind IN ('agent','a2aPrincipal')),
+  from_id TEXT NOT NULL,
+  to_kind TEXT NOT NULL CHECK(to_kind IN ('agent','a2aPrincipal')),
+  to_id TEXT NOT NULL,
   mode TEXT NOT NULL CHECK(mode IN ('notify','request','response')),
   body TEXT NOT NULL,
   context_json TEXT NOT NULL,
@@ -131,13 +133,11 @@ CREATE TABLE messages (
   acknowledged_at INTEGER,
   replied_at INTEGER,
   response_message_id TEXT,
-  FOREIGN KEY(scope_id, from_agent) REFERENCES agents(scope_id, agent_id),
-  FOREIGN KEY(scope_id, to_agent) REFERENCES agents(scope_id, agent_id),
   FOREIGN KEY(response_to) REFERENCES messages(message_id)
 );
-CREATE INDEX messages_inbox ON messages(scope_id, to_agent, state, created_at);
-CREATE INDEX messages_sender ON messages(scope_id, from_agent, created_at DESC);
-CREATE UNIQUE INDEX messages_idempotency ON messages(scope_id, from_agent, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX messages_inbox ON messages(scope_id, to_kind, to_id, state, created_at);
+CREATE INDEX messages_sender ON messages(scope_id, from_kind, from_id, created_at DESC);
+CREATE UNIQUE INDEX messages_idempotency ON messages(scope_id, from_kind, from_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
 CREATE TABLE reservations (
   reservation_id TEXT PRIMARY KEY,
   scope_id TEXT NOT NULL,
@@ -213,6 +213,32 @@ CREATE TABLE a2a_publications (
 	FOREIGN KEY(scope_id, agent_id) REFERENCES agents(scope_id, agent_id)
 );
 CREATE INDEX a2a_publications_scope_created ON a2a_publications(scope_id, created_at);
+CREATE TABLE a2a_tasks (
+	task_id TEXT PRIMARY KEY,
+	scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
+	context_id TEXT NOT NULL,
+	principal_id TEXT NOT NULL,
+	publication_id TEXT NOT NULL REFERENCES a2a_publications(publication_id) ON DELETE CASCADE,
+	target_agent_id TEXT NOT NULL,
+	state TEXT NOT NULL CHECK(state IN ('submitted','working','input-required','completed','failed','canceled','rejected')),
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL,
+	FOREIGN KEY(scope_id,target_agent_id) REFERENCES agents(scope_id,agent_id)
+);
+CREATE INDEX a2a_tasks_principal_updated ON a2a_tasks(principal_id,updated_at DESC);
+CREATE INDEX a2a_tasks_scope_state ON a2a_tasks(scope_id,state,updated_at DESC);
+CREATE TABLE a2a_message_correlations (
+	principal_id TEXT NOT NULL,
+	client_message_id TEXT NOT NULL,
+	task_id TEXT NOT NULL REFERENCES a2a_tasks(task_id) ON DELETE CASCADE,
+	request_hash TEXT NOT NULL,
+	bus_request_message_id TEXT NOT NULL UNIQUE REFERENCES messages(message_id),
+	bus_response_message_id TEXT UNIQUE REFERENCES messages(message_id),
+	created_at INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL,
+	PRIMARY KEY(principal_id,client_message_id)
+);
+CREATE INDEX a2a_messages_task_created ON a2a_message_correlations(task_id,created_at,client_message_id);
 CREATE TABLE scoped_credentials (
 	credential_id TEXT PRIMARY KEY,
 	scope_id TEXT NOT NULL REFERENCES scopes(scope_id) ON DELETE CASCADE,
@@ -272,7 +298,7 @@ CREATE TABLE output_rate_usage (
 	PRIMARY KEY(scope_id,principal_type,principal_id,window_start)
 );
 CREATE INDEX output_rate_usage_window ON output_rate_usage(window_start);
-PRAGMA user_version=8;
+PRAGMA user_version=9;
 COMMIT;`)
 	return err
 }
@@ -623,16 +649,10 @@ WHERE l.scope_id=? AND (l.left_agent=? OR l.right_agent=?) ORDER BY a.registered
 }
 
 func (s *Store) linked(ctx context.Context, tx *sql.Tx, scopeID, left, right string) (bool, error) {
-	a, b := orderedPeers(left, right)
-	var found int
-	err := tx.QueryRowContext(ctx, `SELECT 1 FROM peer_links WHERE scope_id=? AND left_agent=? AND right_agent=?`, scopeID, a, b).Scan(&found)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
-	return err == nil, err
+	return linkedAgents(ctx, tx, scopeID, left, right)
 }
 
-const messageColumns = `message_id,scope_id,from_agent,to_agent,mode,body,context_json,response_to,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id`
+const messageColumns = `message_id,scope_id,from_kind,from_id,to_kind,to_id,mode,body,context_json,response_to,state,created_at,expires_at,delivered_at,acknowledged_at,replied_at,response_message_id`
 
 func scanMessage(row rowScanner) (Message, error) {
 	var message Message
@@ -640,7 +660,7 @@ func scanMessage(row rowScanner) (Message, error) {
 	var responseTo, responseMessageID sql.NullString
 	var expiresAt, deliveredAt, acknowledgedAt, repliedAt sql.NullInt64
 	var createdAt int64
-	err := row.Scan(&message.ID, &message.ScopeID, &message.From, &message.To, &message.Mode, &message.Body, &contextJSON,
+	err := row.Scan(&message.ID, &message.ScopeID, &message.FromKind, &message.From, &message.ToKind, &message.To, &message.Mode, &message.Body, &contextJSON,
 		&responseTo, &message.State, &createdAt, &expiresAt, &deliveredAt, &acknowledgedAt, &repliedAt, &responseMessageID)
 	if err != nil {
 		return Message{}, err
@@ -670,18 +690,19 @@ func receiptFromMessage(message Message) DeliveryReceipt {
 }
 
 func expireMessages(ctx context.Context, tx *sql.Tx, scopeID string, now int64) error {
-	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_agent,to_agent,mode FROM messages WHERE scope_id=? AND expires_at IS NOT NULL AND expires_at<=? AND state NOT IN ('acknowledged','expired')`, scopeID, now)
+	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_id,to_id,mode,delivered_at FROM messages WHERE scope_id=? AND expires_at IS NOT NULL AND expires_at<=? AND state NOT IN ('acknowledged','expired')`, scopeID, now)
 	if err != nil {
 		return err
 	}
 	type expiringMessage struct {
 		id, from, to string
 		mode         MessageMode
+		deliveredAt  sql.NullInt64
 	}
 	values := []expiringMessage{}
 	for rows.Next() {
 		var value expiringMessage
-		if err := rows.Scan(&value.id, &value.from, &value.to, &value.mode); err != nil {
+		if err := rows.Scan(&value.id, &value.from, &value.to, &value.mode, &value.deliveredAt); err != nil {
 			rows.Close()
 			return err
 		}
@@ -699,6 +720,13 @@ func expireMessages(ctx context.Context, tx *sql.Tx, scopeID string, now int64) 
 		}
 		changed, _ := result.RowsAffected()
 		if changed == 1 {
+			if !value.deliveredAt.Valid {
+				if err := transitionA2ATaskForMessage(ctx, tx, scopeID, value.id, func(state A2ATaskState) (A2ATaskState, bool) {
+					return A2ATaskFailed, !a2aTaskTerminal(state)
+				}, now); err != nil {
+					return err
+				}
+			}
 			if err := appendEvent(ctx, tx, scopeID, "message.expired", value.id, eventAttributes(
 				"from", value.from, "to", value.to, "mode", string(value.mode), "state", string(DeliveryExpired),
 			), now); err != nil {
@@ -723,118 +751,162 @@ func messageRequestHash(input SendMessageInput, mode MessageMode, contextJSON st
 	return hex.EncodeToString(sum[:])
 }
 
-func (s *Store) SendMessage(ctx context.Context, principal Principal, input SendMessageInput) (DeliveryReceipt, error) {
+func sendMessageTx(ctx context.Context, tx *sql.Tx, scopeID string, senderKind MessageParticipantKind, senderID string, input SendMessageInput) (Message, error) {
 	mode := input.Mode
 	if mode == "" {
 		mode = MessageNotify
 	}
 	contextJSON, err := jsonValue(input.Context)
 	if err != nil {
-		return DeliveryReceipt{}, err
+		return Message{}, err
 	}
 	requestHash := messageRequestHash(input, mode, contextJSON)
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return DeliveryReceipt{}, err
-	}
-	defer tx.Rollback()
-	linked, err := s.linked(ctx, tx, principal.ScopeID, principal.AgentID, input.To)
-	if err != nil {
-		return DeliveryReceipt{}, err
-	}
-	if !linked {
-		return DeliveryReceipt{}, Errorf(CodePermissionDenied, "Agent "+input.To+" is not a linked peer")
-	}
+	toKind := MessageParticipantAgent
 	now := nowMillis()
-	if err := expireMessages(ctx, tx, principal.ScopeID, now); err != nil {
-		return DeliveryReceipt{}, err
+	if err := expireMessages(ctx, tx, scopeID, now); err != nil {
+		return Message{}, err
 	}
 	if input.IdempotencyKey != "" {
 		var existingID, existingHash string
-		err := tx.QueryRowContext(ctx, `SELECT message_id,request_hash FROM messages WHERE scope_id=? AND from_agent=? AND idempotency_key=?`,
-			principal.ScopeID, principal.AgentID, input.IdempotencyKey).Scan(&existingID, &existingHash)
+		err := tx.QueryRowContext(ctx, `SELECT message_id,request_hash FROM messages WHERE scope_id=? AND from_kind=? AND from_id=? AND idempotency_key=?`,
+			scopeID, senderKind, senderID, input.IdempotencyKey).Scan(&existingID, &existingHash)
 		if err == nil {
 			if existingHash != requestHash {
-				return DeliveryReceipt{}, Errorf(CodeConflict, "Idempotency key was already used with different message content")
+				return Message{}, Errorf(CodeConflict, "Idempotency key was already used with different message content")
 			}
 			message, err := scanMessage(tx.QueryRowContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE message_id=?`, existingID))
-			if err != nil {
-				return DeliveryReceipt{}, err
-			}
-			return receiptFromMessage(message), nil
+			return message, err
 		}
 		if !errors.Is(err, sql.ErrNoRows) {
-			return DeliveryReceipt{}, err
+			return Message{}, err
 		}
-	}
-	var backlog int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages WHERE scope_id=? AND state NOT IN ('acknowledged','expired')`, principal.ScopeID).Scan(&backlog); err != nil {
-		return DeliveryReceipt{}, err
-	}
-	if backlog >= messageBacklogCap {
-		return DeliveryReceipt{}, Errorf(CodeBackpressure, "Scope message backlog is full")
-	}
-	messageID, err := randomID("msg_")
-	if err != nil {
-		return DeliveryReceipt{}, err
-	}
-	if err := appendEvent(ctx, tx, principal.ScopeID, "message.accepted", messageID, eventAttributes(
-		"from", principal.AgentID, "to", input.To, "mode", string(mode), "state", string(DeliveryQueued), "responseTo", input.ResponseTo,
-	), now); err != nil {
-		return DeliveryReceipt{}, err
 	}
 	if mode == MessageResponse {
 		if input.ResponseTo == "" {
-			return DeliveryReceipt{}, Errorf(CodeInvalidArgument, "responseTo is required for a response")
+			return Message{}, Errorf(CodeInvalidArgument, "responseTo is required for a response")
 		}
+		var requestFromKind, requestToKind MessageParticipantKind
+		var requestFrom, requestTo string
 		var state DeliveryState
 		var deliveredAt, repliedAt sql.NullInt64
-		err := tx.QueryRowContext(ctx, `SELECT state,delivered_at,replied_at FROM messages WHERE message_id=? AND scope_id=? AND mode='request' AND from_agent=? AND to_agent=?`,
-			input.ResponseTo, principal.ScopeID, input.To, principal.AgentID).Scan(&state, &deliveredAt, &repliedAt)
+		err := tx.QueryRowContext(ctx, `SELECT from_kind,from_id,to_kind,to_id,state,delivered_at,replied_at FROM messages WHERE message_id=? AND scope_id=? AND mode='request'`,
+			input.ResponseTo, scopeID).Scan(&requestFromKind, &requestFrom, &requestToKind, &requestTo, &state, &deliveredAt, &repliedAt)
 		if errors.Is(err, sql.ErrNoRows) {
-			return DeliveryReceipt{}, Errorf(CodeNotFound, "The response request was not found for these peers")
+			return Message{}, Errorf(CodeNotFound, "The response request was not found for these participants")
 		}
 		if err != nil {
-			return DeliveryReceipt{}, err
+			return Message{}, err
+		}
+		if requestToKind != senderKind || requestTo != senderID || requestFrom != input.To {
+			return Message{}, Errorf(CodeNotFound, "The response request was not found for these participants")
 		}
 		if !deliveredAt.Valid {
 			if state == DeliveryExpired {
-				return DeliveryReceipt{}, Errorf(CodeConflict, "The request expired before delivery")
+				return Message{}, Errorf(CodeConflict, "The request expired before delivery")
 			}
-			return DeliveryReceipt{}, Errorf(CodeConflict, "The request has not been delivered")
+			return Message{}, Errorf(CodeConflict, "The request has not been delivered")
 		}
 		if repliedAt.Valid {
-			return DeliveryReceipt{}, Errorf(CodeConflict, "The request already has a response")
+			return Message{}, Errorf(CodeConflict, "The request already has a response")
 		}
+		toKind = requestFromKind
 	} else if input.ResponseTo != "" {
-		return DeliveryReceipt{}, Errorf(CodeInvalidArgument, "responseTo is valid only for a response")
+		return Message{}, Errorf(CodeInvalidArgument, "responseTo is valid only for a response")
+	}
+	if senderKind == MessageParticipantAgent && toKind == MessageParticipantAgent {
+		linked, err := linkedAgents(ctx, tx, scopeID, senderID, input.To)
+		if err != nil {
+			return Message{}, err
+		}
+		if !linked {
+			return Message{}, Errorf(CodePermissionDenied, "Agent "+input.To+" is not a linked peer")
+		}
+	} else if toKind == MessageParticipantAgent {
+		var found int
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM agents WHERE scope_id=? AND agent_id=?`, scopeID, input.To).Scan(&found); errors.Is(err, sql.ErrNoRows) {
+			return Message{}, Errorf(CodeNotFound, "Agent "+input.To+" was not found")
+		} else if err != nil {
+			return Message{}, err
+		}
+	}
+	var backlog int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages WHERE scope_id=? AND state NOT IN ('acknowledged','expired')`, scopeID).Scan(&backlog); err != nil {
+		return Message{}, err
+	}
+	if backlog >= messageBacklogCap {
+		return Message{}, Errorf(CodeBackpressure, "Scope message backlog is full")
+	}
+	messageID, err := randomID("msg_")
+	if err != nil {
+		return Message{}, err
+	}
+	initialState := DeliveryQueued
+	var deliveredAt, acknowledgedAt any
+	if toKind == MessageParticipantA2APrincipal {
+		initialState = DeliveryAcknowledged
+		deliveredAt, acknowledgedAt = now, now
+	}
+	if err := appendEvent(ctx, tx, scopeID, "message.accepted", messageID, eventAttributes(
+		"from", senderID, "fromKind", string(senderKind), "to", input.To, "toKind", string(toKind), "mode", string(mode), "state", string(initialState), "responseTo", input.ResponseTo,
+	), now); err != nil {
+		return Message{}, err
 	}
 	var expiresAt any
 	if input.ExpiresInMS > 0 {
 		expiresAt = now + input.ExpiresInMS
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO messages(message_id,scope_id,from_agent,to_agent,mode,body,context_json,response_to,idempotency_key,request_hash,state,created_at,expires_at) VALUES(?,?,?,?,?,?,?,?,?,?,'queued',?,?)`,
-		messageID, principal.ScopeID, principal.AgentID, input.To, mode, input.Body, contextJSON, nullableString(input.ResponseTo), nullableString(input.IdempotencyKey), nullableString(requestHash), now, expiresAt)
+	_, err = tx.ExecContext(ctx, `INSERT INTO messages(message_id,scope_id,from_kind,from_id,to_kind,to_id,mode,body,context_json,response_to,idempotency_key,request_hash,state,created_at,expires_at,delivered_at,acknowledged_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		messageID, scopeID, senderKind, senderID, toKind, input.To, mode, input.Body, contextJSON, nullableString(input.ResponseTo), nullableString(input.IdempotencyKey), requestHash, initialState, now, expiresAt, deliveredAt, acknowledgedAt)
 	if err != nil {
-		return DeliveryReceipt{}, err
+		return Message{}, err
 	}
 	if mode == MessageResponse {
-		result, err := tx.ExecContext(ctx, `UPDATE messages SET replied_at=?,response_message_id=? WHERE message_id=? AND scope_id=? AND from_agent=? AND to_agent=? AND replied_at IS NULL`,
-			now, messageID, input.ResponseTo, principal.ScopeID, input.To, principal.AgentID)
+		result, err := tx.ExecContext(ctx, `UPDATE messages SET replied_at=?,response_message_id=? WHERE message_id=? AND scope_id=? AND from_kind=? AND from_id=? AND to_kind=? AND to_id=? AND replied_at IS NULL`,
+			now, messageID, input.ResponseTo, scopeID, toKind, input.To, senderKind, senderID)
 		if err != nil {
-			return DeliveryReceipt{}, err
+			return Message{}, err
 		}
 		changed, _ := result.RowsAffected()
 		if changed != 1 {
-			return DeliveryReceipt{}, Errorf(CodeConflict, "The request already has a response")
+			return Message{}, Errorf(CodeConflict, "The request already has a response")
 		}
-		if err := appendEvent(ctx, tx, principal.ScopeID, "message.replied", input.ResponseTo, eventAttributes(
-			"responseMessageId", messageID, "from", input.To, "to", principal.AgentID,
+		if err := appendEvent(ctx, tx, scopeID, "message.replied", input.ResponseTo, eventAttributes(
+			"responseMessageId", messageID, "from", input.To, "to", senderID,
 		), now); err != nil {
-			return DeliveryReceipt{}, err
+			return Message{}, err
+		}
+		if toKind == MessageParticipantA2APrincipal {
+			if _, err := tx.ExecContext(ctx, `UPDATE a2a_message_correlations SET bus_response_message_id=?,updated_at=? WHERE bus_request_message_id=?`, messageID, now, input.ResponseTo); err != nil {
+				return Message{}, err
+			}
+			if err := transitionA2ATaskForMessage(ctx, tx, scopeID, input.ResponseTo, func(state A2ATaskState) (A2ATaskState, bool) {
+				return A2ATaskCompleted, state != A2ATaskInputRequired && !a2aTaskTerminal(state)
+			}, now); err != nil {
+				return Message{}, err
+			}
 		}
 	}
 	message, err := scanMessage(tx.QueryRowContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE message_id=?`, messageID))
+	return message, err
+}
+
+func linkedAgents(ctx context.Context, tx *sql.Tx, scopeID, left, right string) (bool, error) {
+	a, b := orderedPeers(left, right)
+	var found int
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM peer_links WHERE scope_id=? AND left_agent=? AND right_agent=?`, scopeID, a, b).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func (s *Store) SendMessage(ctx context.Context, principal Principal, input SendMessageInput) (DeliveryReceipt, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return DeliveryReceipt{}, err
+	}
+	defer tx.Rollback()
+	message, err := sendMessageTx(ctx, tx, principal.ScopeID, MessageParticipantAgent, principal.AgentID, input)
 	if err != nil {
 		return DeliveryReceipt{}, err
 	}
@@ -860,7 +932,7 @@ func (s *Store) Receipt(ctx context.Context, principal Principal, messageID stri
 	if err := expireMessages(ctx, tx, principal.ScopeID, nowMillis()); err != nil {
 		return DeliveryReceipt{}, err
 	}
-	message, err := scanMessage(tx.QueryRowContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE message_id=? AND scope_id=? AND (from_agent=? OR to_agent=?)`,
+	message, err := scanMessage(tx.QueryRowContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE message_id=? AND scope_id=? AND ((from_kind='agent' AND from_id=?) OR (to_kind='agent' AND to_id=?))`,
 		messageID, principal.ScopeID, principal.AgentID, principal.AgentID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return DeliveryReceipt{}, Errorf(CodeNotFound, "Message "+messageID+" was not found")
@@ -875,7 +947,7 @@ func (s *Store) Receipt(ctx context.Context, principal Principal, messageID stri
 }
 
 func releaseReservation(ctx context.Context, tx *sql.Tx, scopeID, agentID, reservationID string) error {
-	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_agent,to_agent,mode,CASE WHEN delivered_at IS NULL THEN 'queued' ELSE 'delivered' END FROM messages WHERE reservation_id=? AND scope_id=? AND to_agent=? AND state='reserved'`, reservationID, scopeID, agentID)
+	rows, err := tx.QueryContext(ctx, `SELECT message_id,from_id,to_id,mode,CASE WHEN delivered_at IS NULL THEN 'queued' ELSE 'delivered' END FROM messages WHERE reservation_id=? AND scope_id=? AND to_kind='agent' AND to_id=? AND state='reserved'`, reservationID, scopeID, agentID)
 	if err != nil {
 		return err
 	}
@@ -898,7 +970,7 @@ func releaseReservation(ctx context.Context, tx *sql.Tx, scopeID, agentID, reser
 		return err
 	}
 	rows.Close()
-	if _, err := tx.ExecContext(ctx, `UPDATE messages SET state=CASE WHEN delivered_at IS NULL THEN 'queued' ELSE 'delivered' END,reservation_id=NULL WHERE reservation_id=? AND scope_id=? AND to_agent=? AND state='reserved'`, reservationID, scopeID, agentID); err != nil {
+	if _, err := tx.ExecContext(ctx, `UPDATE messages SET state=CASE WHEN delivered_at IS NULL THEN 'queued' ELSE 'delivered' END,reservation_id=NULL WHERE reservation_id=? AND scope_id=? AND to_kind='agent' AND to_id=? AND state='reserved'`, reservationID, scopeID, agentID); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM reservations WHERE reservation_id=? AND scope_id=? AND agent_id=?`, reservationID, scopeID, agentID); err != nil {
@@ -958,7 +1030,7 @@ func (s *Store) ReserveInbox(ctx context.Context, principal Principal, limit int
 			return nil, err
 		}
 	}
-	rows, err := tx.QueryContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE scope_id=? AND to_agent=? AND state IN ('queued','delivered') AND (expires_at IS NULL OR expires_at>?) ORDER BY created_at LIMIT ?`,
+	rows, err := tx.QueryContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE scope_id=? AND to_kind='agent' AND to_id=? AND state IN ('queued','delivered') AND (expires_at IS NULL OR expires_at>?) ORDER BY created_at LIMIT ?`,
 		principal.ScopeID, principal.AgentID, now, limit)
 	if err != nil {
 		return nil, err
@@ -988,7 +1060,7 @@ func (s *Store) ReserveInbox(ctx context.Context, principal Principal, limit int
 		return nil, err
 	}
 	for i := range messages {
-		result, err := tx.ExecContext(ctx, `UPDATE messages SET state='reserved',reservation_id=? WHERE message_id=? AND scope_id=? AND to_agent=? AND state IN ('queued','delivered')`,
+		result, err := tx.ExecContext(ctx, `UPDATE messages SET state='reserved',reservation_id=? WHERE message_id=? AND scope_id=? AND to_kind='agent' AND to_id=? AND state IN ('queued','delivered')`,
 			reservationID, messages[i].ID, principal.ScopeID, principal.AgentID)
 		if err != nil {
 			return nil, err
@@ -1044,7 +1116,7 @@ func (s *Store) CommitInbox(ctx context.Context, principal Principal, reservatio
 	if err := expireMessages(ctx, tx, principal.ScopeID, nowMillis()); err != nil {
 		return nil, err
 	}
-	rows, err := tx.QueryContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE reservation_id=? AND scope_id=? AND to_agent=? AND state='reserved' ORDER BY created_at`, reservationID, principal.ScopeID, principal.AgentID)
+	rows, err := tx.QueryContext(ctx, `SELECT `+messageColumns+` FROM messages WHERE reservation_id=? AND scope_id=? AND to_kind='agent' AND to_id=? AND state='reserved' ORDER BY created_at`, reservationID, principal.ScopeID, principal.AgentID)
 	if err != nil {
 		return nil, err
 	}
@@ -1059,7 +1131,7 @@ func (s *Store) CommitInbox(ctx context.Context, principal Principal, reservatio
 	}
 	rows.Close()
 	deliveredAt := nowMillis()
-	if _, err := tx.ExecContext(ctx, `UPDATE messages SET state='delivered',delivered_at=COALESCE(delivered_at,?),reservation_id=NULL WHERE reservation_id=? AND scope_id=? AND to_agent=? AND state='reserved'`,
+	if _, err := tx.ExecContext(ctx, `UPDATE messages SET state='delivered',delivered_at=COALESCE(delivered_at,?),reservation_id=NULL WHERE reservation_id=? AND scope_id=? AND to_kind='agent' AND to_id=? AND state='reserved'`,
 		deliveredAt, reservationID, principal.ScopeID, principal.AgentID); err != nil {
 		return nil, err
 	}
@@ -1067,6 +1139,13 @@ func (s *Store) CommitInbox(ctx context.Context, principal Principal, reservatio
 		return nil, err
 	}
 	for _, message := range messages {
+		if message.FromKind == MessageParticipantA2APrincipal {
+			if err := transitionA2ATaskForMessage(ctx, tx, principal.ScopeID, message.ID, func(state A2ATaskState) (A2ATaskState, bool) {
+				return A2ATaskWorking, state == A2ATaskSubmitted
+			}, deliveredAt); err != nil {
+				return nil, err
+			}
+		}
 		if err := appendEvent(ctx, tx, principal.ScopeID, "message.delivered", message.ID, eventAttributes(
 			"from", message.From, "to", message.To, "mode", string(message.Mode), "state", string(DeliveryDelivered),
 		), deliveredAt); err != nil {
@@ -1112,7 +1191,7 @@ func (s *Store) AcknowledgeMessages(ctx context.Context, principal Principal, me
 	var count int64
 	for _, messageID := range unique(messageIDs) {
 		now := nowMillis()
-		result, err := tx.ExecContext(ctx, `UPDATE messages SET state='acknowledged',acknowledged_at=? WHERE message_id=? AND scope_id=? AND to_agent=? AND state='delivered'`,
+		result, err := tx.ExecContext(ctx, `UPDATE messages SET state='acknowledged',acknowledged_at=? WHERE message_id=? AND scope_id=? AND to_kind='agent' AND to_id=? AND state='delivered'`,
 			now, messageID, principal.ScopeID, principal.AgentID)
 		if err != nil {
 			return 0, err
@@ -1122,7 +1201,7 @@ func (s *Store) AcknowledgeMessages(ctx context.Context, principal Principal, me
 		if changed == 1 {
 			var from, to string
 			var mode MessageMode
-			if err := tx.QueryRowContext(ctx, `SELECT from_agent,to_agent,mode FROM messages WHERE message_id=?`, messageID).Scan(&from, &to, &mode); err != nil {
+			if err := tx.QueryRowContext(ctx, `SELECT from_id,to_id,mode FROM messages WHERE message_id=?`, messageID).Scan(&from, &to, &mode); err != nil {
 				return 0, err
 			}
 			if err := appendEvent(ctx, tx, principal.ScopeID, "message.acknowledged", messageID, eventAttributes(

--- a/bus/validation.go
+++ b/bus/validation.go
@@ -49,6 +49,15 @@ func validateMessageMode(value MessageMode) error {
 	}
 }
 
+func validateMessageParticipantKind(value MessageParticipantKind) error {
+	switch value {
+	case MessageParticipantAgent, MessageParticipantA2APrincipal:
+		return nil
+	default:
+		return Errorf(CodeInvalidArgument, "message participant kind is invalid")
+	}
+}
+
 func validateCapabilities(values []AgentCapability) error {
 	if len(values) > 64 {
 		return Errorf(CodeInvalidArgument, "capabilities exceeds 64 items")

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -132,7 +132,8 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			Scope:      bus.ArchivedScope{ID: scopeID + "-archive", CreatedAt: time.Now().UTC().Format(time.RFC3339Nano)},
 			Agents:     []bus.ArchivedAgent{}, Links: []bus.ArchivedPeerLink{}, Messages: []bus.ArchivedMessage{},
 			Tasks: []bus.ArchivedTask{}, TaskProgress: []bus.ArchivedTaskProgress{}, Escalations: []bus.ArchivedEscalation{},
-			AgentCardPublications: []bus.ArchivedAgentCard{}, OutputStreams: []bus.ArchivedOutputStream{}, OutputValues: []bus.ArchivedOutputValue{},
+			AgentCardPublications: []bus.ArchivedAgentCard{}, A2ATasks: []bus.ArchivedA2ATask{}, A2AMessages: []bus.ArchivedA2AMessage{},
+			OutputStreams: []bus.ArchivedOutputStream{}, OutputValues: []bus.ArchivedOutputValue{},
 		}
 		imported, err := admin.ImportScope(ctx, archive)
 		if err != nil || !imported.Imported || imported.ScopeID != archive.Scope.ID || imported.ScopeToken == "" {

--- a/docs/architecture/a2a-bridge.md
+++ b/docs/architecture/a2a-bridge.md
@@ -28,7 +28,7 @@ SDK versions and A2A protocol versions are independent. The bridge records both.
 - Remote principals are bound to one publication. Their credentials do not inherit scope, agent, MCP, or administrative authority.
 - October Bus shared work items are a coordination pool. They are not A2A Tasks. A2A Tasks represent one delegated interaction and its result stream.
 
-The reference daemon stores owner-controlled publications and scoped remote principals, then serves enabled Agent Cards at opaque URLs. It does not implement A2A message or task operations yet.
+The reference daemon stores owner-controlled publications, scoped remote principals, and durable A2A task correlations. Each accepted A2A message maps to one Bus request and its optional linked response. The HTTP+JSON message interface is implemented separately from this storage contract.
 
 Principal credentials are stored as one-way digests and shown only when created or rotated. Rotation invalidates the previous value immediately. Both the principal and its publication must be enabled for authentication to succeed.
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.11",
+  "version": "0.1.0-next.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.11",
+      "version": "0.1.0-next.12",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.11",
+  "version": "0.1.0-next.12",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -8,6 +8,7 @@ export type TaskId = string
 
 export type AgentLifecycle = 'starting' | 'ready' | 'working' | 'idle' | 'needs_input' | 'offline'
 export type MessageMode = 'notify' | 'request' | 'response'
+export type MessageParticipantKind = 'agent' | 'a2aPrincipal'
 export type DeliveryState = 'queued' | 'reserved' | 'delivered' | 'acknowledged' | 'expired'
 export type TaskStatus = 'open' | 'claimed' | 'done'
 export type TaskProgressKind = 'progress' | 'note' | 'blocker'
@@ -47,8 +48,10 @@ export interface ContextItem {
 export interface BusMessage {
   id: MessageId
   scopeId: ScopeId
-  from: AgentId
-  to: AgentId
+  from: string
+  fromKind: MessageParticipantKind
+  to: string
+  toKind: MessageParticipantKind
   mode: MessageMode
   body: string
   context: ContextItem[]
@@ -158,6 +161,35 @@ export interface IssuedA2APrincipal {
   credential: string
 }
 
+export type A2ATaskState =
+  | 'submitted'
+  | 'working'
+  | 'input-required'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'rejected'
+
+export interface A2AMessageCorrelation {
+  clientMessageId: string
+  busRequestMessageId: MessageId
+  busResponseMessageId?: MessageId
+  createdAt: string
+  updatedAt: string
+}
+
+export interface A2ATaskCorrelation {
+  id: string
+  contextId: string
+  principalId: string
+  publicationId: string
+  targetAgentId: AgentId
+  state: A2ATaskState
+  messages: A2AMessageCorrelation[]
+  createdAt: string
+  updatedAt: string
+}
+
 export type OutputContentType = 'text/plain' | 'application/json'
 export type OutputPermission = 'read' | 'publish'
 
@@ -253,8 +285,10 @@ export interface ArchivedPeerLink {
 
 export interface ArchivedMessage {
   id: MessageId
-  from: AgentId
-  to: AgentId
+  from: string
+  fromKind: MessageParticipantKind
+  to: string
+  toKind: MessageParticipantKind
   mode: MessageMode
   body: string
   context: ContextItem[]
@@ -267,6 +301,27 @@ export interface ArchivedMessage {
   acknowledgedAt?: string
   repliedAt?: string
   responseMessageId?: MessageId
+}
+
+export interface ArchivedA2ATask {
+  id: string
+  contextId: string
+  principalId: string
+  publicationId: string
+  targetAgentId: AgentId
+  state: A2ATaskState
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ArchivedA2AMessage {
+  principalId: string
+  clientMessageId: string
+  taskId: string
+  busRequestMessageId: MessageId
+  busResponseMessageId?: MessageId
+  createdAt: string
+  updatedAt: string
 }
 
 export interface ArchivedTask {
@@ -333,7 +388,7 @@ export interface ArchivedOutputValue {
 
 export interface ScopeArchive {
   format: 'october-bus.scope'
-  version: 1
+  version: 2
   exportedAt: string
   scope: ArchivedScope
   agents: ArchivedAgent[]
@@ -343,6 +398,8 @@ export interface ScopeArchive {
   taskProgress: ArchivedTaskProgress[]
   escalations: ArchivedEscalation[]
   agentCardPublications: ArchivedAgentCard[]
+  a2aTasks: ArchivedA2ATask[]
+  a2aMessages: ArchivedA2AMessage[]
   outputStreams: ArchivedOutputStream[]
   outputValues: ArchivedOutputValue[]
 }

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -74,6 +74,8 @@ Message modes are `notify`, `request`, and `response`. An omitted mode means `no
 
 A successful send means the runtime durably accepted the message. It does not mean the recipient read or processed it.
 
+Every message identifies the kind and ID of its sender and recipient. Protocol 0.1 supports registered agents and scoped A2A principals. Agent-to-agent messages still require an explicit peer link. An A2A principal can address only the agent named by its publication.
+
 Delivery states are:
 
 ```text
@@ -153,6 +155,7 @@ Protocol 0.1 defines these event types:
 - `task.created`, `task.claimed`, `task.released`, `task.completed`, and `task.progress_added`
 - `escalation.created` and `escalation.resolved`
 - `a2a.publication_created`, `a2a.publication_enabled`, and `a2a.publication_disabled`
+- `a2a.task_created`, `a2a.message_accepted`, and `a2a.task_state_changed`
 - `credential.created`, `credential.rotated`, `credential.enabled`, and `credential.disabled`
 - `output.stream_created`, `output.stream_removed`, `output.publisher_added`, `output.publisher_removed`, and `output.published`
 - `scope.imported`
@@ -178,6 +181,16 @@ A scope owner MAY create remote principals for an Agent Card publication. Each p
 Rotating a principal invalidates its previous credential immediately without changing the principal ID. Disabling a principal suspends its current credential, and re-enabling it restores that credential unless it was rotated. Disabling the publication also prevents its principals from authenticating.
 
 A scoped A2A credential grants no access to the Bus HTTP API, MCP endpoint, scope authority, agent authority, other publications, or daemon administration. Implementations MUST store a one-way digest instead of the plaintext credential and compare presented credentials in constant time.
+
+### Durable A2A task correlation
+
+An A2A Task and an October Bus shared task are different resources. An A2A Task represents one remote delegated interaction. A Bus shared task is work that any eligible agent can claim.
+
+The bridge stores each A2A task, its context ID, remote principal, publication, target agent, state, and message correlations. Every accepted A2A client message maps to one Bus request. That request can have at most one Bus response. A client can add the next message while the task is `input-required`, without weakening the Bus one-response rule.
+
+A2A task states are `submitted`, `working`, `input-required`, `completed`, `failed`, `canceled`, and `rejected`. Delivery of the first pending Bus request advances `submitted` to `working`. A Bus response completes the task unless it is waiting for input. An undelivered request that expires fails the task. Terminal tasks are immutable.
+
+Client message IDs are idempotent within one remote principal. Repeating an accepted message returns its existing task and Bus correlation. Reusing the ID with different content returns `CONFLICT`. A principal cannot read or change another principal's task records.
 
 ## Output streams
 

--- a/spec/0.1/archives.md
+++ b/spec/0.1/archives.md
@@ -10,6 +10,7 @@ An archive preserves:
 - shared tasks, dependencies, ownership of completed tasks, and progress history;
 - human escalations and answers;
 - Agent Card publication identities;
+- A2A tasks and their Bus message correlations;
 - output streams, publisher assignments, retained values, and cursors.
 
 An archive never contains scope tokens, agent tokens, scoped credentials, credential hashes, execution IDs, leases, reservations, rate-limit counters, or host process evidence.
@@ -22,7 +23,7 @@ Imported agents are offline and receive no usable agent credential. Registering 
 
 The event log is local projection history and is not portable. Import creates a new event stream containing one `scope.imported` event. Event consumers must rebuild their projection from the restored resources.
 
-Scoped A2A and output principals are not portable. Create new principals after import. Output values written by an old principal retain its opaque producer ID as historical attribution, but that ID grants no authority.
+Scoped A2A and output credentials are not portable. A2A principal IDs are replaced by stable archive-only identifiers so task and message relationships remain intact without moving authority. Imported A2A history cannot be invoked by a new credential. Create new principals after import. Output values written by an old principal retain its opaque producer ID as historical attribution, but that ID grants no authority.
 
 ## Atomic and idempotent import
 
@@ -36,7 +37,7 @@ The initial archive identifier is:
 
 ```text
 format: october-bus.scope
-version: 1
+version: 2
 ```
 
 New archive versions require an explicit reader implementation. Readers must reject versions they do not support.

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -19,6 +19,10 @@
       "type": "string",
       "enum": ["notify", "request", "response"]
     },
+    "messageParticipantKind": {
+      "type": "string",
+      "enum": ["agent", "a2aPrincipal"]
+    },
     "deliveryState": {
       "type": "string",
       "enum": ["queued", "reserved", "delivered", "acknowledged", "expired"]
@@ -185,12 +189,14 @@
     "message": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "scopeId", "from", "to", "mode", "body", "context", "state", "createdAt"],
+      "required": ["id", "scopeId", "from", "fromKind", "to", "toKind", "mode", "body", "context", "state", "createdAt"],
       "properties": {
         "id": { "$ref": "#/$defs/identifier" },
         "scopeId": { "$ref": "#/$defs/identifier" },
         "from": { "$ref": "#/$defs/identifier" },
+        "fromKind": { "$ref": "#/$defs/messageParticipantKind" },
         "to": { "$ref": "#/$defs/identifier" },
+        "toKind": { "$ref": "#/$defs/messageParticipantKind" },
         "mode": { "$ref": "#/$defs/messageMode" },
         "body": { "type": "string", "minLength": 1, "maxLength": 65536 },
         "context": {
@@ -410,6 +416,38 @@
         "credential": { "type": "string", "minLength": 1 }
       }
     },
+    "a2aTaskState": {
+      "type": "string",
+      "enum": ["submitted", "working", "input-required", "completed", "failed", "canceled", "rejected"]
+    },
+    "a2aMessageCorrelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["clientMessageId", "busRequestMessageId", "createdAt", "updatedAt"],
+      "properties": {
+        "clientMessageId": { "$ref": "#/$defs/identifier" },
+        "busRequestMessageId": { "$ref": "#/$defs/identifier" },
+        "busResponseMessageId": { "$ref": "#/$defs/identifier" },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "a2aTaskCorrelation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "contextId", "principalId", "publicationId", "targetAgentId", "state", "messages", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "contextId": { "$ref": "#/$defs/identifier" },
+        "principalId": { "$ref": "#/$defs/identifier" },
+        "publicationId": { "$ref": "#/$defs/identifier" },
+        "targetAgentId": { "$ref": "#/$defs/identifier" },
+        "state": { "$ref": "#/$defs/a2aTaskState" },
+        "messages": { "type": "array", "items": { "$ref": "#/$defs/a2aMessageCorrelation" } },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
     "outputContentType": {
       "type": "string",
       "enum": ["text/plain", "application/json"]
@@ -558,7 +596,7 @@
       "additionalProperties": false,
       "required": ["recordType", "state", "count", "estimatedBytes"],
       "properties": {
-        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event", "a2aPublication", "credential", "outputStream", "outputValue"] },
+        "recordType": { "type": "string", "enum": ["message", "task", "taskProgress", "escalation", "event", "a2aPublication", "a2aTask", "a2aMessage", "credential", "outputStream", "outputValue"] },
         "state": { "type": "string", "minLength": 1 },
         "count": { "type": "integer", "minimum": 0 },
         "estimatedBytes": { "type": "integer", "minimum": 0 },

--- a/spec/0.1/schemas/scope-archive.schema.json
+++ b/spec/0.1/schemas/scope-archive.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/october-dev/october-bus/spec/0.1/schemas/scope-archive.schema.json",
-  "title": "October Bus portable scope archive 1",
+  "title": "October Bus portable scope archive 2",
   "type": "object",
   "additionalProperties": false,
-  "required": ["format", "version", "exportedAt", "scope", "agents", "links", "messages", "tasks", "taskProgress", "escalations", "agentCardPublications", "outputStreams", "outputValues"],
+  "required": ["format", "version", "exportedAt", "scope", "agents", "links", "messages", "tasks", "taskProgress", "escalations", "agentCardPublications", "a2aTasks", "a2aMessages", "outputStreams", "outputValues"],
   "properties": {
     "format": { "const": "october-bus.scope" },
-    "version": { "const": 1 },
+    "version": { "const": 2 },
     "exportedAt": { "$ref": "#/$defs/instant" },
     "scope": { "$ref": "#/$defs/scope" },
     "agents": { "type": "array", "items": { "$ref": "#/$defs/agent" } },
@@ -17,6 +17,8 @@
     "taskProgress": { "type": "array", "items": { "$ref": "#/$defs/taskProgress" } },
     "escalations": { "type": "array", "items": { "$ref": "#/$defs/escalation" } },
     "agentCardPublications": { "type": "array", "items": { "$ref": "#/$defs/agentCard" } },
+    "a2aTasks": { "type": "array", "items": { "$ref": "#/$defs/a2aTask" } },
+    "a2aMessages": { "type": "array", "items": { "$ref": "#/$defs/a2aMessage" } },
     "outputStreams": { "type": "array", "items": { "$ref": "#/$defs/outputStream" } },
     "outputValues": { "type": "array", "items": { "$ref": "#/$defs/outputValue" } }
   },
@@ -78,11 +80,13 @@
     "message": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "from", "to", "mode", "body", "context", "state", "createdAt"],
+      "required": ["id", "from", "fromKind", "to", "toKind", "mode", "body", "context", "state", "createdAt"],
       "properties": {
         "id": { "$ref": "#/$defs/identifier" },
         "from": { "$ref": "#/$defs/identifier" },
+        "fromKind": { "type": "string", "enum": ["agent", "a2aPrincipal"] },
         "to": { "$ref": "#/$defs/identifier" },
+        "toKind": { "type": "string", "enum": ["agent", "a2aPrincipal"] },
         "mode": { "type": "string", "enum": ["notify", "request", "response"] },
         "body": { "type": "string", "minLength": 1, "maxLength": 65536 },
         "context": { "type": "array", "maxItems": 32, "items": { "$ref": "#/$defs/contextItem" } },
@@ -157,6 +161,35 @@
       "properties": {
         "id": { "$ref": "#/$defs/identifier" },
         "agentId": { "$ref": "#/$defs/identifier" },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "a2aTask": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "contextId", "principalId", "publicationId", "targetAgentId", "state", "createdAt", "updatedAt"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "contextId": { "$ref": "#/$defs/identifier" },
+        "principalId": { "$ref": "#/$defs/identifier" },
+        "publicationId": { "$ref": "#/$defs/identifier" },
+        "targetAgentId": { "$ref": "#/$defs/identifier" },
+        "state": { "type": "string", "enum": ["submitted", "working", "input-required", "completed", "failed", "canceled", "rejected"] },
+        "createdAt": { "$ref": "#/$defs/instant" },
+        "updatedAt": { "$ref": "#/$defs/instant" }
+      }
+    },
+    "a2aMessage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principalId", "clientMessageId", "taskId", "busRequestMessageId", "createdAt", "updatedAt"],
+      "properties": {
+        "principalId": { "$ref": "#/$defs/identifier" },
+        "clientMessageId": { "$ref": "#/$defs/identifier" },
+        "taskId": { "$ref": "#/$defs/identifier" },
+        "busRequestMessageId": { "$ref": "#/$defs/identifier" },
+        "busResponseMessageId": { "$ref": "#/$defs/identifier" },
         "createdAt": { "$ref": "#/$defs/instant" },
         "updatedAt": { "$ref": "#/$defs/instant" }
       }

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -227,6 +227,8 @@ func TestPortableScopeArchiveSchema(t *testing.T) {
 		TaskProgress:          []bus.ArchivedTaskProgress{},
 		Escalations:           []bus.ArchivedEscalation{},
 		AgentCardPublications: []bus.ArchivedAgentCard{},
+		A2ATasks:              []bus.ArchivedA2ATask{},
+		A2AMessages:           []bus.ArchivedA2AMessage{},
 		OutputStreams:         []bus.ArchivedOutputStream{},
 		OutputValues:          []bus.ArchivedOutputValue{},
 	}


### PR DESCRIPTION
## Summary

- persist A2A tasks and per-message Bus correlations
- preserve principal isolation and idempotent client retries
- track delivery, responses, terminal states, and portable archive history
- document the protocol model and publish matching Go and TypeScript types

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -count=1 ./...`
- `npm run typecheck`
- `npm run build`
- `npm run test:errors`

Closes #3