### PR TITLE
Add authenticated A2A message ingress

### DIFF
--- a/bus/a2a_ingress.go
+++ b/bus/a2a_ingress.go
@@ -1,0 +1,207 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+type a2aRequestHandler struct {
+	runtime       *Runtime
+	publicationID string
+	credential    string
+}
+
+var _ a2asrv.RequestHandler = (*a2aRequestHandler)(nil)
+
+func (s *Server) serveA2A(response http.ResponseWriter, request *http.Request) {
+	credential, _ := bearer(request)
+	publicationID := request.PathValue("publicationId")
+	handler := a2asrv.NewRESTHandler(&a2aRequestHandler{
+		runtime: s.runtime, publicationID: publicationID, credential: credential,
+	})
+
+	forwarded := request.Clone(request.Context())
+	forwarded.URL = new(url.URL)
+	*forwarded.URL = *request.URL
+	prefix := "/a2a/agents/" + publicationID
+	forwarded.URL.Path = strings.TrimPrefix(request.URL.Path, prefix)
+	if forwarded.URL.Path == "" {
+		forwarded.URL.Path = "/"
+	}
+	forwarded.URL.RawPath = ""
+	forwarded.Body = http.MaxBytesReader(response, request.Body, maxBodyBytes)
+	handler.ServeHTTP(response, forwarded)
+}
+
+func (h *a2aRequestHandler) authorize(ctx context.Context) error {
+	if _, err := h.runtime.AuthenticateA2APrincipal(ctx, h.credential, h.publicationID); err != nil {
+		return a2a.NewError(a2a.ErrUnauthenticated, "Valid bearer credentials are required")
+	}
+	call, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return a2a.NewError(a2a.ErrInternalError, "Request context is unavailable")
+	}
+	versions, present := call.ServiceParams().Get(a2a.SvcParamVersion)
+	if present && (len(versions) != 1 || versions[0] != string(a2a.Version)) {
+		return a2a.NewError(a2a.ErrVersionNotSupported, "A2A protocol version is not supported")
+	}
+	return nil
+}
+
+func (h *a2aRequestHandler) SendMessage(ctx context.Context, request *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
+	if err := h.authorize(ctx); err != nil {
+		return nil, err
+	}
+	input, err := acceptA2AInput(request)
+	if err != nil {
+		return nil, err
+	}
+	task, err := h.runtime.AcceptA2AMessage(ctx, h.credential, h.publicationID, input)
+	if err != nil {
+		return nil, mapBusA2AError(err)
+	}
+	return taskToA2A(task, request.Message), nil
+}
+
+func acceptA2AInput(request *a2a.SendMessageRequest) (AcceptA2AMessageInput, error) {
+	if request == nil || request.Message == nil {
+		return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrInvalidParams, "A message is required")
+	}
+	message := request.Message
+	if message.ID == "" {
+		return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrInvalidParams, "messageId is required")
+	}
+	if message.Role != a2a.MessageRoleUser {
+		return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrInvalidParams, "Only user messages are accepted")
+	}
+	if request.Config != nil && request.Config.PushConfig != nil {
+		return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrUnsupportedOperation, "Push notifications are not supported")
+	}
+	if len(request.Metadata) != 0 || len(message.Extensions) != 0 || len(message.Metadata) != 0 || len(message.ReferenceTasks) != 0 {
+		return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrUnsupportedOperation, "Message extensions and task references are not supported")
+	}
+	if len(message.Parts) == 0 {
+		return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrInvalidParams, "At least one text part is required")
+	}
+	parts := make([]string, 0, len(message.Parts))
+	for _, part := range message.Parts {
+		if part == nil {
+			return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrInvalidParams, "Message parts cannot be null")
+		}
+		text, ok := part.Content.(a2a.Text)
+		if !ok {
+			return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrUnsupportedContentType, "Only text message parts are supported")
+		}
+		if part.Filename != "" || len(part.Metadata) != 0 || (part.MediaType != "" && part.MediaType != "text/plain") {
+			return AcceptA2AMessageInput{}, a2a.NewError(a2a.ErrUnsupportedContentType, "Only plain text message parts are supported")
+		}
+		parts = append(parts, string(text))
+	}
+	return AcceptA2AMessageInput{
+		TaskID: string(message.TaskID), ContextID: message.ContextID,
+		ClientMessageID: message.ID, Body: strings.Join(parts, "\n"),
+	}, nil
+}
+
+func taskToA2A(task A2ATaskCorrelation, message *a2a.Message) *a2a.Task {
+	state := a2a.TaskStateSubmitted
+	switch task.State {
+	case A2ATaskWorking:
+		state = a2a.TaskStateWorking
+	case A2ATaskInputRequired:
+		state = a2a.TaskStateInputRequired
+	case A2ATaskCompleted:
+		state = a2a.TaskStateCompleted
+	case A2ATaskFailed:
+		state = a2a.TaskStateFailed
+	case A2ATaskCanceled:
+		state = a2a.TaskStateCanceled
+	case A2ATaskRejected:
+		state = a2a.TaskStateRejected
+	}
+	timestamp, _ := time.Parse(time.RFC3339Nano, task.UpdatedAt)
+	return &a2a.Task{
+		ID: a2a.TaskID(task.ID), ContextID: task.ContextID,
+		Status: a2a.TaskStatus{State: state, Timestamp: &timestamp}, History: []*a2a.Message{message},
+	}
+}
+
+func mapBusA2AError(err error) error {
+	var busErr *BusError
+	if !errors.As(err, &busErr) {
+		return a2a.NewError(a2a.ErrInternalError, "The message could not be accepted")
+	}
+	switch busErr.Code {
+	case CodeUnauthenticated:
+		return a2a.NewError(a2a.ErrUnauthenticated, "Valid bearer credentials are required")
+	case CodeInvalidArgument:
+		return a2a.NewError(a2a.ErrInvalidParams, busErr.Message)
+	case CodeNotFound:
+		return a2a.NewError(a2a.ErrTaskNotFound, "Task not found")
+	case CodeConflict:
+		return a2a.NewError(a2a.ErrInvalidRequest, busErr.Message)
+	case CodeBackpressure:
+		return a2a.NewError(a2a.ErrServerError, "The durable inbox is at capacity")
+	default:
+		return a2a.NewError(a2a.ErrInternalError, "The message could not be accepted")
+	}
+}
+
+func (h *a2aRequestHandler) unsupported(ctx context.Context) error {
+	if err := h.authorize(ctx); err != nil {
+		return err
+	}
+	return a2a.ErrUnsupportedOperation
+}
+
+func (h *a2aRequestHandler) GetTask(ctx context.Context, _ *a2a.GetTaskRequest) (*a2a.Task, error) {
+	return nil, h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) ListTasks(ctx context.Context, _ *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	return nil, h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) CancelTask(ctx context.Context, _ *a2a.CancelTaskRequest) (*a2a.Task, error) {
+	return nil, h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) SubscribeToTask(ctx context.Context, _ *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+	return a2aErrorSequence(h.unsupported(ctx))
+}
+
+func (h *a2aRequestHandler) SendStreamingMessage(ctx context.Context, _ *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error] {
+	return a2aErrorSequence(h.unsupported(ctx))
+}
+
+func a2aErrorSequence(err error) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) { yield(nil, err) }
+}
+
+func (h *a2aRequestHandler) GetTaskPushConfig(ctx context.Context, _ *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
+	return nil, h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) ListTaskPushConfigs(ctx context.Context, _ *a2a.ListTaskPushConfigRequest) (*a2a.ListTaskPushConfigResponse, error) {
+	return nil, h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) CreateTaskPushConfig(ctx context.Context, _ *a2a.PushConfig) (*a2a.PushConfig, error) {
+	return nil, h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) DeleteTaskPushConfig(ctx context.Context, _ *a2a.DeleteTaskPushConfigRequest) error {
+	return h.unsupported(ctx)
+}
+
+func (h *a2aRequestHandler) GetExtendedAgentCard(ctx context.Context, _ *a2a.GetExtendedAgentCardRequest) (*a2a.AgentCard, error) {
+	return nil, h.unsupported(ctx)
+}

