### PR TITLE
Add per-principal A2A resource limits

### DIFF
--- a/bus/a2a_ingress.go
+++ b/bus/a2a_ingress.go
@@ -149,7 +149,7 @@ func mapBusA2AError(err error) error {
 	case CodeConflict:
 		return a2a.NewError(a2a.ErrInvalidRequest, busErr.Message)
 	case CodeBackpressure:
-		return a2a.NewError(a2a.ErrServerError, "The durable inbox is at capacity")
+		return a2a.NewError(a2a.ErrServerError, "Remote work capacity is full")
 	default:
 		return a2a.NewError(a2a.ErrInternalError, "The message could not be accepted")
 	}

--- a/bus/a2a_ingress_test.go
+++ b/bus/a2a_ingress_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -101,5 +102,31 @@ func TestA2ASendMessageEnforcesAuthenticationVersionAndContent(t *testing.T) {
 	reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 0)
 	if err != nil || reservation != nil {
 		t.Fatalf("rejected requests created work: %#v, %v", reservation, err)
+	}
+}
+
+func TestA2ASendMessageReturnsResourceLimitError(t *testing.T) {
+	agents := setupAgentsWithOptions(t, ":memory:", RuntimeOptions{
+		A2APrincipalMessageLimit: 10,
+		A2APrincipalByteLimit:    8,
+	})
+	defer agents.runtime.Close()
+	publication, issued := setupA2APrincipal(t, agents)
+	server := httptest.NewServer(NewServer(agents.runtime, ServerOptions{}))
+	defer server.Close()
+	transport := a2aTestTransport(t, server, publication.ID)
+	defer transport.Destroy()
+	params := a2aTestParams(issued.Credential, string(a2a.Version))
+
+	first := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("12345"))
+	first.ID = "limited-1"
+	if _, err := transport.SendMessage(context.Background(), params, &a2a.SendMessageRequest{Message: first}); err != nil {
+		t.Fatal(err)
+	}
+	second := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("6789"))
+	second.ID = "limited-2"
+	_, err := transport.SendMessage(context.Background(), params, &a2a.SendMessageRequest{Message: second})
+	if !errors.Is(err, a2a.ErrServerError) || !strings.Contains(err.Error(), "Remote work capacity is full") {
+		t.Fatalf("resource limit error = %v", err)
 	}
 }

--- a/bus/a2a_principal_routes.go
+++ b/bus/a2a_principal_routes.go
@@ -32,6 +32,19 @@ func (s *Server) listA2APrincipals(response http.ResponseWriter, request *http.R
 	return nil
 }
 
