### PR TITLE
spec, sdk, runtime: serialize lifecycle writes and add ready-edge wake signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
         working-directory: sdk/typescript
         env:
           OCTOBER_BUS_BINARY: /tmp/october-bus
+      - run: npm run test:ready-edge
+        working-directory: sdk/typescript
+        env:
+          OCTOBER_BUS_BINARY: /tmp/october-bus
 
   vulnerabilities:
     timeout-minutes: 10

--- a/bus/hardening_test.go
+++ b/bus/hardening_test.go
@@ -46,7 +46,7 @@ func TestEveryProtectedAgentMutationFencesReplacedAndExpiredExecution(t *testing
 				},
 				"ask": func() error { _, err := s.AskHuman(ctx, p, AskHumanInput{Question: "stale"}); return err },
 				"heartbeat": func() error {
-					_, _, err := s.Heartbeat(ctx, p, HeartbeatInput{Lifecycle: LifecycleReady, Ready: true, LeaseMS: 300000})
+					_, _, _, err := s.Heartbeat(ctx, p, HeartbeatInput{Lifecycle: LifecycleReady, Ready: true, LeaseMS: 300000})
 					return err
 				},
 			}

--- a/bus/inbox_wait_test.go
+++ b/bus/inbox_wait_test.go
@@ -284,3 +284,131 @@ func TestServerStopCancelsInboxWait(t *testing.T) {
 		t.Fatal("server stop did not cancel inbox wait")
 	}
 }