--- a/bus/a2a_ingress_test.go
+++ b/bus/a2a_ingress_test.go
@@ -1,0 +1,105 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+)
+
+func a2aTestTransport(t *testing.T, server *httptest.Server, publicationID string) a2aclient.Transport {
+	t.Helper()
+	endpoint, err := url.Parse(server.URL + "/a2a/agents/" + publicationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a2aclient.NewRESTTransport(endpoint, server.Client())
+}
+
+func a2aTestParams(credential, version string) a2aclient.ServiceParams {
+	params := a2aclient.ServiceParams{"Authorization": []string{"Bearer " + credential}}
+	if version != "" {
+		params[a2a.SvcParamVersion] = []string{version}
+	}
+	return params
+}
+
+func TestA2ASendMessageCreatesDurableBusRequest(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	publication, issued := setupA2APrincipal(t, agents)
+	server := httptest.NewServer(NewServer(agents.runtime, ServerOptions{}))
+	defer server.Close()
+	transport := a2aTestTransport(t, server, publication.ID)
+	defer transport.Destroy()
+
+	message := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("Review this"), a2a.NewTextPart("Focus on security"))
+	message.ID = "remote-message-1"
+	result, err := transport.SendMessage(context.Background(), a2aTestParams(issued.Credential, string(a2a.Version)), &a2a.SendMessageRequest{Message: message})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, ok := result.(*a2a.Task)
+	if !ok || task.ID == "" || task.ContextID == "" || task.Status.State != a2a.TaskStateSubmitted || len(task.History) != 1 || task.History[0].ID != message.ID {
+		t.Fatalf("unexpected A2A task: %#v", result)
+	}
+
+	reservation, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 0)
+	if err != nil || reservation == nil || len(reservation.Messages) != 1 {
+		t.Fatalf("unexpected inbox: %#v, %v", reservation, err)
+	}
+	inbound := reservation.Messages[0]
+	if inbound.From != issued.Principal.ID || inbound.FromKind != MessageParticipantA2APrincipal || inbound.Body != "Review this\nFocus on security" {
+		t.Fatalf("unexpected Bus request: %#v", inbound)
+	}
+
+	retry, err := transport.SendMessage(context.Background(), a2aTestParams(issued.Credential, string(a2a.Version)), &a2a.SendMessageRequest{Message: message})
+	if err != nil || retry.(*a2a.Task).ID != task.ID {
+		t.Fatalf("A2A retry created different work: %#v, %v", retry, err)
+	}
+}
+
+func TestA2ASendMessageEnforcesAuthenticationVersionAndContent(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	publication, issued := setupA2APrincipal(t, agents)
+	server := httptest.NewServer(NewServer(agents.runtime, ServerOptions{}))
+	defer server.Close()
+	transport := a2aTestTransport(t, server, publication.ID)
+	defer transport.Destroy()
+	ctx := context.Background()
+
+	message := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("Review this"))
+	message.ID = "remote-message-1"
+	_, err := transport.SendMessage(ctx, a2aTestParams("invalid", string(a2a.Version)), &a2a.SendMessageRequest{Message: message})
+	if !errors.Is(err, a2a.ErrUnauthenticated) {
+		t.Fatalf("invalid credential error = %v", err)
+	}
+	_, err = transport.SendMessage(ctx, a2aTestParams(issued.Credential, "broken"), &a2a.SendMessageRequest{Message: message})
+	if !errors.Is(err, a2a.ErrVersionNotSupported) {
+		t.Fatalf("invalid version error = %v", err)
+	}
+	dataMessage := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewDataPart(map[string]any{"private": true}))
+	dataMessage.ID = "remote-data-1"
+	_, err = transport.SendMessage(ctx, a2aTestParams(issued.Credential, string(a2a.Version)), &a2a.SendMessageRequest{Message: dataMessage})
+	if !errors.Is(err, a2a.ErrUnsupportedContentType) {
+		t.Fatalf("unsupported content error = %v", err)
+	}
+	_, err = transport.GetTask(ctx, a2aTestParams("invalid", string(a2a.Version)), &a2a.GetTaskRequest{ID: "hidden-task"})
+	if !errors.Is(err, a2a.ErrUnauthenticated) {
+		t.Fatalf("unauthenticated task lookup error = %v", err)
+	}
+	_, err = transport.GetTask(ctx, a2aTestParams(issued.Credential, string(a2a.Version)), &a2a.GetTaskRequest{ID: "hidden-task"})
+	if !errors.Is(err, a2a.ErrUnsupportedOperation) {
+		t.Fatalf("unsupported task lookup error = %v", err)
+	}
+
+	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
+	if err != nil || reservation != nil {
+		t.Fatalf("rejected requests created work: %#v, %v", reservation, err)
+	}
+}

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -201,6 +201,8 @@ func (s *Server) newRouter() http.Handler {
 		routeMethod{http.MethodHead, s.servePublishedAgentCard},
 		routeMethod{http.MethodOptions, s.servePublishedAgentCard},
 	)