+func (s *Server) listA2APrincipalUsage(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	usage, err := s.runtime.ListA2APrincipalUsage(request.Context(), token)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, usage)
+	return nil
+}
+
 func (s *Server) rotateA2APrincipal(response http.ResponseWriter, request *http.Request) error {
 	token, err := bearer(request)
 	if err != nil {

--- a/bus/a2a_principals.go
+++ b/bus/a2a_principals.go
@@ -72,6 +72,51 @@ ORDER BY c.created_at,c.credential_id`, scopeID, a2aPublicationResource, a2aInvo
 	return principals, rows.Err()
 }
 
+func (s *Store) ListA2APrincipalUsage(ctx context.Context, scopeID string, limits A2APrincipalLimits) ([]A2APrincipalUsage, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	if err := expireMessages(ctx, tx, scopeID, nowMillis()); err != nil {
+		return nil, err
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT credentials.credential_id,grants.resource_id,
+COALESCE(SUM(CASE WHEN tasks.state NOT IN ('completed','failed','canceled','rejected') THEN 1 ELSE 0 END),0),
+COALESCE(SUM(CASE WHEN tasks.state NOT IN ('completed','failed','canceled','rejected') THEN length(CAST(messages.body AS BLOB)) ELSE 0 END),0)
+FROM scoped_credentials AS credentials
+JOIN scoped_credential_grants AS grants ON grants.credential_id=credentials.credential_id
+LEFT JOIN a2a_message_correlations AS correlations ON correlations.principal_id=credentials.credential_id
+LEFT JOIN a2a_tasks AS tasks ON tasks.task_id=correlations.task_id
+LEFT JOIN messages ON messages.message_id=correlations.bus_request_message_id
+WHERE credentials.scope_id=? AND grants.resource_type=? AND grants.permission=?
+GROUP BY credentials.credential_id,grants.resource_id,credentials.created_at
+ORDER BY credentials.created_at,credentials.credential_id`, scopeID, a2aPublicationResource, a2aInvokePermission)
+	if err != nil {
+		return nil, err
+	}
+	usage := []A2APrincipalUsage{}
+	for rows.Next() {
+		var item A2APrincipalUsage
+		if err := rows.Scan(&item.PrincipalID, &item.PublicationID, &item.UnfinishedMessages, &item.UnfinishedBytes); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		item.MessageLimit = limits.MessageLimit
+		item.ByteLimit = limits.ByteLimit
+		usage = append(usage, item)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return usage, nil
+}
+
 func a2aPrincipalPublication(ctx context.Context, tx *sql.Tx, scopeID, principalID string) (string, error) {
 	var publicationID string
 	err := tx.QueryRowContext(ctx, `SELECT g.resource_id FROM scoped_credentials c
@@ -183,6 +228,14 @@ func (r *Runtime) ListA2APrincipals(ctx context.Context, scopeToken string) ([]A
 		return nil, err
 	}
 	return r.store.ListA2APrincipals(ctx, scopeID)
+}
+
+func (r *Runtime) ListA2APrincipalUsage(ctx context.Context, scopeToken string) ([]A2APrincipalUsage, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err != nil {
+		return nil, err
+	}
+	return r.store.ListA2APrincipalUsage(ctx, scopeID, r.a2aPrincipalLimits)
 }
 
 func (r *Runtime) RotateA2APrincipal(ctx context.Context, scopeToken, principalID string) (IssuedA2APrincipal, error) {

--- a/bus/a2a_tasks.go
+++ b/bus/a2a_tasks.go
@@ -83,12 +83,15 @@ func a2aMessageRequestHash(input AcceptA2AMessageInput) string {
 	return hex.EncodeToString(digest[:])
 }
 
-func (s *Store) AcceptA2AMessage(ctx context.Context, principal A2APrincipal, input AcceptA2AMessageInput) (A2ATaskCorrelation, error) {
+func (s *Store) AcceptA2AMessage(ctx context.Context, principal A2APrincipal, limits A2APrincipalLimits, input AcceptA2AMessageInput) (A2ATaskCorrelation, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return A2ATaskCorrelation{}, err
 	}
 	defer tx.Rollback()
+	if err := expireMessages(ctx, tx, principal.ScopeID, nowMillis()); err != nil {
+		return A2ATaskCorrelation{}, err
+	}
 	requestHash := a2aMessageRequestHash(input)
 	var existingTaskID, existingHash string
 	err = tx.QueryRowContext(ctx, `SELECT task_id,request_hash FROM a2a_message_correlations WHERE principal_id=? AND client_message_id=?`, principal.ID, input.ClientMessageID).Scan(&existingTaskID, &existingHash)
@@ -115,6 +118,22 @@ func (s *Store) AcceptA2AMessage(ctx context.Context, principal A2APrincipal, in
 	}
 	if err != nil {
 		return A2ATaskCorrelation{}, err
+	}
+	var unfinishedMessages, unfinishedBytes int64
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*),COALESCE(SUM(length(CAST(messages.body AS BLOB))),0)
+FROM a2a_message_correlations AS correlations
+JOIN a2a_tasks AS tasks ON tasks.task_id=correlations.task_id
+JOIN messages ON messages.message_id=correlations.bus_request_message_id
+WHERE correlations.principal_id=? AND tasks.principal_id=? AND tasks.state NOT IN ('completed','failed','canceled','rejected')`,
+		principal.ID, principal.ID).Scan(&unfinishedMessages, &unfinishedBytes)
+	if err != nil {
+		return A2ATaskCorrelation{}, err
+	}
+	if unfinishedMessages >= limits.MessageLimit {
+		return A2ATaskCorrelation{}, Errorf(CodeBackpressure, "Remote principal unfinished message limit is full")
+	}
+	if unfinishedBytes+int64(len(input.Body)) > limits.ByteLimit {
+		return A2ATaskCorrelation{}, Errorf(CodeBackpressure, "Remote principal unfinished byte limit is full")
 	}
 	now := nowMillis()
 	taskID := input.TaskID
@@ -298,7 +317,7 @@ func (r *Runtime) AcceptA2AMessage(ctx context.Context, credential, publicationI
 	if err := validateText(input.Body, "body", 65536, false); err != nil {
 		return A2ATaskCorrelation{}, err
 	}
-	task, err := r.store.AcceptA2AMessage(ctx, principal, input)
+	task, err := r.store.AcceptA2AMessage(ctx, principal, r.a2aPrincipalLimits, input)
 	if err == nil {
 		r.signals.notify(signalKey{scopeID: principal.ScopeID, consumerID: task.TargetAgentID})
 		r.notifyScope(principal.ScopeID)

--- a/bus/a2a_tasks_test.go
+++ b/bus/a2a_tasks_test.go
@@ -2,8 +2,12 @@ package bus
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func setupA2APrincipal(t *testing.T, agents testAgents) (agentCardPublication, IssuedA2APrincipal) {
@@ -149,4 +153,171 @@ func TestA2ATaskIsIsolatedByPrincipal(t *testing.T) {
 	}
 	_, err = agents.runtime.store.SetA2ATaskState(ctx, otherPrincipal, task.ID, A2ATaskCanceled)
 	requireCode(t, err, CodeNotFound)
+}
+
+func TestA2APrincipalMessageLimitsAreIndependentAndAtomic(t *testing.T) {
+	agents := setupAgentsWithOptions(t, ":memory:", RuntimeOptions{
+		A2APrincipalMessageLimit: 2,
+		A2APrincipalByteLimit:    1024,
+	})
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, first := setupA2APrincipal(t, agents)
+	second, err := agents.runtime.CreateA2APrincipal(ctx, agents.scope.ScopeToken, CreateA2APrincipalInput{
+		PublicationID: publication.ID, Label: "Second caller",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstTask, err := agents.runtime.AcceptA2AMessage(ctx, first.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "first-1", Body: "one"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.AcceptA2AMessage(ctx, first.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "first-2", Body: "two"}); err != nil {
+		t.Fatal(err)
+	}
+	retry, err := agents.runtime.AcceptA2AMessage(ctx, first.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "first-1", Body: "one"})
+	if err != nil || retry.ID != firstTask.ID {
+		t.Fatalf("idempotent retry consumed additional capacity: %#v, %v", retry, err)
+	}
+	_, err = agents.runtime.AcceptA2AMessage(ctx, first.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "first-3", Body: "three"})
+	requireCode(t, err, CodeBackpressure)
+	if _, err := agents.runtime.AcceptA2AMessage(ctx, second.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "second-1", Body: "independent"}); err != nil {
+		t.Fatalf("another principal lost its capacity: %v", err)
+	}
+
+	usage, err := agents.runtime.ListA2APrincipalUsage(ctx, agents.scope.ScopeToken)
+	if err != nil || len(usage) != 2 {
+		t.Fatalf("unexpected principal usage: %#v, %v", usage, err)
+	}
+	if _, err := agents.runtime.ListA2APrincipalUsage(ctx, agents.plannerToken); err == nil {
+		t.Fatal("agent authority inspected remote principal usage")
+	} else {
+		requireCode(t, err, CodeUnauthenticated)
+	}
+	byPrincipal := map[string]A2APrincipalUsage{}
+	for _, item := range usage {
+		byPrincipal[item.PrincipalID] = item
+	}
+	if got := byPrincipal[first.Principal.ID]; got.UnfinishedMessages != 2 || got.UnfinishedBytes != 6 || got.MessageLimit != 2 || got.ByteLimit != 1024 {
+		t.Fatalf("unexpected first principal usage: %#v", got)
+	}
+	if got := byPrincipal[second.Principal.ID]; got.UnfinishedMessages != 1 || got.UnfinishedBytes != int64(len("independent")) {
+		t.Fatalf("unexpected second principal usage: %#v", got)
+	}
+	encoded, err := json.Marshal(usage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range []string{"one", "two", "independent"} {
+		if strings.Contains(string(encoded), body) {
+			t.Fatalf("usage exposed message content: %s", encoded)
+		}
+	}
+
+	var tasks, correlations, messages int
+	if err := agents.runtime.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_tasks`).Scan(&tasks); err != nil {
+		t.Fatal(err)
+	}
+	if err := agents.runtime.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_message_correlations`).Scan(&correlations); err != nil {
+		t.Fatal(err)
+	}
+	if err := agents.runtime.store.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE from_kind='a2aPrincipal'`).Scan(&messages); err != nil {
+		t.Fatal(err)
+	}
+	if tasks != 3 || correlations != 3 || messages != 3 {
+		t.Fatalf("limit failure left partial records: tasks=%d correlations=%d messages=%d", tasks, correlations, messages)
+	}
+
+	principal, err := agents.runtime.AuthenticateA2APrincipal(ctx, first.Credential, publication.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.store.SetA2ATaskState(ctx, principal, firstTask.ID, A2ATaskCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.AcceptA2AMessage(ctx, first.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "first-3", Body: "three"}); err != nil {
+		t.Fatalf("terminal work did not release capacity: %v", err)
+	}
+}
+
+func TestA2APrincipalByteLimitAndExpiryRelease(t *testing.T) {
+	agents := setupAgentsWithOptions(t, ":memory:", RuntimeOptions{
+		A2APrincipalMessageLimit: 10,
+		A2APrincipalByteLimit:    8,
+	})
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	publication, issued := setupA2APrincipal(t, agents)
+	task, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "bytes-1", Body: "12345"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "bytes-2", Body: "6789"})
+	requireCode(t, err, CodeBackpressure)
+	if _, err := agents.runtime.store.db.Exec(`UPDATE messages SET expires_at=? WHERE message_id=?`, time.Now().Add(-time.Second).UnixMilli(), task.Messages[0].BusRequestMessageID); err != nil {
+		t.Fatal(err)
+	}
+	usage, err := agents.runtime.ListA2APrincipalUsage(ctx, agents.scope.ScopeToken)
+	if err != nil || len(usage) != 1 || usage[0].UnfinishedMessages != 0 || usage[0].UnfinishedBytes != 0 {
+		t.Fatalf("expired work retained capacity: %#v, %v", usage, err)
+	}
+	if _, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "bytes-2", Body: "6789"}); err != nil {
+		t.Fatalf("expiry did not release byte capacity: %v", err)
+	}
+}
+
+func TestConcurrentA2ARequestsCannotBypassPrincipalLimit(t *testing.T) {
+	agents := setupAgentsWithOptions(t, ":memory:", RuntimeOptions{
+		A2APrincipalMessageLimit: 1,
+		A2APrincipalByteLimit:    1024,
+	})
+	defer agents.runtime.Close()
+	publication, issued := setupA2APrincipal(t, agents)
+	start := make(chan struct{})
+	errorsByRequest := make(chan error, 2)
+	var wait sync.WaitGroup
+	for _, id := range []string{"concurrent-1", "concurrent-2"} {
+		wait.Add(1)
+		go func(messageID string) {
+			defer wait.Done()
+			<-start
+			_, err := agents.runtime.AcceptA2AMessage(context.Background(), issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: messageID, Body: "work"})
+			errorsByRequest <- err
+		}(id)
+	}
+	close(start)
+	wait.Wait()
+	close(errorsByRequest)
+	succeeded, limited := 0, 0
+	for err := range errorsByRequest {
+		if err == nil {
+			succeeded++
+			continue
+		}
+		if AsBusError(err).Code == CodeBackpressure {
+			limited++
+			continue
+		}
+		t.Fatalf("unexpected concurrent result: %v", err)
+	}
+	if succeeded != 1 || limited != 1 {
+		t.Fatalf("concurrent results: succeeded=%d limited=%d", succeeded, limited)
+	}
+}
+
+func TestA2APrincipalLimitConfiguration(t *testing.T) {
+	for _, options := range []RuntimeOptions{
+		{A2APrincipalMessageLimit: messageBacklogCap},
+		{A2APrincipalByteLimit: int64(messageBacklogCap) * 65536},
+		{A2APrincipalMessageLimit: -1},
+		{A2APrincipalByteLimit: -1},
+	} {
+		if runtimeValue, err := OpenWithOptions(":memory:", options); err == nil {
+			runtimeValue.Close()
+			t.Fatalf("invalid options were accepted: %#v", options)
+		} else {
+			requireCode(t, err, CodeInvalidArgument)
+		}
+	}
 }

--- a/bus/client.go
+++ b/bus/client.go
@@ -226,6 +226,10 @@ func (c Client) ListA2APrincipals(ctx context.Context) ([]A2APrincipal, error) {
 	return request[[]A2APrincipal](ctx, c, http.MethodGet, "/v1/a2a/principals", nil)
 }
 
+func (c Client) ListA2APrincipalUsage(ctx context.Context) ([]A2APrincipalUsage, error) {
+	return request[[]A2APrincipalUsage](ctx, c, http.MethodGet, "/v1/a2a/principals/usage", nil)
+}
+
 func (c Client) RotateA2APrincipal(ctx context.Context, principalID string) (IssuedA2APrincipal, error) {
 	return request[IssuedA2APrincipal](ctx, c, http.MethodPost, "/v1/a2a/principals/"+url.PathEscape(principalID)+"/rotate", map[string]any{})
 }

--- a/bus/daemon.go
+++ b/bus/daemon.go
@@ -227,7 +227,12 @@ func StartDaemon(ctx context.Context, port int, paths *DaemonPaths) (*RunningDae
 		_ = os.Remove(resolved.RunFile)
 		_ = os.Remove(resolved.LockFile)
 	}
-	runtimeValue, err := Open(resolved.Database)
+	runtimeOptions, err := runtimeOptionsFromEnvironment()
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	runtimeValue, err := OpenWithOptions(resolved.Database, runtimeOptions)
 	if err != nil {
 		cleanup()
 		return nil, err
@@ -261,6 +266,30 @@ func StartDaemon(ctx context.Context, port int, paths *DaemonPaths) (*RunningDae
 		return nil, err
 	}
 	return &RunningDaemon{Server: server, RunFile: run, Paths: resolved, lock: lock}, nil
+}
+
+func runtimeOptionsFromEnvironment() (RuntimeOptions, error) {
+	messageLimit, err := positiveEnvironmentInt64("OCTOBER_BUS_A2A_PRINCIPAL_MESSAGE_LIMIT")
+	if err != nil {
+		return RuntimeOptions{}, err
+	}
+	byteLimit, err := positiveEnvironmentInt64("OCTOBER_BUS_A2A_PRINCIPAL_BYTE_LIMIT")
+	if err != nil {
+		return RuntimeOptions{}, err
+	}
+	return RuntimeOptions{A2APrincipalMessageLimit: messageLimit, A2APrincipalByteLimit: byteLimit}, nil
+}
+
+func positiveEnvironmentInt64(name string) (int64, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || value < 1 {
+		return 0, fmt.Errorf("%s must be a positive integer", name)
+	}
+	return value, nil
 }
 
 func (d *RunningDaemon) Stop(ctx context.Context) error {

--- a/bus/protocol.go
+++ b/bus/protocol.go
@@ -130,6 +130,20 @@ type AcceptA2AMessageInput struct {
 	Body            string `json:"body"`
 }
 
+type A2APrincipalLimits struct {
+	MessageLimit int64 `json:"messageLimit"`
+	ByteLimit    int64 `json:"byteLimit"`
+}
+
+type A2APrincipalUsage struct {
+	PrincipalID        string `json:"principalId"`
+	PublicationID      string `json:"publicationId"`
+	UnfinishedMessages int64  `json:"unfinishedMessages"`
+	UnfinishedBytes    int64  `json:"unfinishedBytes"`
+	MessageLimit       int64  `json:"messageLimit"`
+	ByteLimit          int64  `json:"byteLimit"`
+}
+
 type DeliveryReceipt struct {
 	MessageID         string        `json:"messageId"`
 	State             DeliveryState `json:"state"`

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -153,6 +153,9 @@ func (s *Server) newRouter() http.Handler {
 		routeMethod{http.MethodGet, s.listA2APrincipals},
 		routeMethod{http.MethodPost, s.createA2APrincipal},
 	)
+	registerRoute(router, "/v1/a2a/principals/usage",
+		routeMethod{http.MethodGet, s.listA2APrincipalUsage},
+	)
 	registerRoute(router, "/v1/a2a/principals/{principalId}/rotate",
 		routeMethod{http.MethodPost, s.rotateA2APrincipal},
 	)

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -10,19 +10,55 @@ const (
 	// Inbox waits stay below the server and default client timeout of 30 seconds.
 	maxInboxWaitMS int64 = 25 * 1000
 	maxEventWaitMS int64 = 25 * 1000
+
+	DefaultA2APrincipalMessageLimit int64 = 1000
+	DefaultA2APrincipalByteLimit    int64 = 16 * 1024 * 1024
 )
 
 type Runtime struct {
-	store   *Store
-	signals *runtimeSignals
+	store              *Store
+	signals            *runtimeSignals
+	a2aPrincipalLimits A2APrincipalLimits
+}
+
+type RuntimeOptions struct {
+	A2APrincipalMessageLimit int64
+	A2APrincipalByteLimit    int64
 }
 
 func Open(source string) (*Runtime, error) {
+	return OpenWithOptions(source, RuntimeOptions{})
+}
+
+func OpenWithOptions(source string, options RuntimeOptions) (*Runtime, error) {
+	limits, err := normalizedA2APrincipalLimits(options)
+	if err != nil {
+		return nil, err
+	}
 	store, err := OpenStore(source)
 	if err != nil {
 		return nil, err
 	}
-	return &Runtime{store: store, signals: newRuntimeSignals()}, nil
+	return &Runtime{store: store, signals: newRuntimeSignals(), a2aPrincipalLimits: limits}, nil
+}
+
+func normalizedA2APrincipalLimits(options RuntimeOptions) (A2APrincipalLimits, error) {
+	messageLimit := options.A2APrincipalMessageLimit
+	if messageLimit == 0 {
+		messageLimit = DefaultA2APrincipalMessageLimit
+	}
+	if messageLimit < 1 || messageLimit >= messageBacklogCap {
+		return A2APrincipalLimits{}, Errorf(CodeInvalidArgument, "A2A principal message limit must be between 1 and 9999")
+	}
+	byteLimit := options.A2APrincipalByteLimit
+	if byteLimit == 0 {
+		byteLimit = DefaultA2APrincipalByteLimit
+	}
+	maxBytes := int64(messageBacklogCap-1) * 65536
+	if byteLimit < 1 || byteLimit > maxBytes {
+		return A2APrincipalLimits{}, Errorf(CodeInvalidArgument, "A2A principal byte limit must be between 1 and 655294464")
+	}
+	return A2APrincipalLimits{MessageLimit: messageLimit, ByteLimit: byteLimit}, nil
 }
 
 func (r *Runtime) Close() error { return r.store.Close() }

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -26,9 +26,13 @@ type testAgents struct {
 }
 
 func setupAgents(t *testing.T, source string) testAgents {
+	return setupAgentsWithOptions(t, source, RuntimeOptions{})
+}
+
+func setupAgentsWithOptions(t *testing.T, source string, options RuntimeOptions) testAgents {
 	t.Helper()
 	ctx := context.Background()
-	runtimeValue, err := Open(source)
+	runtimeValue, err := OpenWithOptions(source, options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,6 +59,19 @@ func requireCode(t *testing.T, err error, code ErrorCode) {
 	var failure *BusError
 	if !errors.As(err, &failure) || failure.Code != code {
 		t.Fatalf("expected %s, got %v", code, err)
+	}
+}
+
+func TestA2APrincipalLimitsLoadFromEnvironment(t *testing.T) {
+	t.Setenv("OCTOBER_BUS_A2A_PRINCIPAL_MESSAGE_LIMIT", "12")
+	t.Setenv("OCTOBER_BUS_A2A_PRINCIPAL_BYTE_LIMIT", "4096")
+	options, err := runtimeOptionsFromEnvironment()
+	if err != nil || options.A2APrincipalMessageLimit != 12 || options.A2APrincipalByteLimit != 4096 {
+		t.Fatalf("unexpected runtime options: %#v, %v", options, err)
+	}
+	t.Setenv("OCTOBER_BUS_A2A_PRINCIPAL_MESSAGE_LIMIT", "invalid")
+	if _, err := runtimeOptionsFromEnvironment(); err == nil {
+		t.Fatal("invalid A2A limit was accepted")
 	}
 }
 

--- a/docs/architecture/a2a-bridge.md
+++ b/docs/architecture/a2a-bridge.md
@@ -34,6 +34,8 @@ Principal credentials are stored as one-way digests and shown only when created 
 
 The interface accepts a bearer credential only for the publication it was issued against. If the `A2A-Version` service parameter is present, it must contain exactly `1.0`. Unsupported message content and operations return A2A protocol errors without creating Bus work.
 
+Each remote principal has an independent budget for unfinished messages and text bytes. The check is part of the durable acceptance transaction, so concurrent requests cannot exceed it. This prevents one caller from consuming the capacity reserved for local agents or another remote principal. Scope owners can inspect usage metadata without seeing message bodies.
+
 ### Handler caching and conditional requests
 
 The handler returned by `a2abridge.NewAgentCardHandler` defaults to a

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -48,6 +48,8 @@ issued, err := owner.CreateA2APrincipal(ctx, bus.CreateA2APrincipalInput{
 // Send the issued credential as a bearer token. The first write surface
 // accepts text-only SendMessage requests and returns a durable A2A Task.
 
+principalUsage, err := owner.ListA2APrincipalUsage(ctx)
+
 for batch, err := range owner.WatchEvents(ctx, lastRevision, 50) {
     if err != nil {
         return err

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -94,6 +94,10 @@ Pruning scope events can make an old event cursor incomplete. Event clients rece
 
 Agent Card publications and remote principals are configuration records and are not removed by retention. Disable a publication to stop serving its public card and reject its principals. Disable an individual principal to suspend only that caller.
 
+Inbound A2A work is limited independently for each remote principal. The defaults are 1,000 unfinished messages and 16 MiB of unfinished text. Set `OCTOBER_BUS_A2A_PRINCIPAL_MESSAGE_LIMIT` and `OCTOBER_BUS_A2A_PRINCIPAL_BYTE_LIMIT` before starting the daemon to choose stricter limits. The message limit must be from 1 through 9,999. The byte limit must be from 1 through 655,294,464.
+
+Use the scope client `ListA2APrincipalUsage` method or `GET /v1/a2a/principals/usage` to inspect current usage. The result contains identifiers, counts, bytes, and limits, but no message content.
+
 Output streams apply their own bounded retention on every publication. The default is 1,000 values and the owner can select 1 through 10,000 when creating a stream. Removing a stream also removes its values and scoped principals.
 
 Browser output access is disabled unless the request origin is explicitly configured. Set a comma-separated exact allowlist before starting the daemon:

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -52,6 +52,7 @@ const issued = await scope.createA2APrincipal({
   label: 'CI reviewer'
 })
 // Store issued.credential securely. It cannot be retrieved later.
+const principalUsage = await scope.listA2APrincipalUsage()
 
 const outputStream = await scope.createOutputStream({
   name: 'site-preview',

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.12",
+  "version": "0.1.0-next.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@october-dev/october-bus",
-      "version": "0.1.0-next.12",
+      "version": "0.1.0-next.13",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^7.0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@october-dev/october-bus",
-  "version": "0.1.0-next.12",
+  "version": "0.1.0-next.13",
   "description": "TypeScript client for October Bus.",
   "type": "module",
   "sideEffects": false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -4,6 +4,7 @@ import type {
   Agent,
   AgentCardPublication,
   A2APrincipal,
+  A2APrincipalUsage,
   AgentLifecycle,
   AddTaskInput,
   AddTaskProgressInput,
@@ -287,6 +288,10 @@ export class OctoberBusScopeClient {
 
   listA2APrincipals(options?: OperationOptions): Promise<A2APrincipal[]> {
     return request(this.address, this.scopeToken, 'GET', '/v1/a2a/principals', undefined, options)
+  }
+
+  listA2APrincipalUsage(options?: OperationOptions): Promise<A2APrincipalUsage[]> {
+    return request(this.address, this.scopeToken, 'GET', '/v1/a2a/principals/usage', undefined, options)
   }
 
   rotateA2APrincipal(principalId: string, options?: OperationOptions): Promise<IssuedA2APrincipal> {

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -161,6 +161,15 @@ export interface IssuedA2APrincipal {
   credential: string
 }
 
+export interface A2APrincipalUsage {
+  principalId: string
+  publicationId: string
+  unfinishedMessages: number
+  unfinishedBytes: number
+  messageLimit: number
+  byteLimit: number
+}
+
 export type A2ATaskState =
   | 'submitted'
   | 'working'

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -194,6 +194,8 @@ Client message IDs are idempotent within one remote principal. Repeating an acce
 
 The reference HTTP+JSON binding accepts authenticated A2A `SendMessage` requests containing plain text parts. It joins multiple parts in order with a newline, creates a durable Bus request, and returns the correlated A2A Task. The first binding does not accept file, URL, data, extension, referenced-task, streaming, push-notification, task-read, task-list, or cancellation operations. Rejected requests do not create Bus work. If an `A2A-Version` header is present, it MUST contain exactly `1.0`.
 
+The reference runtime limits unfinished inbound work independently for each A2A principal. The defaults are 1,000 messages and 16 MiB of text. A limit check and message acceptance occur in the same transaction. Terminal tasks and undelivered expired requests release their capacity. Scope authority can inspect each principal's counts, bytes, and effective limits without reading message content.
+
 ## Output streams
 
 A scope owner MAY create a named output stream for values consumed by websites, dashboards, automations, and other tools. A stream has an opaque ID, a scope-unique name, a retention limit, a monotonically increasing sequence, and an explicit set of agent publishers.

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -72,6 +72,7 @@ Failures use:
 | `POST` | `/v1/a2a/publications/{publicationId}/disable` | Scope | Disabled publication |
 | `POST` | `/v1/a2a/principals` | Scope | New principal and one-time credential |
 | `GET` | `/v1/a2a/principals` | Scope | Remote A2A principals without credentials |
+| `GET` | `/v1/a2a/principals/usage` | Scope | Per-principal unfinished inbound usage and limits |
 | `POST` | `/v1/a2a/principals/{principalId}/rotate` | Scope | Principal and replacement credential |
 | `POST` | `/v1/a2a/principals/{principalId}/enable` | Scope | Enabled principal |
 | `POST` | `/v1/a2a/principals/{principalId}/disable` | Scope | Disabled principal |
@@ -106,6 +107,8 @@ Clients resume from `nextRevision`. `minimumCursor` is the oldest cursor that ca
 Agent Card publications are absent by default. A scope owner publishes one registered agent by sending its exact `agentId`. The returned opaque publication ID and URLs remain stable while the publication is disabled and re-enabled. Public card requests for unknown and disabled IDs return the same `NOT_FOUND` response. Card and interface URLs come from the runtime's trusted address configuration, never the request `Host` header.
 
 `POST /v1/a2a/principals` accepts a publication ID and label. Create and rotate responses are the only responses that contain the bearer credential. List, enable, and disable responses return principal metadata only. A principal credential is restricted to its publication and cannot authenticate to any `/v1` or `/mcp` operation.
+
+`GET /v1/a2a/principals/usage` returns unfinished message counts, text bytes, and effective limits for every A2A principal in the scope. It does not return message content. Terminal tasks and undelivered expired requests do not consume capacity.
 
 `POST /a2a/agents/{publicationId}/message:send` implements A2A 1.0 HTTP+JSON `SendMessage`. It accepts user messages made only of plain text parts and returns a durable A2A Task. The bearer credential must belong to the requested publication. The optional `A2A-Version` header must contain exactly `1.0`. Other A2A operations and content types return A2A protocol errors.
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -416,6 +416,19 @@
         "credential": { "type": "string", "minLength": 1 }
       }
     },
+    "a2aPrincipalUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["principalId", "publicationId", "unfinishedMessages", "unfinishedBytes", "messageLimit", "byteLimit"],
+      "properties": {
+        "principalId": { "$ref": "#/$defs/identifier" },
+        "publicationId": { "$ref": "#/$defs/identifier" },
+        "unfinishedMessages": { "type": "integer", "minimum": 0 },
+        "unfinishedBytes": { "type": "integer", "minimum": 0 },
+        "messageLimit": { "type": "integer", "minimum": 1, "maximum": 9999 },
+        "byteLimit": { "type": "integer", "minimum": 1, "maximum": 655294464 }
+      }
+    },
     "a2aTaskState": {
       "type": "string",
       "enum": ["submitted", "working", "input-required", "completed", "failed", "canceled", "rejected"]

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -175,6 +175,15 @@ func TestProtocolSchemas(t *testing.T) {
 	createPrincipal := resolvedSchema(t, path, "createA2APrincipalInput")
 	requireValid(t, createPrincipal, map[string]any{"publicationId": "pub_123", "label": "Review service"})
 	requireInvalid(t, createPrincipal, map[string]any{"publicationId": "pub_123", "label": ""})
+	principalUsage := resolvedSchema(t, path, "a2aPrincipalUsage")
+	requireValid(t, principalUsage, map[string]any{
+		"principalId": "cred_123", "publicationId": "pub_123", "unfinishedMessages": float64(2),
+		"unfinishedBytes": float64(1024), "messageLimit": float64(1000), "byteLimit": float64(16777216),
+	})
+	requireInvalid(t, principalUsage, map[string]any{
+		"principalId": "cred_123", "publicationId": "pub_123", "unfinishedMessages": float64(-1),
+		"unfinishedBytes": float64(0), "messageLimit": float64(1000), "byteLimit": float64(16777216),
+	})
 	outputStream := resolvedSchema(t, path, "outputStream")
 	requireValid(t, outputStream, map[string]any{
 		"id": "out_123", "scopeId": "scope", "name": "site-preview", "retentionLimit": float64(1000),
@@ -349,6 +358,11 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	requireValid(t, resolvedSchema(t, path, "issuedA2APrincipal"), jsonValue(t, principal))
+	principalUsage, err := owner.ListA2APrincipalUsage(ctx)
+	if err != nil || len(principalUsage) != 1 {
+		t.Fatalf("unexpected principal usage: %#v, %v", principalUsage, err)
+	}
+	requireValid(t, resolvedSchema(t, path, "a2aPrincipalUsage"), jsonValue(t, principalUsage[0]))
 	outputStream, err := owner.CreateOutputStream(ctx, bus.CreateOutputStreamInput{
 		Name: "site-preview", PublisherAgentIDs: []string{"reviewer"},
 	})


### PR DESCRIPTION
## Summary
- enforce independent unfinished-message and byte limits for each remote principal
- apply capacity checks atomically with durable A2A message acceptance
- release capacity for terminal and expired work
- expose content-free usage to scope owners through Go and TypeScript clients
- return a clear A2A resource error when capacity is full

Closes #5

## Validation
- go vet ./...
- go test ./... -count=1
- go test -race -count=1 ./...
- npm run typecheck
- npm run build
- npm run test:errors