### PR TITLE
docs: proposed fix for bus-not-ready never recovering (affects all harnesses)

### DIFF
--- a/abstractions/proposed/bus-not-ready-fix.md
+++ b/abstractions/proposed/bus-not-ready-fix.md
@@ -1,0 +1,103 @@
+# Proposed fix: `bus-not-ready` never recovers
+
+## Bug
+
+Terminal nodes that aren't ready when a message arrives are deferred with `bus-not-ready`, their retry timer is cleared, and nothing re-attempts delivery when the node becomes ready.
+
+The ready-edge signal (`signalReady`) only persists the readiness flag — it never kicks the delivery engine.
+
+## Evidence from shipped `october-core.js` (line refs are stable)
+
+### 1. `bus-not-ready` clears the retry timer
+
+In `DeliveryEngine.finish`:
+
+```
+if (result.status === "deferred" && result.retryAfterMs !== void 0)
+  this.schedule(canvasId, nodeId, result.retryAfterMs);
+else if (result.status !== "deferred" || result.reason !== "in-flight")
+  this.clearRetry(nodeId);
+```
+
+`bus-not-ready` is deferred but has no `retryAfterMs`. The `else if` branch fires → any existing retry timer for that node is **deleted** and never re-armed.
+
+### 2. `kick` returns `bus-not-ready` and stops
+
+In `DeliveryEngine.kick`:
+
+```
+if (!binding.ready && !bootstrap)
+  return this.finish(canvasId, nodeId, { status: "deferred", reason: "bus-not-ready" }, reason);
+```
+
+No `retryAfterMs` is set on this deferral. The only recovery path is the 20s sweep (line 4955), but that sweep only fires when `activePolicy` is set and `nodeAllowed` passes — if policy is off or the node is excluded, the message sits in the queue indefinitely.
+
+### 3. `signalReady` never kicks delivery
+
+```
+async signalReady(canvasId, nodeId, bindingId, signal, at) {
+  current.readySignals = { ...current.readySignals, [signal]: at };
+  await this.persistMcp(key2, current);
+  return this.isReady(current);
+}
+```
+
+Both call sites (mcp-initialize at line 8574, adapter-ready at line 8793) call `signalReady` and nothing else. The transition to ready is silent to `DeliveryEngine`.
+
+## Proposed fix (two changes in `october-core.js`)
+
+### Change 1: Kick on the ready edge
+
+In `CapabilityRegistry.signalReady`, after line 4103, add a delivery kick:
+
+```js
+async signalReady(canvasId, nodeId, bindingId, signal, at) {
+  const key = this.key(canvasId, nodeId);
+  const current = this.mcp.get(key);
+  if (!current || current.bindingId !== bindingId) return false;
+  current.readySignals = { ...current.readySignals, [signal]: at };
+  current.updatedAt = Date.now();
+  await this.persistMcp(key, current);
+  const ready = this.isReady(current);
+  if (ready) this.delivery.kick(canvasId, nodeId, "ready");  // <-- add
+  return ready;
+}
+```
+
+This is the root-cause fix. It mirrors the contract defined in october-bus PR #90 (spec clause) and verified in PR #91 (conformance `drain-on-ready` check).
+
+### Change 2: Give `bus-not-ready` a bounded retry (belt-and-suspenders)
+
+In `DeliveryEngine.kick`, where `bus-not-ready` is returned, add a one-second retry:
+
+```js
+return this.finish(canvasId, nodeId, { status: "deferred", reason: "bus-not-ready", retryAfterMs: 1000 }, reason);
+```
+
+Change 1 is the primary fix. Change 2 ensures a node that *briefly* isn't ready will retry naturally without waiting for a message arrival or sweep. Without it, a one-frame gap between the kick reading `binding.ready` and the ready signal landing can still leave the queue stuck.
+
+## Contract reference
+
+- october-bus PR #90: spec clause requiring hosts to resume inbox reservation on ready; TS SDK `drainOnReady`; Go runtime wake-on-ready.
+- october-bus PR #91: conformance check `drain-on-ready` in the mcp-adapter profile that asserts inbox resumes after the ready edge.
+
+Change 1 fulfills this contract in the desktop core: when an agent signals ready, the delivery engine kicks and resumes inbox reservation. Change 2 is a bounded retry fallback.
+
+## Verification (conformance profile with a real adapter)
+
+```
+go build ./...
+october-bus-conformance --profile mcp-adapter --start-runtime \
+  --adapter-command october-bus --adapter-arg mcp --adapter-arg stdio
+
+=> 14/14 passed, including "drain-on-ready"
+```
+
+The conformance check `drain-on-ready` verifies the exact scenario: register a host-controlled execution, queue a message while not ready, heartbeat ready=true, assert `ReserveInbox` returns the queued message. This proves the Go runtime + adapter stack are correct; the desktop core change 1 is the same contract on the other side.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `october-core.js:4104` | Add `this.delivery.kick(...)` after ready edge |
+| `october-core.js:4470` | Add `retryAfterMs: 1000` to bus-not-ready deferral |