+	registerAllMethods(router, "/a2a/agents/{publicationId}", s.serveA2A)
+	registerAllMethods(router, "/a2a/agents/{publicationId}/{path...}", s.serveA2A)
 	return router
 }
 

--- a/bus/server.go
+++ b/bus/server.go
@@ -227,12 +227,16 @@ func (s *Server) newMCPServer(token string) *mcp.Server {
 	}
 	mcp.AddTool(server, &mcp.Tool{Name: "message_peer", Description: "Send a durable notification, request, or response to a linked peer."},
 		func(ctx context.Context, _ *mcp.CallToolRequest, input messagePeerInput) (*mcp.CallToolResult, any, error) {
-			peer, err := s.resolvePeer(ctx, token, input.Peer)
-			if err != nil {
-				return nil, nil, err
+			to := input.Peer
+			if input.Mode != MessageResponse {
+				peer, err := s.resolvePeer(ctx, token, input.Peer)
+				if err != nil {
+					return nil, nil, err
+				}
+				to = peer.ID
 			}
 			result, err := s.runtime.SendMessage(ctx, token, SendMessageInput{
-				To: peer.ID, Body: input.Message, Mode: input.Mode, ResponseTo: input.ResponseTo,
+				To: to, Body: input.Message, Mode: input.Mode, ResponseTo: input.ResponseTo,
 				IdempotencyKey: input.IdempotencyKey, ExpiresInMS: input.ExpiresInMS, Context: input.Context,
 			})
 			return nil, result, err

--- a/docs/architecture/a2a-bridge.md
+++ b/docs/architecture/a2a-bridge.md
@@ -28,9 +28,11 @@ SDK versions and A2A protocol versions are independent. The bridge records both.
 - Remote principals are bound to one publication. Their credentials do not inherit scope, agent, MCP, or administrative authority.
 - October Bus shared work items are a coordination pool. They are not A2A Tasks. A2A Tasks represent one delegated interaction and its result stream.
 
-The reference daemon stores owner-controlled publications, scoped remote principals, and durable A2A task correlations. Each accepted A2A message maps to one Bus request and its optional linked response. The HTTP+JSON message interface is implemented separately from this storage contract.
+The reference daemon stores owner-controlled publications, scoped remote principals, and durable A2A task correlations. Each accepted A2A message maps to one Bus request and its optional linked response. The published interface accepts A2A `SendMessage` over HTTP+JSON and returns the durable A2A Task. Text parts are supported in the first write surface. Streaming, push notifications, task listing, task reads, and cancellation are not yet supported.
 
 Principal credentials are stored as one-way digests and shown only when created or rotated. Rotation invalidates the previous value immediately. Both the principal and its publication must be enabled for authentication to succeed.
+
+The interface accepts a bearer credential only for the publication it was issued against. If the `A2A-Version` service parameter is present, it must contain exactly `1.0`. Unsupported message content and operations return A2A protocol errors without creating Bus work.
 
 ### Handler caching and conditional requests
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -44,6 +44,10 @@ issued, err := owner.CreateA2APrincipal(ctx, bus.CreateA2APrincipalInput{
 })
 // Store issued.Credential securely. It cannot be retrieved later.
 
+// Use an A2A 1.0 HTTP+JSON client against publication.InterfaceURL.
+// Send the issued credential as a bearer token. The first write surface
+// accepts text-only SendMessage requests and returns a durable A2A Task.
+
 for batch, err := range owner.WatchEvents(ctx, lastRevision, 50) {
     if err != nil {
         return err

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfv
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -192,6 +192,8 @@ A2A task states are `submitted`, `working`, `input-required`, `completed`, `fail
 
 Client message IDs are idempotent within one remote principal. Repeating an accepted message returns its existing task and Bus correlation. Reusing the ID with different content returns `CONFLICT`. A principal cannot read or change another principal's task records.
 
+The reference HTTP+JSON binding accepts authenticated A2A `SendMessage` requests containing plain text parts. It joins multiple parts in order with a newline, creates a durable Bus request, and returns the correlated A2A Task. The first binding does not accept file, URL, data, extension, referenced-task, streaming, push-notification, task-read, task-list, or cancellation operations. Rejected requests do not create Bus work. If an `A2A-Version` header is present, it MUST contain exactly `1.0`.
+
 ## Output streams
 
 A scope owner MAY create a named output stream for values consumed by websites, dashboards, automations, and other tools. A stream has an opaque ID, a scope-unique name, a retention limit, a monotonically increasing sequence, and an explicit set of agent publishers.

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -90,6 +90,7 @@ Failures use:
 | `GET` | `/outputs/{streamId}/values` | Scope or scoped read | Ordered output history |
 | `GET` | `/outputs/{streamId}/latest` | Scope or scoped read | Latest output value or `null` |
 | `GET` | `/a2a/agents/{publicationId}/.well-known/agent-card.json` | None | Enabled A2A Agent Card |
+| `POST` | `/a2a/agents/{publicationId}/message:send` | Scoped A2A | Durable A2A Task |
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
 
 `POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
@@ -105,6 +106,8 @@ Clients resume from `nextRevision`. `minimumCursor` is the oldest cursor that ca
 Agent Card publications are absent by default. A scope owner publishes one registered agent by sending its exact `agentId`. The returned opaque publication ID and URLs remain stable while the publication is disabled and re-enabled. Public card requests for unknown and disabled IDs return the same `NOT_FOUND` response. Card and interface URLs come from the runtime's trusted address configuration, never the request `Host` header.
 
 `POST /v1/a2a/principals` accepts a publication ID and label. Create and rotate responses are the only responses that contain the bearer credential. List, enable, and disable responses return principal metadata only. A principal credential is restricted to its publication and cannot authenticate to any `/v1` or `/mcp` operation.
+
+`POST /a2a/agents/{publicationId}/message:send` implements A2A 1.0 HTTP+JSON `SendMessage`. It accepts user messages made only of plain text parts and returns a durable A2A Task. The bearer credential must belong to the requested publication. The optional `A2A-Version` header must contain exactly `1.0`. Other A2A operations and content types return A2A protocol errors.
 
 `POST /outputs/{streamId}/values` accepts `contentType`, `value`, and an optional URI reference. Agent credentials require an explicit publisher grant. Scoped output credentials require `publish` permission. `GET /outputs/{streamId}/values?after=0&limit=50` returns ordered values after the cursor. The limit is 1 through 100. Clients use `nextSequence` as their next cursor and rebuild from the latest value when `resyncRequired` is true.
 


### PR DESCRIPTION
## Summary
- serve A2A 1.0 SendMessage over the official HTTP+JSON transport
- authenticate remote principals and accept plain text into the durable Bus inbox
- return correlated A2A tasks with protocol-native validation errors
- allow MCP-connected agents to reply to A2A requests

Closes #7

## Validation
- go vet ./...
- go test ./... -count=1