### PR TITLE
Prepare runtime storage backends

### DIFF
--- a/bus/a2a_tasks_test.go
+++ b/bus/a2a_tasks_test.go
@@ -114,7 +114,7 @@ func TestA2ATaskAllowsFollowUpOnlyBeforeTerminalState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := agents.runtime.store.SetA2ATaskState(ctx, principal, task.ID, A2ATaskInputRequired); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).SetA2ATaskState(ctx, principal, task.ID, A2ATaskInputRequired); err != nil {
 		t.Fatal(err)
 	}
 	followUp, err := agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{
@@ -123,7 +123,7 @@ func TestA2ATaskAllowsFollowUpOnlyBeforeTerminalState(t *testing.T) {
 	if err != nil || followUp.State != A2ATaskWorking || len(followUp.Messages) != 2 {
 		t.Fatalf("follow-up was not correlated: %#v, %v", followUp, err)
 	}
-	if _, err := agents.runtime.store.SetA2ATaskState(ctx, principal, task.ID, A2ATaskCanceled); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).SetA2ATaskState(ctx, principal, task.ID, A2ATaskCanceled); err != nil {
 		t.Fatal(err)
 	}
 	_, err = agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{
@@ -151,7 +151,7 @@ func TestA2ATaskIsIsolatedByPrincipal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = agents.runtime.store.SetA2ATaskState(ctx, otherPrincipal, task.ID, A2ATaskCanceled)
+	_, err = sqliteStore(t, agents.runtime).SetA2ATaskState(ctx, otherPrincipal, task.ID, A2ATaskCanceled)
 	requireCode(t, err, CodeNotFound)
 }
 
@@ -216,13 +216,13 @@ func TestA2APrincipalMessageLimitsAreIndependentAndAtomic(t *testing.T) {
 	}
 
 	var tasks, correlations, messages int
-	if err := agents.runtime.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_tasks`).Scan(&tasks); err != nil {
+	if err := sqliteStore(t, agents.runtime).db.QueryRow(`SELECT COUNT(*) FROM a2a_tasks`).Scan(&tasks); err != nil {
 		t.Fatal(err)
 	}
-	if err := agents.runtime.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_message_correlations`).Scan(&correlations); err != nil {
+	if err := sqliteStore(t, agents.runtime).db.QueryRow(`SELECT COUNT(*) FROM a2a_message_correlations`).Scan(&correlations); err != nil {
 		t.Fatal(err)
 	}
-	if err := agents.runtime.store.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE from_kind='a2aPrincipal'`).Scan(&messages); err != nil {
+	if err := sqliteStore(t, agents.runtime).db.QueryRow(`SELECT COUNT(*) FROM messages WHERE from_kind='a2aPrincipal'`).Scan(&messages); err != nil {
 		t.Fatal(err)
 	}
 	if tasks != 3 || correlations != 3 || messages != 3 {
@@ -233,7 +233,7 @@ func TestA2APrincipalMessageLimitsAreIndependentAndAtomic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := agents.runtime.store.SetA2ATaskState(ctx, principal, firstTask.ID, A2ATaskCompleted); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).SetA2ATaskState(ctx, principal, firstTask.ID, A2ATaskCompleted); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := agents.runtime.AcceptA2AMessage(ctx, first.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "first-3", Body: "three"}); err != nil {
@@ -255,7 +255,7 @@ func TestA2APrincipalByteLimitAndExpiryRelease(t *testing.T) {
 	}
 	_, err = agents.runtime.AcceptA2AMessage(ctx, issued.Credential, publication.ID, AcceptA2AMessageInput{ClientMessageID: "bytes-2", Body: "6789"})
 	requireCode(t, err, CodeBackpressure)
-	if _, err := agents.runtime.store.db.Exec(`UPDATE messages SET expires_at=? WHERE message_id=?`, time.Now().Add(-time.Second).UnixMilli(), task.Messages[0].BusRequestMessageID); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE messages SET expires_at=? WHERE message_id=?`, time.Now().Add(-time.Second).UnixMilli(), task.Messages[0].BusRequestMessageID); err != nil {
 		t.Fatal(err)
 	}
 	usage, err := agents.runtime.ListA2APrincipalUsage(ctx, agents.scope.ScopeToken)

--- a/bus/archive_test.go
+++ b/bus/archive_test.go
@@ -174,10 +174,10 @@ func TestPortableScopeArchiveRoundTripAndRetry(t *testing.T) {
 		t.Fatal("source execution authority survived import")
 	}
 	var restoredA2ATasks, restoredA2AMessages int