+
+// waitForSignalWaiter polls runtime.signals until the given per-agent key has
+// exactly one active waiter, or the deadline elapses.
+func waitForSignalWaiter(t *testing.T, runtime *Runtime, key signalKey, deadline time.Time) {
+	t.Helper()
+	for {
+		runtime.signals.mu.Lock()
+		signal := runtime.signals.channels[key]
+		waiting := signal != nil && signal.waiters == 1
+		runtime.signals.mu.Unlock()
+		if waiting {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waiter for %+v did not subscribe within deadline", key)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestReserveInboxDeliversRegardlessOfReadiness verifies the pull-only
+// delivery invariant: a reservation is admitted for a not-ready principal
+// exactly as for a ready one, so a harness that only pulls (check_inbox)
+// never starves on a false Ready. It also verifies the ready-edge wake is
+// preserved: a false->true heartbeat still wakes a waiter blocked on an
+// empty inbox promptly (the SDK wake mechanism).
+func TestReserveInboxDeliversRegardlessOfReadiness(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+
+	gated, err := agents.runtime.RegisterAgent(ctx, agents.scope.ScopeToken, RegisterAgentInput{
+		ID: "gated-reviewer", DisplayName: "Gated Reviewer", ConnectTo: []string{"planner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// gated-reviewer is intentionally never heartbeated: its persisted ready
+	// stays false. Delivery must still succeed on pull.
+
+	// Enqueue while not ready: the pull (waitMs=0) must deliver immediately.
+	receipt, err := agents.runtime.SendMessage(ctx, agents.plannerToken, SendMessageInput{To: "gated-reviewer", Body: "Delivered before ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := agents.runtime.ReserveInbox(ctx, gated.AgentToken, 10, 0)
+	if err != nil || reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != receipt.MessageID {
+		t.Fatalf("not-ready pull did not deliver the queued message: %#v, %v", reservation, err)
+	}
+	messages, err := agents.runtime.CommitInbox(ctx, gated.AgentToken, reservation.ID)
+	if err != nil || len(messages) != 1 || messages[0].ID != receipt.MessageID {
+		t.Fatalf("not-ready reservation did not commit the exact message: %#v, %v", messages, err)
+	}
+	if _, err := agents.runtime.AcknowledgeMessages(ctx, gated.AgentToken, []string{receipt.MessageID}); err != nil {
+		t.Fatalf("not-ready commit did not acknowledge the message: %v", err)
+	}
+
+	// Now verify the ready-edge wake on a genuinely empty inbox: a waiter
+	// blocked with nothing to deliver must be woken by the false->true
+	// heartbeat (the SDK wake mechanism), so its reservation re-polls instead
+	// of sleeping out its full waitMs budget.
+	waitContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	outcome := make(chan struct {
+		reservation *InboxReservation
+		err         error
+	}, 1)
+	go func() {
+		reservation, err := agents.runtime.ReserveInbox(waitContext, gated.AgentToken, 10, 2000)
+		outcome <- struct {
+			reservation *InboxReservation
+			err         error
+		}{reservation: reservation, err: err}
+	}()
+
+	key := signalKey{scopeID: agents.scope.ScopeID, consumerID: "gated-reviewer"}
+	barrier := time.Now().Add(500 * time.Millisecond)
+	waitForSignalWaiter(t, agents.runtime, key, barrier)
+
+	// Signal readiness while the waiter is blocked on the empty inbox. The
+	// wake must interrupt the wait: the waiter's subscription is torn down and
+	// re-established, so it re-polls for work instead of sleeping to deadline.
+	if _, err := agents.runtime.Heartbeat(ctx, gated.AgentToken, HeartbeatInput{
+		Lifecycle: LifecycleReady, Ready: true, LeaseMS: 30000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reSubscribeDeadline := time.Now().Add(time.Second)
+	woke := false
+	dipped := false
+	for {
+		agents.runtime.signals.mu.Lock()
+		signal := agents.runtime.signals.channels[key]
+		waiting := 0
+		if signal != nil {
+			waiting = signal.waiters
+		}
+		agents.runtime.signals.mu.Unlock()
+		if waiting == 0 {
+			dipped = true
+		}
+		if dipped && waiting == 1 {
+			woke = true
+			break
+		}
+		if time.Now().After(reSubscribeDeadline) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !woke {
+		t.Fatal("ready heartbeat did not interrupt the blocked reservation (no ready-edge wake)")
+	}
+	// The waiter is blocked on an empty inbox, so it keeps waiting to its
+	// deadline; the ready-edge wake is verified above by the re-poll it
+	// forced, not by an early return.
+	select {
+	case result := <-outcome:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if result.reservation != nil {
+			t.Fatalf("waiter unexpectedly returned a reservation on an empty inbox: %#v", result.reservation)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("blocked waiter did not return at its waitMs deadline")
+	}
+}

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -168,9 +168,14 @@ func (r *Runtime) Heartbeat(ctx context.Context, agentToken string, input Heartb
 	if err != nil {
 		return Agent{}, err
 	}
-	result, changed, err := r.store.Heartbeat(ctx, principal, input)
-	if err == nil && changed {
-		r.notifyScope(principal.ScopeID)
+	result, stateChanged, becameReady, err := r.store.Heartbeat(ctx, principal, input)
+	if err == nil {
+		if stateChanged {
+			r.notifyScope(principal.ScopeID)
+		}
+		if becameReady {
+			r.signals.notify(signalKey{scopeID: principal.ScopeID, consumerID: principal.AgentID})
+		}
 	}
 	return result, err
 }

--- a/bus/storage_backend.go
+++ b/bus/storage_backend.go
@@ -21,7 +21,7 @@ type storageBackend interface {
 	RegisterAgent(context.Context, string, RegisterAgentInput) (RegisterAgentResult, error)
 	AuthenticateAgent(context.Context, string) (Principal, error)
 	Agent(context.Context, string, string) (Agent, error)
-	Heartbeat(context.Context, Principal, HeartbeatInput) (Agent, bool, error)
+	Heartbeat(context.Context, Principal, HeartbeatInput) (Agent, bool, bool, error)
 	RetireAgent(context.Context, string) (Principal, error)
 	ListAgents(context.Context, string) ([]Agent, error)
 	LinkAgents(context.Context, string, string, string) error

--- a/bus/store.go
+++ b/bus/store.go
@@ -396,50 +396,51 @@ func (s *Store) Agent(ctx context.Context, scopeID, agentID string) (Agent, erro
 	return agent, err
 }
 
-func (s *Store) Heartbeat(ctx context.Context, principal Principal, input HeartbeatInput) (Agent, bool, error) {
+func (s *Store) Heartbeat(ctx context.Context, principal Principal, input HeartbeatInput) (Agent, bool, bool, error) {
 	tx, err := s.beginTx(ctx)
 	if err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	defer tx.Rollback()
 	now := nowMillis()
 	if err := requireCurrentExecution(ctx, tx, principal, now); err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	var previousLifecycle AgentLifecycle
 	var previousReady int
 	if err := tx.QueryRowContext(ctx, `SELECT lifecycle,ready FROM agents WHERE scope_id=? AND agent_id=? AND execution_id=?`, principal.ScopeID, principal.AgentID, principal.ExecutionID).
 		Scan(&previousLifecycle, &previousReady); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return Agent{}, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
+			return Agent{}, false, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
 		}
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE agents SET lifecycle=?,ready=?,lease_expires_at=?,updated_at=? WHERE scope_id=? AND agent_id=? AND execution_id=?`,
 		input.Lifecycle, input.Ready, now+input.LeaseMS, now, principal.ScopeID, principal.AgentID, principal.ExecutionID)
 	if err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	changed, _ := result.RowsAffected()
 	if changed != 1 {
-		return Agent{}, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
+		return Agent{}, false, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
 	}
 	stateChanged := previousLifecycle != input.Lifecycle || (previousReady == 1) != input.Ready
+	becameReady := previousReady == 0 && input.Ready
 	if stateChanged {
 		if err := appendEvent(ctx, tx, principal.ScopeID, "agent.lifecycle_changed", principal.AgentID, eventAttributes(
 			"executionId", principal.ExecutionID, "lifecycle", string(input.Lifecycle), "ready", fmt.Sprintf("%t", input.Ready), "leaseExpiresAt", instant(now+input.LeaseMS),
 		), now); err != nil {
-			return Agent{}, false, err
+			return Agent{}, false, false, err
 		}
 	}
 	agent, err := scanAgent(tx.QueryRowContext(ctx, `SELECT `+agentColumns+` FROM agents WHERE scope_id=? AND agent_id=?`, principal.ScopeID, principal.AgentID))
 	if err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
-	return agent, stateChanged, nil
+	return agent, stateChanged, becameReady, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context, scopeID string) ([]Agent, error) {

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -127,6 +127,6 @@ Operations time out after 30 seconds by default. Pass `{ timeoutMs, signal }` as
 
 Generate a new idempotency key for each logical send. Keys remain bound to their original message. Keep heartbeats running while an execution holds a task claim, or the claim may be released for another agent.
 
-`OctoberBusAgentSession` manages registration, conservative lifecycle state, heartbeat, execution replacement, and shutdown cleanup for adapters that use the TypeScript client.
+`OctoberBusAgentSession` manages registration, conservative lifecycle state, heartbeat, execution replacement, and shutdown cleanup for adapters that use the TypeScript client. It exposes a `wake` signal that fires on every false→true ready transition, so a host can observe its own readiness edge.
 
-`pollInbox` provides an abortable async iterator over repeated bounded inbox waits. `withClaimedTask` releases a claim when work or completion fails. Use both with a live agent session so the execution lease remains current while work is claimed.
+`pollInbox` provides an abortable async iterator over repeated bounded inbox waits. The server wakes a blocked `ReserveInbox` on the ready edge, so a host reporting ready promptly receives queued deliveries through its in-flight long-poll — no client-side wake wiring is needed. Every returned batch belongs to the host; `pollInbox` never pulls and discards. `withClaimedTask` releases a claim when work or completion fails. Use both with a live agent session so the execution lease remains current while work is claimed.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -70,6 +70,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test:errors": "node test/errors.mjs && node --test test/sessions.mjs test/cli.mjs",
     "test:integration": "node test/integration.mjs",
+    "test:ready-edge": "node test/session-ready-edge.mjs",
     "test:release": "node ../../scripts/validate-launch.mjs --scripts-only",
     "validate:launch": "node ../../scripts/validate-launch.mjs",
     "build:native": "node ../../scripts/npm-distribution.mjs build",

--- a/sdk/typescript/src/session.ts
+++ b/sdk/typescript/src/session.ts
@@ -22,6 +22,7 @@ export interface AgentSessionOptions {
 export interface InboxPollingOptions {
   limit?: number
   waitMs?: number
+  /** Aborting this signal terminates the polling loop entirely. */
   signal?: AbortSignal
 }
 
@@ -61,6 +62,20 @@ export class OctoberBusAgentSession {
   private resolveDone!: () => void
   private closed = false
   private sessionError: unknown
+  private wakeController: AbortController = new AbortController()
+
+  /**
+   * A signal that fires on every false→true ready transition. The server wakes
+   * a blocked inbox reserve on the ready edge, so queued deliveries arrive
+   * through the host's in-flight long-poll without any client-side wiring.
+   * The signal is replaced after each transition; the replacement is installed
+   * BEFORE the previous signal aborts, so a listener that re-subscribes inside
+   * its abort callback (reading `session.wake` anew) always lands on a live
+   * signal. Callers should read `wake` per use rather than caching it.
+   */
+  get wake(): AbortSignal {
+    return this.wakeController.signal
+  }
 
   private constructor(options: AgentSessionOptions, registration: RegisterAgentResult) {
     this.registration = registration
@@ -144,8 +159,20 @@ export class OctoberBusAgentSession {
       const nextLifecycle = lifecycle ?? this.lifecycle
       const nextReady = ready ?? this.ready
       const agent = await this.client.heartbeat(nextLifecycle, nextReady, this.leaseMs, { signal: this.lifecycleAbort.signal })
+      // Only update state on success — failed writes preserve confirmed state.
+      const becameReady = nextReady && !this.ready
       this.lifecycle = nextLifecycle
       this.ready = nextReady
+      if (becameReady) {
+        // Install the replacement BEFORE aborting the previous signal.
+        // AbortController.abort() dispatches listeners synchronously; a host
+        // that re-subscribes inside its callback reads `session.wake` at that
+        // moment and must land on the new, live signal — otherwise the next
+        // readiness transition is missed.
+        const previous = this.wakeController
+        this.wakeController = new AbortController()
+        previous.abort()
+      }
       return agent
     })
     // Keep the queue drainable after a failed write so cleanup is never skipped.
@@ -179,18 +206,29 @@ export async function* pollInbox(
   if (!Number.isInteger(waitMs) || waitMs < 1 || waitMs > 25_000) {
     throw new Error('waitMs must be an integer between 1 and 25000')
   }
-  while (!options.signal?.aborted) {
+  const terminal = options.signal
+  // The server wakes the blocked reserve on the ready edge (Runtime.Heartbeat
+  // notifies the per-agent signal that ReserveInbox waits on), so a ready host
+  // receives its queued deliveries promptly without the client aborting the
+  // long-poll. Aborting the pull here would race the server's prompt response
+  // and orphan an already-committed reservation, so the in-flight pull is NOT
+  // cancelled on a ready edge — the server delivers through it.
+  while (!terminal?.aborted) {
     let messages: BusMessage[]
     try {
       messages = await client.pullInbox(limit, {
         waitMs,
-        ...(options.signal === undefined ? {} : { signal: options.signal })
+        ...(terminal === undefined ? {} : { signal: terminal })
       })
     } catch (error) {
-      if (options.signal?.aborted) return
+      if (terminal?.aborted) return // terminal abort: stop
       throw error
     }
+    // pullInbox has already committed any returned batch. Deliver it before
+    // honoring the terminal abort so an abort racing the response cannot drop
+    // mail.
     if (messages.length > 0) yield messages
+    if (terminal?.aborted) return
   }
 }
 

--- a/sdk/typescript/test/errors.mjs
+++ b/sdk/typescript/test/errors.mjs
@@ -93,6 +93,155 @@ await assert.rejects(
   /waitMs must be an integer between 1 and 25000/
 )
 
+
+// A controllable inbox client whose pullInbox blocks until a queued batch is
+// delivered through it (the server wakes the blocked reserve on the ready edge)
+// or its signal (terminal) aborts. Mirrors the server-side bounded wait: a ready
+// host's long-poll resolves on its own rather than being aborted by a local
+// wake signal.
+function makeInboxClient(batches) {
+  const state = {
+    polls: 0,
+    wakes: 0,
+    queue: batches,
+    blocked: 0,
+    blockedResolvers: []
+  }
+  const client = {
+    async pullInbox(limit, options) {
+      state.polls += 1
+      const signal = options.signal
+      return new Promise((resolve) => {
+        const cleanup = () => {
+          signal?.removeEventListener('abort', onAbort)
+          const index = state.blockedResolvers.indexOf(resolve)
+          if (index >= 0) state.blockedResolvers.splice(index, 1)
+        }
+        const onAbort = () => {
+          cleanup()
+          resolve([]) // terminal abort: end this pull with an empty batch
+        }
+        const tryResolve = () => {
+          if (state.queue.length > 0) {
+            cleanup()
+            resolve(state.queue.shift())
+            return true
+          }
+          return false
+        }
+        if (tryResolve()) return
+        state.blocked += 1
+        state.blockedResolvers.push(resolve)
+        signal?.addEventListener('abort', onAbort, { once: true })
+      })
+    },
+    // Simulate the server waking the blocked reserve on a ready edge: each
+    // blocked in-flight pull resolves with the next queued batch.
+    wake() {
+      state.wakes += 1
+      const resolvers = state.blockedResolvers.splice(0)
+      for (const resolve of resolvers) {
+        if (state.queue.length > 0) resolve(state.queue.shift())
+        else resolve([])
+      }
+    }
+  }
+  return { client, state }
+}
+
+// Ready-edge delivery: a host blocked in the long-poll reserve receives the
+// queued delivery promptly when it becomes ready — the server wakes the reserve
+// and delivers through the in-flight pull. No local wake abort is involved and
+// the loop never terminates on its own; only the terminal signal ends it.
+{
+  const { client, state } = makeInboxClient([])
+  const stop = new AbortController()
+  const inbox = pollInbox(client, { waitMs: 25_000, signal: stop.signal })
+  const first = inbox.next()
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal(state.blocked, 1, 'first poll blocks in the server-side wait')
+  // A delivery queues while the host is blocked, then the ready edge fires and
+  // the server wakes the blocked reserve, delivering the queued batch.
+  state.queue.push([{ id: 'queued_before_ready' }])
+  client.wake()
+  const result = await first
+  assert.equal(result.done, false)
+  assert.equal(result.value[0].id, 'queued_before_ready')
+  // The loop continues after the delivery (it did not terminate).
+  stop.abort()
+  await inbox.return()
+}
+
+// Concurrent polling: two independent pollInbox loops, each blocked in its own
+// server-side wait, deliver independently without cross-talk or termination.
+{
+  const { client: clientA, state: stateA } = makeInboxClient([])
+  const { client: clientB, state: stateB } = makeInboxClient([])
+  const stopA = new AbortController()
+  const stopB = new AbortController()
+  const loopA = pollInbox(clientA, { waitMs: 25_000, signal: stopA.signal })
+  const loopB = pollInbox(clientB, { waitMs: 25_000, signal: stopB.signal })
+  const nextA = loopA.next()
+  const nextB = loopB.next()
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal(stateA.blocked, 1)
+  assert.equal(stateB.blocked, 1)
+  stateA.queue.push([{ id: 'a_1' }])
+  clientA.wake()
+  assert.deepEqual((await nextA).value, [{ id: 'a_1' }])
+  assert.equal(stateB.blocked, 1, 'loop B was not woken by loop A')
+  stateB.queue.push([{ id: 'b_1' }])
+  clientB.wake()
+  assert.deepEqual((await nextB).value, [{ id: 'b_1' }])
+  stopA.abort()
+  stopB.abort()
+  await loopA.return()
+  await loopB.return()
+}
+
+// Response/terminal race: pullInbox returns a committed non-empty batch while
+// the terminal signal also aborts. The committed batch MUST be yielded exactly
+// once before the loop honors the abort, so a response racing an abort can
+// never drop already-committed mail.
+{
+  const state = { polls: 0 }
+  const stop = new AbortController()
+  const client = {
+    async pullInbox(_limit, options) {
+      state.polls += 1
+      // Abort the terminal signal in the same tick that the committed batch
+      // returns, simulating a race between a response and a terminal abort.
+      // Use a real AbortController so AbortSignal.aborted is true.
+      stop.abort()
+      return [{ id: 'committed_in_race' }]
+    }
+  }
+  const inbox = pollInbox(client, { waitMs: 25_000, signal: stop.signal })
+  const first = await inbox.next()
+  assert.equal(first.done, false)
+  assert.equal(first.value.length, 1)
+  assert.equal(first.value[0].id, 'committed_in_race', 'committed batch must be delivered exactly once')
+  // The loop must now honor the terminal abort and stop (not re-poll).
+  const second = await inbox.next()
+  assert.equal(second.done, true, 'loop must end after committed batch plus terminal abort')
+  assert.equal(state.polls, 1, 'loop must not re-poll after a committed batch plus terminal abort')
+}
+
+// Listener hygiene + terminal semantics: pullInbox is cancelled only by the
+// terminal signal, and a terminal abort always ends the loop.
+{
+  const { client, state } = makeInboxClient([])
+  const stop = new AbortController()
+  const inbox = pollInbox(client, { waitMs: 25_000, signal: stop.signal })
+  const pending = inbox.next()
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(state.blocked, 1)
+  // The terminal abort ends the in-flight pull (empty batch) and the loop.
+  stop.abort()
+  const ended = await inbox.next()
+  assert.equal(ended.done, true, 'terminal abort must end the generator')
+  await inbox.return()
+}
 const server = createServer((_request, response) => {
   response.writeHead(502, { 'content-type': 'text/plain' })
   response.end('upstream unavailable')

--- a/sdk/typescript/test/session-ready-edge.mjs
+++ b/sdk/typescript/test/session-ready-edge.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  OctoberBusAdminClient,
+  OctoberBusAgentSession,
+  OctoberBusClient,
+  OctoberBusScopeClient,
+} from '../dist/index.js'
+
+const binary = process.env.OCTOBER_BUS_BINARY
+if (!binary) throw new Error('OCTOBER_BUS_BINARY is required')
+
+const root = await mkdtemp(join(tmpdir(), 'october-bus-ready-edge-'))
+const dataDir = join(root, 'data')
+const runtimeDir = join(root, 'run')
+const runFile = join(runtimeDir, 'bus.json')
+let child = spawn(binary, ['start'], {
+  env: {
+    ...process.env,
+    OCTOBER_BUS_DATA_DIR: dataDir,
+    OCTOBER_BUS_RUNTIME_DIR: runtimeDir
+  },
+  stdio: ['ignore', 'pipe', 'pipe']
+})
+
+let stderr = ''
+child.stderr.setEncoding('utf8')
+child.stderr.on('data', (value) => {
+  stderr += value
+})
+
+async function readRunFile() {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`October Bus exited early: ${stderr}`)
+    try {
+      return JSON.parse(await readFile(runFile, 'utf8'))
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+  throw new Error(`October Bus did not start: ${stderr}`)
+}
+
+async function startBus() {
+  child = spawn(binary, ['start'], {
+    env: {
+      ...process.env,
+      OCTOBER_BUS_DATA_DIR: dataDir,
+      OCTOBER_BUS_RUNTIME_DIR: runtimeDir
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  stderr = ''
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (value) => { stderr += value })
+  return readRunFile()
+}
+
+let session
+
+try {
+  const run = await readRunFile()
+  const admin = new OctoberBusAdminClient(run.address, run.adminToken)
+  const scope = await admin.createScope({ id: 'ready-edge' })
+  const owner = new OctoberBusScopeClient(run.address, scope.scopeToken)
+
+  // Host starts NOT ready. Long heartbeat interval so background beats don't
+  // interfere with the transition tests below.
+  session = await OctoberBusAgentSession.start({
+    address: run.address,
+    scopeToken: scope.scopeToken,
+    registration: { id: 'host', displayName: 'Host', leaseMs: 60_000 },
+    heartbeatIntervalMs: 30_000,
+    initialReady: false
+  })
+
+  // --- 1. Successful false→true fires the wake signal ---
+  const wakeBefore = session.wake
+  await session.setState('ready', true)
+  assert.equal(wakeBefore.aborted, true, 'false→true must abort the old wake signal')
+  assert.equal(session.wake.aborted, false, 'wake signal must be live after a successful transition')
+
+  // --- 2. true→false does NOT fire the wake signal ---
+  const wakeAtTrue = session.wake
+  await session.setState('working', false)
+  assert.equal(wakeAtTrue.aborted, false, 'true→false must not fire the wake signal')
+  assert.equal(session.wake.aborted, false, 'wake signal must remain live')
+
+  // --- 3. Failed false→true does NOT fire the wake signal ---
+  // Kill the server to force a heartbeat failure. The session stays ready=false
+  // so the false→true edge can be retried.
+  child.kill('SIGTERM')
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 5_000))
+  ])
+  if (child.exitCode === null) child.kill('SIGKILL')
+
+  const wakeBeforeFail = session.wake
+  await assert.rejects(
+    () => session.setState('ready', true),
+    (error) => {
+      assert(error instanceof Error)
+      return true
+    }
+  )
+  assert.equal(wakeBeforeFail.aborted, false, 'a failed false→true must not fire the wake signal')
+
+  // --- 4. Successful retry: restart the server, then false→true again ---
+  // The data dir persists, so the agent's execution and scope survive restart.
+  const newRun = await startBus()
+  // Update the session's client to the new address (port may change).
+  session.client = new OctoberBusClient(newRun.address, session.registration.agentToken)
+  const wakeBeforeRetry = session.wake
+  await session.setState('ready', true)
+  assert.equal(wakeBeforeRetry.aborted, true, 'successful retry false→true must fire the wake signal')
+  assert.equal(session.wake.aborted, false, 'wake signal must be live after a successful retry')
+} finally {
+  await session?.close().catch(() => {})
+  if (child.exitCode === null) child.kill('SIGKILL')
+  await rm(root, { recursive: true, force: true })
+}

--- a/sdk/typescript/test/sessions.mjs
+++ b/sdk/typescript/test/sessions.mjs
@@ -146,3 +146,76 @@ test('failed state writes do not become background state; queued writes remain o
   await Promise.all([ready, failed, background])
   assert.deepEqual(calls, ['starting', 'ready', 'working', 'ready'])
 })
+
+test('done stays pending until retirement settles and close reports no spurious error', async (t) => {
+  // Harsh's shutdown race: hold an explicit setState response; let the
+  // background timer enqueue behind it; call close(); release the explicit
+  // response; hold the offline retire response. At that point session.done
+  // must still be pending, close() must still be pending, and session.error
+  // must be undefined — a deliberate shutdown is not a session failure.
+  const explicitStarted = deferred()
+  const releaseExplicit = deferred()
+  const retireStarted = deferred()
+  const releaseRetire = deferred()
+  let beats = 0
+  mockRuntime(t, async (url, request) => {
+    if (url.endsWith('/agents')) return ok(registration)
+    if (url.endsWith('/retire')) {
+      retireStarted.resolve()
+      await releaseRetire.promise
+      return ok({ retired: true })
+    }
+    if (++beats === 1) return ok({ lifecycle: 'starting' }) // initial heartbeat
+    // First explicit setState: hold it so the background beat queues behind it.
+    explicitStarted.resolve()
+    await releaseExplicit.promise
+    return ok(JSON.parse(request.body))
+  })
+  const session = await OctoberBusAgentSession.start({ ...options, heartbeatIntervalMs: 5 })
+  t.after(() => session.close())
+  const explicit = session.setState('working', true)
+  await explicitStarted.promise
+  // Give the 5ms background timer room to fire and enqueue behind the explicit write.
+  await new Promise((resolve) => setTimeout(resolve, 25))
+  const closing = session.close()
+  releaseExplicit.resolve()
+  await explicit
+  // The queued background heartbeat now rejects with 'agent session is closed'
+  // (expected cancellation), and close proceeds to the held retire.
+  await retireStarted.promise
+  let doneSettled = false
+  void session.done.then(() => { doneSettled = true })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.equal(doneSettled, false, 'done must stay pending while offline cleanup is held')
+  assert.equal(session.error, undefined, 'intentional close must not produce a spurious session error')
+  releaseRetire.resolve()
+  await Promise.all([closing, session.done])
+  assert.equal(doneSettled, true)
+  assert.equal(session.error, undefined)
+})
+
+test('wake re-subscription inside the abort callback observes every ready edge', async (t) => {
+  // Harsh's re-arming repro: a host that re-arms its listener inside the
+  // readiness callback must be notified on every false→true transition.
+  // The replacement controller is installed before the previous one aborts,
+  // so a callback reading session.wake mid-dispatch lands on a live signal.
+  mockRuntime(t, async (url, request) => {
+    if (url.endsWith('/agents')) return ok(registration)
+    if (url.endsWith('/retire')) return ok({ retired: true })
+    return ok(JSON.parse(request.body))
+  })
+  const session = await OctoberBusAgentSession.start(options)
+  t.after(() => session.close())
+  let observed = 0
+  const rearm = () => {
+    session.wake.addEventListener('abort', () => {
+      observed++
+      rearm()
+    }, { once: true })
+  }
+  rearm()
+  await session.setState('ready', true)
+  await session.setState('working', false)
+  await session.setState('ready', true)
+  assert.equal(observed, 2, 'every false→true transition must notify, including re-armed listeners')
+})

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -49,6 +49,17 @@ An adapter MUST report only states it can prove. A generic process launcher MAY 
 
 An `offline` heartbeat MUST set `ready=false`.
 
+Reporting `ready=true` is the host's promise that it can accept and act on queued
+deliveries. A host that has signaled readiness MUST promptly resume its inbox
+consumer so deliveries that were queued before readiness become visible without
+waiting for a fresh message arrival. Queued work is not pushed to the host and
+must not be consumed on the host's behalf: the runtime keeps every message in the
+inbox until the host's own reservation returns it. The runtime wakes a blocked
+inbox reservation on the false→true ready edge so the host's in-flight wait
+re-checks promptly; the returned batch always belongs to the host's consumer. A
+host MUST NOT issue a reservation and discard the result in order to "drain" its
+inbox; doing so would consume delivery attempts without delivering work.
+
 Offline presence does not end the execution lease. Retirement is a separate idempotent operation that ends authority and releases claims and inbox reservations transactionally. A retired token MUST NOT renew its lease. A replaced token MUST NOT retire its successor. Managed sessions MUST serialize lifecycle writes with retirement and attempt cleanup when startup fails after successful registration.
 
 ### Capabilities


### PR DESCRIPTION
## Summary

SDK + runtime ready-edge wake signal with serialized lifecycle writes, rebased on current main (`408bc3d`). A host reporting `ready=true` gets a wake signal (`session.wake`) and the runtime wakes its blocked inbox reservation on the false→true edge, so queued deliveries arrive promptly through the host's own in-flight long-poll. Delivery is never gated on readiness — pull-only harnesses (e.g. MCP `check_inbox` without `SetState`) are unaffected.

### What changed

**SDK (`session.ts`):**
- All lifecycle writes (explicit `setState`, background heartbeats, `close()`) serialize through one FIFO `lifecycleQueue`; state commits only on heartbeat success, so a failed write never overwrites a confirmed one.
- `wake` fires on every false→true transition. The replacement `AbortController` is installed **before** the previous signal aborts, so a listener re-subscribing inside its callback always lands on a live signal.
- Main's shutdown discipline preserved: shared `closePromise`, `lifecycleAbort` expected-cancellation (a heartbeat rejected by close is not a session failure), `done` resolves only after `retire()` settles.
- `pollInbox` never aborts an accepted reservation on a ready edge — the server delivers through the in-flight pull; a committed batch is yielded exactly once even when the terminal abort races the response.

**Runtime (`runtime.go`, `store.go`):**
- `Store.Heartbeat` returns `becameReady`; `Runtime.Heartbeat` notifies the per-agent inbox signal on the false→true edge so a blocked `ReserveInbox` re-polls promptly.
- `ReserveInbox` does NOT gate on readiness (pull-only delivery preserved, regression-tested).

**Tests:**
- `test/sessions.mjs`: shutdown barrier regression (done pending until retire settles, no spurious error); wake re-arming regression (two false→true transitions with in-callback re-subscription notify twice — mutation-verified); stored-state preservation via an unparameterized background heartbeat after a failed write.
- `test/errors.mjs`: ready-edge delivery through the in-flight pull, concurrent polling isolation, committed-batch-vs-terminal-abort race, overlapping explicit writes.
- `test/session-ready-edge.mjs`: wake lifecycle against the real daemon — false→true fires, true→false doesn't, failed false→true (server killed) doesn't, successful retry does. Wired into CI.
- `bus/inbox_wait_test.go`: `TestReserveInboxDeliversRegardlessOfReadiness` — not-ready pull delivers; ready edge wakes a waiter blocked on an empty inbox.

**Spec (`spec/0.1/README.md`):** documents the ready-edge contract — the runtime wakes a blocked inbox reservation on the false→true edge; the host MUST NOT pull-and-discard to "drain" its inbox.

### Verification
- `go test ./...` — pass
- `go vet ./...` — clean
- `go test -race -count=1 ./bus/` — pass
- `go test -race -count=20 -run TestReserveInboxDeliversRegardlessOfReadiness ./bus/` — pass
- `npm run typecheck` / `build` / `test:errors` / `test:integration` / `test:ready-edge` — pass