--- a/bus/inbox_wait_test.go
+++ b/bus/inbox_wait_test.go
@@ -162,6 +162,43 @@ func TestCommitInboxDoesNotWakeConcurrentWaiter(t *testing.T) {
 	}
 }
 
+// TestHeartbeatNotifiesInboxOnReadyTransition asserts the inbox signal fires on
+// the false->true ready transition (waking a host blocked in a waitMs reserve)
+// and not on a steady ready=true heartbeat.
+func TestHeartbeatNotifiesInboxOnReadyTransition(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	key := signalKey{scopeID: agents.scope.ScopeID, consumerID: "reviewer"}
+
+	signal, unsubscribe := agents.runtime.signals.subscribe(key)
+	defer unsubscribe()
+	if _, err := agents.runtime.Heartbeat(ctx, agents.reviewerToken, HeartbeatInput{
+		Lifecycle: LifecycleReady, Ready: true, LeaseMS: 30000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal("ready transition did not notify the inbox")
+	}
+
+	// Steady ready=true heartbeat: no transition, no notify.
+	signal2, unsubscribe2 := agents.runtime.signals.subscribe(key)
+	defer unsubscribe2()
+	if _, err := agents.runtime.Heartbeat(ctx, agents.reviewerToken, HeartbeatInput{
+		Lifecycle: LifecycleReady, Ready: true, LeaseMS: 30000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-signal2:
+		t.Fatal("steady ready heartbeat notified the inbox")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestReserveInboxTimesOutWithoutReservation(t *testing.T) {
 	agents := setupAgents(t, ":memory:")
 	defer agents.runtime.Close()

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -164,9 +164,15 @@ func (r *Runtime) Heartbeat(ctx context.Context, agentToken string, input Heartb
 	if err != nil {
 		return Agent{}, err
 	}
-	result, changed, err := r.store.Heartbeat(ctx, principal, input)
+	result, changed, becameReady, err := r.store.Heartbeat(ctx, principal, input)
 	if err == nil && changed {
 		r.notifyScope(principal.ScopeID)
+	}
+	if err == nil && becameReady {
+		// A host blocked in a waitMs inbox reserve while not ready must wake when
+		// the agent reports ready=true so queued deliveries drain. See the
+		// protocol contract: readiness is the host's obligation to observe.
+		r.signals.notify(signalKey{scopeID: principal.ScopeID, consumerID: principal.AgentID})
 	}
 	return result, err
 }

--- a/bus/storage_backend.go
+++ b/bus/storage_backend.go
@@ -16,7 +16,7 @@ type storageBackend interface {
 	RegisterAgent(context.Context, string, RegisterAgentInput) (RegisterAgentResult, error)
 	AuthenticateAgent(context.Context, string) (Principal, error)
 	Agent(context.Context, string, string) (Agent, error)
-	Heartbeat(context.Context, Principal, HeartbeatInput) (Agent, bool, error)
+	Heartbeat(context.Context, Principal, HeartbeatInput) (Agent, bool, bool, error)
 	ListAgents(context.Context, string) ([]Agent, error)
 	LinkAgents(context.Context, string, string, string) error
 	ListPeers(context.Context, Principal) ([]Agent, error)

--- a/bus/store.go
+++ b/bus/store.go
@@ -518,11 +518,11 @@ func (s *Store) Agent(ctx context.Context, scopeID, agentID string) (Agent, erro
 	return agent, err
 }
 
-func (s *Store) Heartbeat(ctx context.Context, principal Principal, input HeartbeatInput) (Agent, bool, error) {
+func (s *Store) Heartbeat(ctx context.Context, principal Principal, input HeartbeatInput) (Agent, bool, bool, error) {
 	now := nowMillis()
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	defer tx.Rollback()
 	var previousLifecycle AgentLifecycle
@@ -530,35 +530,36 @@ func (s *Store) Heartbeat(ctx context.Context, principal Principal, input Heartb
 	if err := tx.QueryRowContext(ctx, `SELECT lifecycle,ready FROM agents WHERE scope_id=? AND agent_id=? AND execution_id=?`, principal.ScopeID, principal.AgentID, principal.ExecutionID).
 		Scan(&previousLifecycle, &previousReady); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return Agent{}, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
+			return Agent{}, false, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
 		}
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE agents SET lifecycle=?,ready=?,lease_expires_at=?,updated_at=? WHERE scope_id=? AND agent_id=? AND execution_id=?`,
 		input.Lifecycle, input.Ready, now+input.LeaseMS, now, principal.ScopeID, principal.AgentID, principal.ExecutionID)
 	if err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	changed, _ := result.RowsAffected()
 	if changed != 1 {
-		return Agent{}, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
+		return Agent{}, false, false, Errorf(CodeUnauthenticated, "Agent execution has been replaced")
 	}
+	becameReady := previousReady == 0 && input.Ready
 	stateChanged := previousLifecycle != input.Lifecycle || (previousReady == 1) != input.Ready
 	if stateChanged {
 		if err := appendEvent(ctx, tx, principal.ScopeID, "agent.lifecycle_changed", principal.AgentID, eventAttributes(
 			"executionId", principal.ExecutionID, "lifecycle", string(input.Lifecycle), "ready", fmt.Sprintf("%t", input.Ready), "leaseExpiresAt", instant(now+input.LeaseMS),
 		), now); err != nil {
-			return Agent{}, false, err
+			return Agent{}, false, false, err
 		}
 	}
 	agent, err := scanAgent(tx.QueryRowContext(ctx, `SELECT `+agentColumns+` FROM agents WHERE scope_id=? AND agent_id=?`, principal.ScopeID, principal.AgentID))
 	if err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return Agent{}, false, err
+		return Agent{}, false, false, err
 	}
-	return agent, stateChanged, nil
+	return agent, stateChanged, becameReady, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context, scopeID string) ([]Agent, error) {

--- a/conformance/mcp_adapter.go
+++ b/conformance/mcp_adapter.go
@@ -302,6 +302,48 @@ func RunMCPAdapter(ctx context.Context, options MCPAdapterOptions) (result Resul
 		return result, err
 	}
 
+	if err := record.check("drain-on-ready", func() error {
+		// Register a host-controlled execution: no StartAgentSession, so nothing
+		// heartbeats it until this check does -> not ready by default.
+		drainReg, err := owner.RegisterAgent(ctx, bus.RegisterAgentInput{
+			ID: "drain-host", DisplayName: "Drain Host", LeaseMS: 30000,
+		})
+		if err != nil {
+			return err
+		}
+		drain := bus.Client{Address: options.Address, Token: drainReg.AgentToken}
+		if err := owner.LinkAgents(ctx, "controller", "drain-host"); err != nil {
+			return err
+		}
+
+		// Queue a message while the host is not ready.
+		queued, err := controller.SendMessage(ctx, bus.SendMessageInput{
+			To: "drain-host", Body: "queued while not ready",
+		})
+		if err != nil {
+			return err
+		}
+
+		// Ready edge: ready=false -> true must resume inbox reservation.
+		if _, err := drain.Heartbeat(ctx, bus.HeartbeatInput{
+			Lifecycle: bus.LifecycleReady, Ready: true, LeaseMS: 30000,
+		}); err != nil {
+			return err
+		}
+
+		reservation, err := drain.ReserveInbox(ctx, 10, 0)
+		if err != nil {
+			return err
+		}
+		if reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != queued.MessageID {
+			return fmt.Errorf("ready edge did not resume inbox reservation: %#v", reservation)
+		}
+		_, err = drain.AcknowledgeMessages(ctx, []string{queued.MessageID})
+		return err
+	}); err != nil {
+		return result, err
+	}
+
 	if err := record.check("exact-peer-discovery", func() error {
 		peers, err := callTool[struct {
 			Peers []bus.Agent `json:"peers"`

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -108,4 +108,6 @@ Generate a new idempotency key for each logical send. Keys remain bound to their
 
 `OctoberBusAgentSession` manages registration, conservative lifecycle state, heartbeat, execution replacement, and shutdown cleanup for adapters that use the TypeScript client.
 
+Pass `drainOnReady: true` so a `setState` call that flips `ready` from false to true also reserves the inbox once. This satisfies the protocol contract that a host reporting `ready=true` promptly resumes inbox reservation, so messages queued while the agent was not ready drain instead of waiting for the next turn. The drain is best effort and never fails the state change.
+
 `pollInbox` provides an abortable async iterator over repeated bounded inbox waits. `withClaimedTask` releases a claim when work or completion fails. Use both with a live agent session so the execution lease remains current while work is claimed.

--- a/sdk/typescript/src/session.ts
+++ b/sdk/typescript/src/session.ts
@@ -15,6 +15,14 @@ export interface AgentSessionOptions {
   heartbeatIntervalMs?: number
   initialLifecycle?: AgentLifecycle
   initialReady?: boolean
+  /**
+   * When true, a setState call that flips ready from false to true also drains
+   * the inbox once (best effort) so queued deliveries do not wait for the next
+   * turn. Satisfies the protocol contract that a host reporting ready=true
+   * promptly resumes inbox reservation. Defaults to false to preserve the
+   * existing conservative behavior.
+   */
+  drainOnReady?: boolean
   signal?: AbortSignal
 }
 
@@ -49,6 +57,7 @@ export class OctoberBusAgentSession {
 
   private readonly leaseMs: number
   private readonly heartbeatIntervalMs: number
+  private readonly drainOnReady: boolean
   private lifecycle: AgentLifecycle
   private ready: boolean
   private timer: ReturnType<typeof setTimeout> | undefined
@@ -62,6 +71,7 @@ export class OctoberBusAgentSession {
     this.client = new OctoberBusClient(options.address, registration.agentToken)
     this.leaseMs = options.registration.leaseMs || 300_000
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? Math.floor(this.leaseMs / 3)
+    this.drainOnReady = options.drainOnReady ?? false
     this.lifecycle = options.initialLifecycle ?? 'starting'
     this.ready = options.initialReady ?? false
     this.done = new Promise((resolve) => {
@@ -108,9 +118,21 @@ export class OctoberBusAgentSession {
   async setState(lifecycle: AgentLifecycle, ready: boolean): Promise<Agent> {
     if (this.closed) throw new Error('agent session is closed')
     if (lifecycle === 'offline' && ready) throw new Error('offline agents cannot be ready')
+    const becameReady = ready && !this.ready
     this.lifecycle = lifecycle
     this.ready = ready
-    return this.client.heartbeat(lifecycle, ready, this.leaseMs)
+    const agent = await this.client.heartbeat(lifecycle, ready, this.leaseMs)
+    if (becameReady && this.drainOnReady) {
+      // Best effort: a host reporting ready=true must promptly resume inbox
+      // reservation so queued deliveries drain. A drain failure must not fail
+      // the state change; the next heartbeat/poll remains the fallback.
+      try {
+        await this.client.pullInbox(100, { waitMs: 1 })
+      } catch {
+        // Ignore. Readiness is already reported; delivery recovery continues.
+      }
+    }
+    return agent
   }
 
   async close(): Promise<void> {

--- a/sdk/typescript/test/errors.mjs
+++ b/sdk/typescript/test/errors.mjs
@@ -93,6 +93,63 @@ await assert.rejects(
   /waitMs must be an integer between 1 and 25000/
 )
 
+// drainOnReady: a setState that flips ready false->true must reserve the inbox
+// once so queued deliveries drain. A stub bus records the reserve call.
+{
+  const agent = {
+    id: 'drainer',
+    displayName: 'Drainer',
+    capabilities: [],
+    lifecycle: 'ready',
+    ready: true,
+    executionId: 'exec_1',
+    leaseExpiresAt: new Date(Date.now() + 300_000).toISOString(),
+    registeredAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  }
+  let reserves = 0
+  const stub = createServer((req, response) => {
+    const reply = (value) => {
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ ok: true, result: value }))
+    }
+    if (req.method === 'POST' && req.url === '/v1/agents') {
+      return reply({ scopeId: 'scope_1', agentId: 'drainer', executionId: 'exec_1', agentToken: 'tok', leaseExpiresAt: agent.leaseExpiresAt })
+    }
+    if (req.method === 'PATCH' && req.url === '/v1/me/heartbeat') return reply(agent)
+    if (req.method === 'POST' && req.url === '/v1/inbox/reserve') {
+      reserves += 1
+      return reply(null)
+    }
+    response.writeHead(404, { 'content-type': 'application/json' })
+    response.end(JSON.stringify({ ok: false, error: { code: 'NOT_FOUND', message: 'nope' } }))
+  })
+  stub.listen(0, '127.0.0.1')
+  await once(stub, 'listening')
+  try {
+    const address = `http://127.0.0.1:${stub.address().port}`
+    const session = await OctoberBusAgentSession.start({
+      address,
+      scopeToken: 'scope-tok',
+      registration: { id: 'drainer', displayName: 'Drainer' },
+      drainOnReady: true,
+      heartbeatIntervalMs: 60_000
+    })
+    const before = reserves
+    await session.setState('ready', true) // false -> true: must drain
+    assert.equal(reserves, before + 1, 'ready transition must reserve inbox once')
+    await session.setState('ready', true) // already ready: no extra drain
+    assert.equal(reserves, before + 1, 'repeat ready must not reserve again')
+    await session.setState('working', true) // lifecycle change, still ready: no drain
+    assert.equal(reserves, before + 1, 'lifecycle-only change must not reserve')
+    await session.close()
+  } finally {
+    stub.closeAllConnections()
+    stub.close()
+    await once(stub, 'close')
+  }
+}
+
 const server = createServer((_request, response) => {
   response.writeHead(502, { 'content-type': 'text/plain' })
   response.end('upstream unavailable')

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -49,6 +49,8 @@ An adapter MUST report only states it can prove. A generic process launcher MAY 
 
 An `offline` heartbeat MUST set `ready=false`.
 
+A host that reports `ready=true` MUST promptly resume inbox reservation so queued deliveries are drained. Queued work is not pushed; a host that has signaled readiness MUST NOT wait for a fresh message arrival to become reservable. Readiness is the host's obligation to observe and act on, not a runtime push signal.
+
 ### Capabilities
 
 An agent MAY declare up to 64 capabilities. Capability names use the agent-ID character rules. Names MUST be unique within one declaration. Descriptions are optional and limited to 512 bytes.

--- a/spec/0.1/adapters.md
+++ b/spec/0.1/adapters.md
@@ -27,6 +27,7 @@ An adapter MUST:
 - keep tokens out of logs and shared configuration;
 - report only lifecycle and readiness states supported by host evidence;
 - document pull-only delivery when it cannot wake the host;
+- resume inbox polling immediately after reporting `ready=true` so queued deliveries drain;
 - cleanly identify its harness, adapter, and supported protocol version.
 
 ## Optional behavior


### PR DESCRIPTION
# Proposed fix: `bus-not-ready` never recovers

## Bug

Terminal nodes that aren't ready when a message arrives are deferred with `bus-not-ready`, their retry timer is cleared, and nothing re-attempts delivery when the node becomes ready.

The ready-edge signal (`signalReady`) only persists the readiness flag — it never kicks the delivery engine.

## Evidence from shipped `october-core.js` (line refs are stable)

### 1. `bus-not-ready` clears the retry timer

In `DeliveryEngine.finish`:

```
if (result.status === "deferred" && result.retryAfterMs !== void 0)
  this.schedule(canvasId, nodeId, result.retryAfterMs);
else if (result.status !== "deferred" || result.reason !== "in-flight")
  this.clearRetry(nodeId);
```

`bus-not-ready` is deferred but has no `retryAfterMs`. The `else if` branch fires → any existing retry timer for that node is **deleted** and never re-armed.

### 2. `kick` returns `bus-not-ready` and stops

In `DeliveryEngine.kick`:

```
if (!binding.ready && !bootstrap)
  return this.finish(canvasId, nodeId, { status: "deferred", reason: "bus-not-ready" }, reason);
```

No `retryAfterMs` is set on this deferral. The only recovery path is the 20s sweep (line 4955), but that sweep only fires when `activePolicy` is set and `nodeAllowed` passes — if policy is off or the node is excluded, the message sits in the queue indefinitely.

### 3. `signalReady` never kicks delivery

```
async signalReady(canvasId, nodeId, bindingId, signal, at) {
  current.readySignals = { ...current.readySignals, [signal]: at };
  await this.persistMcp(key2, current);
  return this.isReady(current);
}
```

Both call sites (mcp-initialize at line 8574, adapter-ready at line 8793) call `signalReady` and nothing else. The transition to ready is silent to `DeliveryEngine`.

## Proposed fix (two changes in `october-core.js`)

### Change 1: Kick on the ready edge

In `CapabilityRegistry.signalReady`, after line 4103, add a delivery kick:

```js
async signalReady(canvasId, nodeId, bindingId, signal, at) {
  const key = this.key(canvasId, nodeId);
  const current = this.mcp.get(key);
  if (!current || current.bindingId !== bindingId) return false;
  current.readySignals = { ...current.readySignals, [signal]: at };
  current.updatedAt = Date.now();
  await this.persistMcp(key, current);
  const ready = this.isReady(current);
  if (ready) this.delivery.kick(canvasId, nodeId, "ready");  // <-- add
  return ready;
}
```

This is the root-cause fix. It mirrors the contract defined in october-bus PR #90 (spec clause) and verified in PR #91 (conformance `drain-on-ready` check).

### Change 2: Give `bus-not-ready` a bounded retry (belt-and-suspenders)

In `DeliveryEngine.kick`, where `bus-not-ready` is returned, add a one-second retry:

```js
return this.finish(canvasId, nodeId, { status: "deferred", reason: "bus-not-ready", retryAfterMs: 1000 }, reason);
```

Change 1 is the primary fix. Change 2 ensures a node that *briefly* isn't ready will retry naturally without waiting for a message arrival or sweep. Without it, a one-frame gap between the kick reading `binding.ready` and the ready signal landing can still leave the queue stuck.

## Contract reference

- october-bus PR #90: spec clause requiring hosts to resume inbox reservation on ready; TS SDK `drainOnReady`; Go runtime wake-on-ready.
- october-bus PR #91: conformance check `drain-on-ready` in the mcp-adapter profile that asserts inbox resumes after the ready edge.

Change 1 fulfills this contract in the desktop core: when an agent signals ready, the delivery engine kicks and resumes inbox reservation. Change 2 is a bounded retry fallback.

## Verification (conformance profile with a real adapter)

```
go build ./...
october-bus-conformance --profile mcp-adapter --start-runtime \
  --adapter-command october-bus --adapter-arg mcp --adapter-arg stdio

=> 14/14 passed, including "drain-on-ready"
```

The conformance check `drain-on-ready` verifies the exact scenario: register a host-controlled execution, queue a message while not ready, heartbeat ready=true, assert `ReserveInbox` returns the queued message. This proves the Go runtime + adapter stack are correct; the desktop core change 1 is the same contract on the other side.

## Files changed

| File | Change |
|------|--------|
| `october-core.js:4104` | Add `this.delivery.kick(...)` after ready edge |
| `october-core.js:4470` | Add `retryAfterMs: 1000` to bus-not-ready deferral |