-	if err := destination.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_tasks WHERE scope_id=?`, imported.ScopeID).Scan(&restoredA2ATasks); err != nil {
+	if err := sqliteStore(t, destination).db.QueryRow(`SELECT COUNT(*) FROM a2a_tasks WHERE scope_id=?`, imported.ScopeID).Scan(&restoredA2ATasks); err != nil {
 		t.Fatal(err)
 	}
-	if err := destination.store.db.QueryRow(`SELECT COUNT(*) FROM a2a_message_correlations`).Scan(&restoredA2AMessages); err != nil {
+	if err := sqliteStore(t, destination).db.QueryRow(`SELECT COUNT(*) FROM a2a_message_correlations`).Scan(&restoredA2AMessages); err != nil {
 		t.Fatal(err)
 	}
 	if restoredA2ATasks != 1 || restoredA2AMessages != 1 {
@@ -243,7 +243,7 @@ func TestPortableScopeArchiveRejectsMalformedInputAtomically(t *testing.T) {
 	_, err = destination.ImportScope(ctx, archive)
 	requireCode(t, err, CodeInvalidArgument)
 	var count int
-	if err := destination.store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM scopes`).Scan(&count); err != nil || count != 0 {
+	if err := sqliteStore(t, destination).db.QueryRowContext(ctx, `SELECT COUNT(*) FROM scopes`).Scan(&count); err != nil || count != 0 {
 		t.Fatalf("malformed import applied partial state: %d, %v", count, err)
 	}
 	archive.Version = ScopeArchiveVersion + 1

--- a/bus/client.go
+++ b/bus/client.go
@@ -83,12 +83,33 @@ func (c Client) Health(ctx context.Context) (Health, error) {
 		return Health{}, err
 	}
 	defer response.Body.Close()
+	var health Health
+	decodeErr := json.NewDecoder(response.Body).Decode(&health)
 	if response.StatusCode != http.StatusOK {
+		if decodeErr == nil {
+			return health, fmt.Errorf("health check failed with HTTP %d", response.StatusCode)
+		}
 		return Health{}, fmt.Errorf("health check failed with HTTP %d", response.StatusCode)
 	}
-	var health Health
-	err = json.NewDecoder(response.Body).Decode(&health)
-	return health, err
+	return health, decodeErr
+}
+
+func (c Client) Liveness(ctx context.Context) (Liveness, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.Address+"/health/live", nil)
+	if err != nil {
+		return Liveness{}, err
+	}
+	response, err := c.httpClient().Do(req)
+	if err != nil {
+		return Liveness{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return Liveness{}, fmt.Errorf("liveness check failed with HTTP %d", response.StatusCode)
+	}
+	var liveness Liveness
+	err = json.NewDecoder(response.Body).Decode(&liveness)
+	return liveness, err
 }
 
 func (c Client) CreateScope(ctx context.Context, input CreateScopeInput) (CreateScopeResult, error) {

--- a/bus/events_test.go
+++ b/bus/events_test.go
@@ -212,7 +212,7 @@ func TestPrunedEventCursorRequiresResync(t *testing.T) {
 	ctx := context.Background()
 	old := time.Now().Add(-2 * time.Hour).UnixMilli()
 	cutoff := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
-	if _, err := agents.runtime.store.db.Exec(`UPDATE events SET created_at=? WHERE scope_id=?`, old, agents.scope.ScopeID); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE events SET created_at=? WHERE scope_id=?`, old, agents.scope.ScopeID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := agents.runtime.Heartbeat(ctx, agents.plannerToken, HeartbeatInput{Lifecycle: LifecycleReady, Ready: true, LeaseMS: 30000}); err != nil {

--- a/bus/inbox_wait_test.go
+++ b/bus/inbox_wait_test.go
@@ -237,7 +237,7 @@ func TestInboxWaitRechecksAtLeaseExpiry(t *testing.T) {
 	agents := setupAgents(t, ":memory:")
 	defer agents.runtime.Close()
 	expiresAt := nowMillis() + 60
-	if _, err := agents.runtime.store.db.Exec(`UPDATE agents SET lease_expires_at=? WHERE scope_id=? AND agent_id=?`, expiresAt, agents.scope.ScopeID, agents.reviewer.AgentID); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE agents SET lease_expires_at=? WHERE scope_id=? AND agent_id=?`, expiresAt, agents.scope.ScopeID, agents.reviewer.AgentID); err != nil {
 		t.Fatal(err)
 	}
 	started := time.Now()
@@ -259,7 +259,7 @@ func TestInboxWaitRechecksWhenReservationExpires(t *testing.T) {
 	if err != nil || first == nil {
 		t.Fatalf("unexpected initial reservation: %#v, %v", first, err)
 	}
-	if _, err := agents.runtime.store.db.Exec(`UPDATE reservations SET expires_at=? WHERE reservation_id=?`, nowMillis()+60, first.ID); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE reservations SET expires_at=? WHERE reservation_id=?`, nowMillis()+60, first.ID); err != nil {
 		t.Fatal(err)
 	}
 	redelivery, err := agents.runtime.ReserveInbox(context.Background(), agents.reviewerToken, 10, 2000)

--- a/bus/output_streams_test.go
+++ b/bus/output_streams_test.go
@@ -202,7 +202,7 @@ func TestOutputStreamsPersistAndRemoveTheirDataAndCredentials(t *testing.T) {
 		t.Fatalf("stream removal left principals: %#v, %v", principals, err)
 	}
 	var valueCount int
-	if err := restarted.store.db.QueryRow(`SELECT COUNT(*) FROM output_values WHERE stream_id=?`, stream.ID).Scan(&valueCount); err != nil || valueCount != 0 {
+	if err := sqliteStore(t, restarted).db.QueryRow(`SELECT COUNT(*) FROM output_values WHERE stream_id=?`, stream.ID).Scan(&valueCount); err != nil || valueCount != 0 {
 		t.Fatalf("stream removal left values: %d, %v", valueCount, err)
 	}
 }
@@ -229,7 +229,7 @@ func TestOutputPayloadLimitsAndPerPrincipalQuota(t *testing.T) {
 	}
 	window := nowMillis()
 	window -= window % 60000
-	if _, err := agents.runtime.store.db.Exec(`INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,publish_count) VALUES(?,?,?,?,?),(?,?,?,?,?)`,
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,publish_count) VALUES(?,?,?,?,?),(?,?,?,?,?)`,
 		agents.scope.ScopeID, "agent", agents.reviewer.AgentID, window, outputPublishRate,
 		agents.scope.ScopeID, "agent", agents.reviewer.AgentID, window+60000, outputPublishRate); err != nil {
 		t.Fatal(err)
@@ -242,7 +242,7 @@ func TestOutputPayloadLimitsAndPerPrincipalQuota(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := agents.runtime.store.db.Exec(`INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,read_count) VALUES(?,?,?,?,?),(?,?,?,?,?)`,
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`INSERT INTO output_rate_usage(scope_id,principal_type,principal_id,window_start,read_count) VALUES(?,?,?,?,?),(?,?,?,?,?)`,
 		agents.scope.ScopeID, "principal", reader.Principal.ID, window, outputReadRate,
 		agents.scope.ScopeID, "principal", reader.Principal.ID, window+60000, outputReadRate); err != nil {
 		t.Fatal(err)

--- a/bus/protocol.go
+++ b/bus/protocol.go
@@ -436,11 +436,28 @@ type RunFile struct {
 }
 
 type Health struct {
-	Name            string `json:"name"`
-	ProtocolVersion string `json:"protocolVersion"`
-	RuntimeVersion  string `json:"runtimeVersion"`
-	Status          string `json:"status"`
-	StartedAt       string `json:"startedAt"`
+	Name            string        `json:"name"`
+	ProtocolVersion string        `json:"protocolVersion"`
+	RuntimeVersion  string        `json:"runtimeVersion"`
+	Status          string        `json:"status"`
+	StartedAt       string        `json:"startedAt"`
+	Storage         StorageHealth `json:"storage"`
+}
+
+const (
+	StorageAvailable   = "available"
+	StorageUnavailable = "unavailable"
+)
+
+type StorageHealth struct {
+	Backend StorageBackend `json:"backend"`
+	Status  string         `json:"status"`
+}
+
+type Liveness struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	StartedAt string `json:"startedAt"`
 }
 
 type NodeIdentity struct {

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -57,6 +57,12 @@ func (s *Server) newRouter() http.Handler {
 	registerRoute(router, "/health",
 		routeMethod{http.MethodGet, s.health},
 	)
+	registerRoute(router, "/health/live",
+		routeMethod{http.MethodGet, s.liveness},
+	)
+	registerRoute(router, "/health/ready",
+		routeMethod{http.MethodGet, s.health},
+	)
 	registerAllMethods(router, "/mcp", s.serveMCP)
 	registerRoute(router, "/v1/admin/shutdown",
 		routeMethod{http.MethodPost, s.shutdownServer},
@@ -240,11 +246,23 @@ func handleRoute(handler routeHandler) http.Handler {
 	})
 }
 
-func (s *Server) health(response http.ResponseWriter, _ *http.Request) error {
-	writeJSON(response, http.StatusOK, Health{
+func (s *Server) health(response http.ResponseWriter, request *http.Request) error {
+	storage := s.runtime.StorageHealth(request.Context())
+	status := "ready"
+	httpStatus := http.StatusOK
+	if storage.Status != StorageAvailable {
+		status = "not_ready"
+		httpStatus = http.StatusServiceUnavailable
+	}
+	writeJSON(response, httpStatus, Health{
 		Name: "october-bus", ProtocolVersion: ProtocolVersion, RuntimeVersion: Version,
-		Status: "ready", StartedAt: s.options.StartedAt,
+		Status: status, StartedAt: s.options.StartedAt, Storage: storage,
 	})
+	return nil
+}
+
+func (s *Server) liveness(response http.ResponseWriter, _ *http.Request) error {
+	writeJSON(response, http.StatusOK, Liveness{Name: "october-bus", Status: "alive", StartedAt: s.options.StartedAt})
 	return nil
 }
 

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -16,7 +16,7 @@ const (
 )
 
 type Runtime struct {
-	store              *Store
+	store              storageBackend
 	signals            *runtimeSignals
 	a2aPrincipalLimits A2APrincipalLimits
 }
@@ -39,7 +39,11 @@ func OpenWithOptions(source string, options RuntimeOptions) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Runtime{store: store, signals: newRuntimeSignals(), a2aPrincipalLimits: limits}, nil
+	return openWithStorage(store, limits), nil
+}
+
+func openWithStorage(store storageBackend, limits A2APrincipalLimits) *Runtime {
+	return &Runtime{store: store, signals: newRuntimeSignals(), a2aPrincipalLimits: limits}
 }
 
 func normalizedA2APrincipalLimits(options RuntimeOptions) (A2APrincipalLimits, error) {
@@ -62,6 +66,14 @@ func normalizedA2APrincipalLimits(options RuntimeOptions) (A2APrincipalLimits, e
 }
 
 func (r *Runtime) Close() error { return r.store.Close() }
+
+func (r *Runtime) StorageHealth(ctx context.Context) StorageHealth {
+	health := StorageHealth{Backend: r.store.Backend(), Status: StorageAvailable}
+	if err := r.store.Ping(ctx); err != nil {
+		health.Status = StorageUnavailable
+	}
+	return health
+}
 
 func (r *Runtime) CreateScope(ctx context.Context, input CreateScopeInput) (CreateScopeResult, error) {
 	if err := validateIdentity(input.ID, "id", true); err != nil {

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -23,6 +24,15 @@ type testAgents struct {
 	reviewer      RegisterAgentResult
 	plannerToken  string
 	reviewerToken string
+}
+
+func sqliteStore(t testing.TB, runtime *Runtime) *Store {
+	t.Helper()
+	store, ok := runtime.store.(*Store)
+	if !ok {
+		t.Fatalf("test requires SQLite storage, got %s", runtime.store.Backend())
+	}
+	return store
 }
 
 func setupAgents(t *testing.T, source string) testAgents {
@@ -371,6 +381,59 @@ func TestOfflineHeartbeatCannotClaimReadiness(t *testing.T) {
 		Lifecycle: LifecycleOffline, Ready: true,
 	})
 	requireCode(t, err, CodeInvalidArgument)
+}
+
+func TestHealthSeparatesLivenessFromStorageReadiness(t *testing.T) {
+	runtimeValue, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(runtimeValue, ServerOptions{StartedAt: "2026-09-03T00:00:00Z"})
+
+	request := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("ready health returned HTTP %d", response.Code)
+	}
+	var ready Health
+	if err := json.Unmarshal(response.Body.Bytes(), &ready); err != nil {
+		t.Fatal(err)
+	}
+	if ready.Status != "ready" || ready.Storage.Backend != StorageBackendSQLite || ready.Storage.Status != StorageAvailable {
+		t.Fatalf("unexpected ready health: %#v", ready)
+	}
+
+	if err := runtimeValue.Close(); err != nil {
+		t.Fatal(err)
+	}
+	request = httptest.NewRequest(http.MethodGet, "/health", nil)
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unready health returned HTTP %d", response.Code)
+	}
+	var unready Health
+	if err := json.Unmarshal(response.Body.Bytes(), &unready); err != nil {
+		t.Fatal(err)
+	}
+	if unready.Status != "not_ready" || unready.Storage.Status != StorageUnavailable {
+		t.Fatalf("unexpected unready health: %#v", unready)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/health/live", nil)
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("liveness returned HTTP %d", response.Code)
+	}
+	var live Liveness
+	if err := json.Unmarshal(response.Body.Bytes(), &live); err != nil {
+		t.Fatal(err)
+	}
+	if live.Status != "alive" || live.StartedAt == "" {
+		t.Fatalf("unexpected liveness: %#v", live)
+	}
 }
 
 func TestShutdownRequiresAdminAuthority(t *testing.T) {

--- a/bus/storage_backend.go
+++ b/bus/storage_backend.go
@@ -1,0 +1,77 @@
+package bus
+
+import "context"
+
+type StorageBackend string
+
+const StorageBackendSQLite StorageBackend = "sqlite"
+
+type storageBackend interface {
+	Backend() StorageBackend
+	Ping(context.Context) error
+	Close() error
+
+	CreateScope(context.Context, string) (CreateScopeResult, error)
+	AuthenticateScope(context.Context, string) (string, error)
+	RegisterAgent(context.Context, string, RegisterAgentInput) (RegisterAgentResult, error)
+	AuthenticateAgent(context.Context, string) (Principal, error)
+	Agent(context.Context, string, string) (Agent, error)
+	Heartbeat(context.Context, Principal, HeartbeatInput) (Agent, bool, error)
+	ListAgents(context.Context, string) ([]Agent, error)
+	LinkAgents(context.Context, string, string, string) error
+	ListPeers(context.Context, Principal) ([]Agent, error)
+
+	SendMessage(context.Context, Principal, SendMessageInput) (DeliveryReceipt, error)
+	Receipt(context.Context, Principal, string) (DeliveryReceipt, error)
+	ReserveInbox(context.Context, Principal, int) (*InboxReservation, error)
+	NextInboxReservationExpiry(context.Context, Principal) (int64, error)
+	CommitInbox(context.Context, Principal, string) ([]Message, error)
+	ReleaseInbox(context.Context, Principal, string) error
+	AcknowledgeMessages(context.Context, Principal, []string) (int64, error)
+
+	AddTask(context.Context, string, string, AddTaskInput) (Task, error)
+	ClaimTask(context.Context, Principal, string) (Task, error)
+	ReleaseTask(context.Context, Principal, string) (Task, error)
+	CompleteTask(context.Context, Principal, string, string) (Task, error)
+	ListTasks(context.Context, string, bool) ([]Task, error)
+	AddTaskProgress(context.Context, Principal, string, AddTaskProgressInput) (TaskProgress, error)
+	ListTaskProgress(context.Context, string, string) ([]TaskProgress, error)
+
+	AskHuman(context.Context, Principal, AskHumanInput) (HumanEscalation, error)
+	Escalation(context.Context, string, string) (HumanEscalation, error)
+	ListEscalations(context.Context, string) ([]HumanEscalation, error)
+	ResolveEscalation(context.Context, string, string, string) (HumanEscalation, error)
+
+	StorageSummary(context.Context, string) (StorageSummary, error)
+	PruneScope(context.Context, string, int64, bool) (PruneScopeResult, error)
+	Events(context.Context, string, int64, int) (EventBatch, error)
+	ExportScope(context.Context, string) (ScopeArchive, error)
+	ImportScope(context.Context, ScopeArchive) (ImportScopeResult, error)
+
+	CreateAgentCardPublication(context.Context, string, string) (agentCardPublication, error)
+	ListAgentCardPublications(context.Context, string) ([]agentCardPublication, error)
+	SetAgentCardPublicationEnabled(context.Context, string, string, bool) (agentCardPublication, error)
+	PublishedAgent(context.Context, string) (agentCardPublication, Agent, error)
+	CreateA2APrincipal(context.Context, string, CreateA2APrincipalInput) (IssuedA2APrincipal, error)
+	ListA2APrincipals(context.Context, string) ([]A2APrincipal, error)
+	ListA2APrincipalUsage(context.Context, string, A2APrincipalLimits) ([]A2APrincipalUsage, error)
+	RotateA2APrincipal(context.Context, string, string) (IssuedA2APrincipal, error)
+	SetA2APrincipalEnabled(context.Context, string, string, bool) (A2APrincipal, error)
+	AuthenticateA2APrincipal(context.Context, string, string) (A2APrincipal, error)
+	AcceptA2AMessage(context.Context, A2APrincipal, A2APrincipalLimits, AcceptA2AMessageInput) (A2ATaskCorrelation, error)
+	A2ATask(context.Context, A2APrincipal, string) (A2ATaskCorrelation, error)
+
+	CreateOutputStream(context.Context, string, CreateOutputStreamInput) (OutputStream, error)
+	ListOutputStreams(context.Context, string) ([]OutputStream, error)
+	OutputStream(context.Context, string, string) (OutputStream, error)
+	RemoveOutputStream(context.Context, string, string) error
+	SetOutputPublisher(context.Context, string, string, string, bool) (OutputStream, error)
+	PublishOutput(context.Context, outputPublisher, string, PublishOutputInput, string, string) (OutputValue, string, error)
+	readOutput(context.Context, string, string, string, int64, int, bool) (OutputHistory, *OutputValue, error)
+	CreateOutputPrincipal(context.Context, string, CreateOutputPrincipalInput) (IssuedOutputPrincipal, error)
+	ListOutputPrincipals(context.Context, string) ([]OutputPrincipal, error)
+	RotateOutputPrincipal(context.Context, string, string) (IssuedOutputPrincipal, error)
+	SetOutputPrincipalEnabled(context.Context, string, string, bool) (OutputPrincipal, error)
+}
+
+var _ storageBackend = (*Store)(nil)

--- a/bus/storage_test.go
+++ b/bus/storage_test.go
@@ -54,7 +54,7 @@ func TestStorageSummaryAndRetentionPreserveActiveObligations(t *testing.T) {
 	if _, err := agents.runtime.AddTask(ctx, agents.plannerToken, AddTaskInput{Title: "Still active", Dependencies: []string{dependency.ID}}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := agents.runtime.store.db.Exec(`UPDATE tasks SET updated_at=? WHERE task_id IN (?,?)`, old, independent.ID, dependency.ID); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE tasks SET updated_at=? WHERE task_id IN (?,?)`, old, independent.ID, dependency.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,7 +65,7 @@ func TestStorageSummaryAndRetentionPreserveActiveObligations(t *testing.T) {
 	if _, err := agents.runtime.ResolveEscalation(ctx, agents.scope.ScopeToken, resolved.ID, "yes"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := agents.runtime.store.db.Exec(`UPDATE escalations SET resolved_at=? WHERE escalation_id=?`, old, resolved.ID); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE escalations SET resolved_at=? WHERE escalation_id=?`, old, resolved.ID); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := agents.runtime.AskHuman(ctx, agents.reviewerToken, AskHumanInput{Question: "Pending question"}); err != nil {
@@ -139,7 +139,7 @@ func setMessageState(t *testing.T, agents testAgents, id string, state DeliveryS
 	if deliveredAt != 0 {
 		delivered = deliveredAt
 	}
-	if _, err := agents.runtime.store.db.Exec(`UPDATE messages SET state=?,acknowledged_at=?,delivered_at=? WHERE message_id=?`, state, acknowledged, delivered, id); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE messages SET state=?,acknowledged_at=?,delivered_at=? WHERE message_id=?`, state, acknowledged, delivered, id); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -150,7 +150,7 @@ func setMessageExpired(t *testing.T, agents testAgents, id string, expiresAt int
 	if delivered {
 		deliveredAt = expiresAt - 1
 	}
-	if _, err := agents.runtime.store.db.Exec(`UPDATE messages SET state='expired',expires_at=?,delivered_at=? WHERE message_id=?`, expiresAt, deliveredAt, id); err != nil {
+	if _, err := sqliteStore(t, agents.runtime).db.Exec(`UPDATE messages SET state='expired',expires_at=?,delivered_at=? WHERE message_id=?`, expiresAt, deliveredAt, id); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -175,7 +175,7 @@ func requireRowCount(t *testing.T, agents testAgents, table, column, id string, 
 	t.Helper()
 	query := `SELECT COUNT(*) FROM ` + table + ` WHERE ` + column + `=?`
 	var count int
-	if err := agents.runtime.store.db.QueryRow(query, id).Scan(&count); err != nil {
+	if err := sqliteStore(t, agents.runtime).db.QueryRow(query, id).Scan(&count); err != nil {
 		t.Fatal(err)
 	}
 	if count != want {

--- a/bus/store.go
+++ b/bus/store.go
@@ -64,6 +64,10 @@ func OpenStore(source string) (*Store, error) {
 
 func (s *Store) Close() error { return s.db.Close() }
 
+func (s *Store) Backend() StorageBackend { return StorageBackendSQLite }
+
+func (s *Store) Ping(ctx context.Context) error { return s.db.PingContext(ctx) }
+
 func (s *Store) initialize(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, `PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=2500;`); err != nil {
 		return err

--- a/bus/task_progress_test.go
+++ b/bus/task_progress_test.go
@@ -126,7 +126,7 @@ func TestTaskProgressCountIsBounded(t *testing.T) {
 	if _, err := agents.runtime.ClaimTask(ctx, agents.reviewerToken, task.ID); err != nil {
 		t.Fatal(err)
 	}
-	transaction, err := agents.runtime.store.db.Begin()
+	transaction, err := sqliteStore(t, agents.runtime).db.Begin()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/october-bus/main.go
+++ b/cmd/october-bus/main.go
@@ -118,6 +118,8 @@ type diagnosticReport struct {
 	RuntimeDirectory string `json:"runtimeDirectory"`
 	DatabaseExists   bool   `json:"databaseExists"`
 	RunFileExists    bool   `json:"runFileExists"`
+	StorageBackend   string `json:"storageBackend,omitempty"`
+	StorageStatus    string `json:"storageStatus,omitempty"`
 	Problem          string `json:"problem,omitempty"`
 }
 
@@ -155,8 +157,14 @@ func doctor(args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			health, healthErr := (bus.Client{Address: run.Address}).Health(ctx)
 			cancel()
+			report.StorageBackend = string(health.Storage.Backend)
+			report.StorageStatus = health.Storage.Status
 			if healthErr != nil {
-				report.Problem = healthErr.Error()
+				if health.Storage.Status == bus.StorageUnavailable {
+					report.Problem = "Storage backend is unavailable"
+				} else {
+					report.Problem = healthErr.Error()
+				}
 			} else if health.ProtocolVersion != run.ProtocolVersion {
 				report.Problem = "run file and daemon protocol versions differ"
 			} else {
@@ -186,6 +194,9 @@ func doctor(args []string) error {
 		if report.Address != "" {
 			fmt.Printf("Endpoint: %s, pid %d\n", report.Address, report.PID)
 		}
+		if report.StorageBackend != "" {
+			fmt.Printf("Storage: %s (%s)\n", report.StorageBackend, report.StorageStatus)
+		}
 		if report.Problem != "" {
 			fmt.Printf("Problem: %s\n", report.Problem)
 		}
@@ -213,6 +224,7 @@ func status() error {
 	}
 	fmt.Printf("October Bus is %s at %s\n", health.Status, run.Address)
 	fmt.Printf("Runtime %s, protocol %s, pid %d\n", health.RuntimeVersion, health.ProtocolVersion, run.PID)
+	fmt.Printf("Storage %s (%s)\n", health.Storage.Backend, health.Storage.Status)
 	return nil
 }
 

--- a/docs/architecture/storage-backends.md
+++ b/docs/architecture/storage-backends.md
@@ -1,0 +1,39 @@
+# Storage backend contract
+
+October Bus keeps protocol behavior above its storage implementation. The runtime depends on a domain-level storage contract instead of issuing database queries from HTTP, MCP, or A2A handlers.
+
+SQLite is the default and currently supported backend. It requires no external service and keeps local operation simple.
+
+## Required behavior
+
+Every backend must preserve the same observable semantics:
+
+- accepted messages are durable before success is returned;
+- idempotent retries return the original result;
+- inbox reservation, delivery, and acknowledgement transitions are atomic;
+- one request accepts at most one response;
+- task claims belong to one current execution;
+- dependencies are checked in the same transaction as task claims;
+- scope events commit with the state change they describe;
+- credentials are stored as one-way digests;
+- retention preserves active delivery, reply, task, and escalation obligations;
+- archive import applies completely or not at all.
+
+A backend cannot weaken these rules to match the features of its database.
+
+## Readiness
+
+The runtime reports its backend name and whether the backend is reachable. Liveness and readiness are separate:
+
+- `GET /health/live` reports whether the server process can answer requests;
+- `GET /health/ready` reports whether protocol operations can reach storage;
+- `GET /health` is the standard readiness endpoint.
+
+Health responses never contain a database address or credential.
+
+## PostgreSQL
+
+PostgreSQL support requires its own versioned schema, migrations, transaction tests, and concurrency checks. It must pass the same public conformance profile as SQLite before it is supported.
+
+Shared deployments may run several stateless Bus server instances over one PostgreSQL database. Independent databases are not replicas of one scope, and storage support does not grant a server authority over processes running on another host.
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,6 +15,8 @@ october-bus stop
 
 `stop` sends an authenticated shutdown request through the local endpoint. The admin token stays in the protected run file and is not passed on the command line.
 
+Service supervisors can use `GET /health/live` for liveness and `GET /health/ready` for readiness. Readiness includes storage availability and returns HTTP 503 when storage cannot be reached. Health responses do not include database addresses or credentials.
+
 Use `october-bus doctor --json` for machine-readable diagnostics. It reports versions, paths, process state, and endpoint health. It does not print credentials or message content.
 
 ## MCP over stdio
@@ -74,6 +76,8 @@ october-bus task list --ready
 Claims, progress updates, release, and completion require an execution-bound agent credential. Task listings include the most recent progress, notes, and blockers so a later agent or user can continue from durable state.
 
 ## Storage and retention
+
+The runtime accesses durable state through the [storage backend contract](architecture/storage-backends.md). SQLite remains the default and currently supported backend.
 
 Scope owners can inspect storage growth without reading message, task, or escalation content:
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -10,6 +10,7 @@ import type {
   AddTaskProgressInput,
   AskHumanInput,
   BusHealth,
+  BusLiveness,
   BusMessage,
   BusTask,
   CreateScopeInput,
@@ -152,6 +153,10 @@ export class OctoberBusAdminClient {
 
   health(options?: OperationOptions): Promise<BusHealth> {
     return request(this.address, undefined, 'GET', '/health', undefined, options)
+  }
+
+  liveness(options?: OperationOptions): Promise<BusLiveness> {
+    return request(this.address, undefined, 'GET', '/health/live', undefined, options)
   }
 
   createScope(input: CreateScopeInput = {}, options?: OperationOptions): Promise<CreateScopeResult> {

--- a/sdk/typescript/src/protocol.ts
+++ b/sdk/typescript/src/protocol.ts
@@ -535,6 +535,16 @@ export interface BusHealth {
   name: 'october-bus'
   protocolVersion: string
   runtimeVersion: string
-  status: 'ready'
+  status: 'ready' | 'not_ready'
+  startedAt: string
+  storage: {
+    backend: string
+    status: 'available' | 'unavailable'
+  }
+}
+
+export interface BusLiveness {
+  name: 'october-bus'
+  status: 'alive'
   startedAt: string
 }

--- a/sdk/typescript/test/integration.mjs
+++ b/sdk/typescript/test/integration.mjs
@@ -55,6 +55,9 @@ try {
   const health = await admin.health()
   assert.equal(health.protocolVersion, '0.1')
   assert.equal(typeof health.runtimeVersion, 'string')
+  assert.deepEqual(health.storage, { backend: 'sqlite', status: 'available' })
+  const liveness = await admin.liveness()
+  assert.equal(liveness.status, 'alive')
   const scope = await admin.createScope({ id: 'typescript-integration' })
   const owner = new OctoberBusScopeClient(run.address, scope.scopeToken)
   plannerSession = await OctoberBusAgentSession.start({

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -36,7 +36,9 @@ Failures use:
 
 | Method | Route | Authority | Result |
 | --- | --- | --- | --- |
-| `GET` | `/health` | None | Runtime health and protocol version |
+| `GET` | `/health` | None | Readiness, storage health, and protocol version |
+| `GET` | `/health/live` | None | Process liveness |
+| `GET` | `/health/ready` | None | Readiness, storage health, and protocol version |
 | `POST` | `/v1/admin/shutdown` | Admin | Accepted shutdown request |
 | `GET` | `/v1/admin/scopes/{scopeId}/export` | Admin | Portable scope archive |
 | `POST` | `/v1/admin/scopes/import` | Admin | Imported scope and one-time scope token |
@@ -93,6 +95,8 @@ Failures use:
 | `GET` | `/a2a/agents/{publicationId}/.well-known/agent-card.json` | None | Enabled A2A Agent Card |
 | `POST` | `/a2a/agents/{publicationId}/message:send` | Scoped A2A | Durable A2A Task |
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
+
+`/health/live` returns HTTP 200 while the server process can answer requests. `/health` and `/health/ready` return HTTP 200 only when the runtime can reach its storage backend. An unavailable backend returns HTTP 503 with `status: not_ready`. Health responses expose the backend name and availability, never its address or credentials.
 
 `POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -58,12 +58,32 @@
     "health": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "protocolVersion", "runtimeVersion", "status", "startedAt"],
+      "required": ["name", "protocolVersion", "runtimeVersion", "status", "startedAt", "storage"],
       "properties": {
         "name": { "const": "october-bus" },
         "protocolVersion": { "const": "0.1" },
         "runtimeVersion": { "type": "string", "minLength": 1 },
-        "status": { "const": "ready" },
+        "status": { "enum": ["ready", "not_ready"] },
+        "startedAt": { "$ref": "#/$defs/instant" },
+        "storage": { "$ref": "#/$defs/storageHealth" }
+      }
+    },
+    "storageHealth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["backend", "status"],
+      "properties": {
+        "backend": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["available", "unavailable"] }
+      }
+    },
+    "liveness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "startedAt"],
+      "properties": {
+        "name": { "const": "october-bus" },
+        "status": { "const": "alive" },
         "startedAt": { "$ref": "#/$defs/instant" }
       }
     },

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -3,6 +3,7 @@ package spec_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -333,6 +334,21 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 		t.Fatal(err)
 	}
 	requireValid(t, resolvedSchema(t, path, "health"), jsonValue(t, health))
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address+"/health/live", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var liveness bus.Liveness
+	decodeErr := json.NewDecoder(response.Body).Decode(&liveness)
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || decodeErr != nil {
+		t.Fatalf("unexpected liveness response: HTTP %d, %v", response.StatusCode, decodeErr)
+	}
+	requireValid(t, resolvedSchema(t, path, "liveness"), jsonValue(t, liveness))
 	scope, err := client.CreateScope(ctx, bus.CreateScopeInput{ID: "schema"})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- separate runtime coordination behavior from the SQLite implementation
- add storage-aware readiness and independent liveness endpoints
- expose storage status through the Go and TypeScript clients
- document the transactional contract every backend must preserve

## Validation

- Go race tests
- Go vet
- TypeScript typecheck and build
- TypeScript integration and error tests

Advances #11