### PR TITLE
feat: add runnable A2A Agent Card server example (closes #9)

### DIFF
--- a/examples/a2a-agent-card/README.md
+++ b/examples/a2a-agent-card/README.md
@@ -1,0 +1,31 @@
+# A2A Agent Card example
+
+A minimal, runnable server that exposes an [A2A Agent Card][a2a] at
+`/.well-known/agent-card.json`.
+
+## Run
+
+```sh
+go run ./examples/a2a-agent-card
+```
+
+The server listens on `127.0.0.1:8080` by default. Override with the `PORT`
+environment variable:
+
+```sh
+PORT=9090 go run ./examples/a2a-agent-card
+```
+
+## Verify
+
+```sh
+curl http://127.0.0.1:8080/.well-known/agent-card.json
+```
+
+## Test
+
+```sh
+go test ./examples/a2a-agent-card/
+```
+
+[a2a]: https://a2aproject.github.io/A2A/latest/

--- a/examples/a2a-agent-card/main.go
+++ b/examples/a2a-agent-card/main.go
@@ -1,0 +1,57 @@
+// Example A2A Agent Card server.
+//
+// Run with:
+//
+//	go run ./examples/a2a-agent-card
+//
+// Then curl:
+//
+//	curl http://127.0.0.1:8080/.well-known/agent-card.json
+//
+// The PORT environment variable overrides the default (8080).
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/october-dev/october-bus/a2abridge"
+)
+
+const defaultPort = "8080"
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	card, err := a2abridge.NewAgentCard(a2abridge.AgentProfile{
+		DisplayName: "October Bus Example Agent",
+		Capabilities: []a2abridge.Capability{
+			{Name: "chat", Description: "Conversational chat capability."},
+			{Name: "code_review", Description: "Reviews code changes for correctness and style."},
+		},
+	}, a2abridge.CardOptions{
+		InterfaceURL: "http://127.0.0.1:" + port,
+	})
+	if err != nil {
+		log.Fatalf("creating agent card: %v", err)
+	}
+
+	handler, err := a2abridge.NewAgentCardHandler(card)
+	if err != nil {
+		log.Fatalf("creating handler: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(a2abridge.AgentCardPath, handler)
+
+	addr := "127.0.0.1:" + port
+	fmt.Printf("Agent Card server listening on http://%s%s\n", addr, a2abridge.AgentCardPath)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("server: %v", err)
+	}
+}

--- a/examples/a2a-agent-card/main_test.go
+++ b/examples/a2a-agent-card/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/october-dev/october-bus/a2abridge"
+)
+
+func TestAgentCardServer(t *testing.T) {
+	card, err := a2abridge.NewAgentCard(a2abridge.AgentProfile{
+		DisplayName: "Test Agent",
+		Capabilities: []a2abridge.Capability{
+			{Name: "test_cap", Description: "A test capability."},
+		},
+	}, a2abridge.CardOptions{
+		InterfaceURL: "http://127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatalf("NewAgentCard: %v", err)
+	}
+
+	handler, err := a2abridge.NewAgentCardHandler(card)
+	if err != nil {
+		t.Fatalf("NewAgentCardHandler: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle(a2abridge.AgentCardPath, handler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + a2abridge.AgentCardPath)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if name, ok := body["name"].(string); !ok || name != "Test Agent" {
+		t.Fatalf("unexpected name: %v", body["name"])
+	}
+
+	skills, ok := body["skills"].([]any)
+	if !ok || len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %v", body["skills"])
+	}
+
+	fmt.Fprintf(os.Stderr, "TestAgentCardServer: card endpoint returned valid agent card JSON\n")
+}


### PR DESCRIPTION
Adds a runnable A2A Agent Card server example.

- 57-line agent-card server built on `a2abridge.NewAgentCard`
- Exposes a curl-able `.well-known` URL serving the Agent Card

Tests pass: `go test ./examples/a2a-agent-card/`

Closes #9