### PR TITLE
fix(spec): align HTTP contract with reference runtime

### DIFF
--- a/bus/http_contract_test.go
+++ b/bus/http_contract_test.go
@@ -1,0 +1,189 @@
+package bus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// These tests protect the reference runtime contract documented in
+// spec/0.1/http.md; they are intentionally narrower than conformance coverage.
+type httpContractFixture struct {
+	server   *Server
+	scope    CreateScopeResult
+	planner  RegisterAgentResult
+	reviewer RegisterAgentResult
+}
+
+func newHTTPContractFixture(t *testing.T) *httpContractFixture {
+	t.Helper()
+	runtimeValue, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewServer(runtimeValue, ServerOptions{AdminToken: "contract-admin-token"})
+	t.Cleanup(func() {
+		if err := server.Stop(context.Background()); err != nil {
+			t.Error(err)
+		}
+	})
+	scope, err := runtimeValue.CreateScope(context.Background(), CreateScopeInput{ID: "contract"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	planner, err := runtimeValue.RegisterAgent(context.Background(), scope.ScopeToken, RegisterAgentInput{ID: "planner", DisplayName: "Planner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewer, err := runtimeValue.RegisterAgent(context.Background(), scope.ScopeToken, RegisterAgentInput{ID: "reviewer", DisplayName: "Reviewer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtimeValue.LinkAgents(context.Background(), scope.ScopeToken, planner.AgentID, reviewer.AgentID); err != nil {
+		t.Fatal(err)
+	}
+	return &httpContractFixture{server: server, scope: scope, planner: planner, reviewer: reviewer}
+}
+
+func contractRequest(t *testing.T, fixture *httpContractFixture, method, path, token string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var data []byte
+	var err error
+	if body != nil {
+		data, err = json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := httptest.NewRequest(method, path, bytes.NewReader(data))
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response := httptest.NewRecorder()
+	fixture.server.ServeHTTP(response, request)
+	return response
+}
+
+func TestHTTPContract(t *testing.T) {
+	t.Run("health bare + headers", func(t *testing.T) {
+		fixture := newHTTPContractFixture(t)
+		response := contractRequest(t, fixture, http.MethodGet, "/health", "", nil)
+		if response.Code != http.StatusOK {
+			t.Fatalf("health returned HTTP %d: %s", response.Code, response.Body.String())
+		}
+		if got := response.Header().Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		if got := response.Header().Get("Cache-Control"); got != "no-store" {
+			t.Fatalf("Cache-Control = %q, want no-store", got)
+		}
+		var health Health
+		if err := json.Unmarshal(response.Body.Bytes(), &health); err != nil {
+			t.Fatal(err)
+		}
+		if health.Status != "ready" {
+			t.Fatalf("unexpected health response: %#v", health)
+		}
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(response.Body.Bytes(), &object); err != nil {
+			t.Fatal(err)
+		}
+		if _, enveloped := object["ok"]; enveloped {
+			t.Fatal("health response unexpectedly contains an ok envelope field")
+		}
+	})
+
+	t.Run("register agent 201", func(t *testing.T) {
+		fixture := newHTTPContractFixture(t)
+		response := contractRequest(t, fixture, http.MethodPost, "/v1/agents", fixture.scope.ScopeToken, map[string]any{
+			"id": "implementer", "displayName": "Implementer",
+		})
+		if response.Code != http.StatusCreated {
+			t.Fatalf("register returned HTTP %d: %s", response.Code, response.Body.String())
+		}
+		var envelope responseEnvelope[RegisterAgentResult]
+		if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if !envelope.OK || envelope.Result.AgentToken == "" {
+			t.Fatalf("unexpected register response: %#v", envelope)
+		}
+	})
+
+	t.Run("list agents array", func(t *testing.T) {
+		fixture := newHTTPContractFixture(t)
+		response := contractRequest(t, fixture, http.MethodGet, "/v1/agents", fixture.scope.ScopeToken, nil)
+		if response.Code != http.StatusOK {
+			t.Fatalf("list returned HTTP %d: %s", response.Code, response.Body.String())
+		}
+		var envelope struct {
+			OK     bool              `json:"ok"`
+			Result []json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if !envelope.OK || len(envelope.Result) != 2 {
+			t.Fatalf("unexpected list response: %#v", envelope)
+		}
+	})
+
+	t.Run("link left/right", func(t *testing.T) {
+		fixture := newHTTPContractFixture(t)
+		response := contractRequest(t, fixture, http.MethodPost, "/v1/links", fixture.scope.ScopeToken, map[string]any{
+			"left": fixture.planner.AgentID, "right": fixture.reviewer.AgentID,
+		})
+		if response.Code != http.StatusOK {
+			t.Fatalf("link returned HTTP %d: %s", response.Code, response.Body.String())
+		}
+		var envelope responseEnvelope[map[string]bool]
+		if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if !envelope.OK || len(envelope.Result) != 1 || !envelope.Result["linked"] {
+			t.Fatalf("unexpected link response: %#v", envelope)
+		}
+
+		for name, body := range map[string]any{
+			"from/to":       map[string]any{"from": fixture.planner.AgentID, "to": fixture.reviewer.AgentID},
+			"missing right": map[string]any{"left": fixture.planner.AgentID},
+		} {
+			t.Run(name, func(t *testing.T) {
+				response := contractRequest(t, fixture, http.MethodPost, "/v1/links", fixture.scope.ScopeToken, body)
+				if response.Code != http.StatusBadRequest {
+					t.Fatalf("invalid link returned HTTP %d: %s", response.Code, response.Body.String())
+				}
+				var envelope responseEnvelope[json.RawMessage]
+				if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+					t.Fatal(err)
+				}
+				if envelope.OK || envelope.Error.Code != CodeInvalidArgument {
+					t.Fatalf("unexpected invalid link response: %#v", envelope)
+				}
+			})
+		}
+	})
+
+	t.Run("send message 202", func(t *testing.T) {
+		fixture := newHTTPContractFixture(t)
+		response := contractRequest(t, fixture, http.MethodPost, "/v1/messages", fixture.planner.AgentToken, map[string]any{
+			"to": fixture.reviewer.AgentID, "body": "Review this", "mode": "request",
+		})
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("send returned HTTP %d: %s", response.Code, response.Body.String())
+		}
+		var envelope responseEnvelope[DeliveryReceipt]
+		if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if !envelope.OK || envelope.Result.MessageID == "" || envelope.Result.State != DeliveryQueued {
+			t.Fatalf("unexpected send response: %#v", envelope)
+		}
+	})
+}

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -32,6 +32,10 @@ Failures use:
 }
 ```
 
+For Bus API responses using the envelope above, success status codes are route-specific. Clients MUST treat any 2xx response with `ok: true` as success and MUST NOT require HTTP 200. The reference runtime returns HTTP 201 from `POST /v1/agents` because a new execution was created, and HTTP 202 from `POST /v1/messages` because the message is durably accepted but not yet delivered.
+
+`/health`, `/health/live`, and `/health/ready` return the bare `health` and `liveness` objects without the `ok` and `result` envelope so generic probes can read them. They still set `Content-Type: application/json` and `Cache-Control: no-store`.
+
 ## Routes
 
 | Method | Route | Authority | Result |
@@ -44,13 +48,13 @@ Failures use:
 | `POST` | `/v1/admin/scopes/import` | Admin | Imported scope and one-time scope token |
 | `POST` | `/v1/scopes` | Admin | New scope ID and scope token |
 | `POST` | `/v1/agents` | Scope | New execution identity, lease, and agent token |
-| `GET` | `/v1/agents` | Scope | Agents in the scope |
-| `POST` | `/v1/links` | Scope | Symmetric peer link |
+| `GET` | `/v1/agents` | Scope | Array of `agent` objects |
+| `POST` | `/v1/links` | Scope | `{"linked": true}` (idempotent) |
 | `PATCH` | `/v1/me/heartbeat` | Agent | Renewed presence |
 | `GET` | `/v1/peers` | Agent | Linked peers |
 | `POST` | `/v1/messages` | Agent | Durable delivery receipt |
 | `GET` | `/v1/messages/{messageId}` | Sender or recipient | Delivery receipt |
-| `POST` | `/v1/messages/ack` | Recipient | Acknowledgement count |
+| `POST` | `/v1/messages/ack` | Recipient | `{"acknowledged": n}` |
 | `POST` | `/v1/inbox/reserve` | Agent | Reservation or `null` |
 | `POST` | `/v1/inbox/{reservationId}/commit` | Reserving agent | Delivered messages |
 | `POST` | `/v1/inbox/{reservationId}/release` | Reserving agent | Release confirmation |
@@ -97,6 +101,8 @@ Failures use:
 | `POST` | `/mcp` | Agent | MCP Streamable HTTP endpoint |
 
 `/health/live` returns HTTP 200 while the server process can answer requests. `/health` and `/health/ready` return HTTP 200 only when the runtime can reach its storage backend. An unavailable backend returns HTTP 503 with `status: not_ready`. Health responses expose the backend name and availability, never its address or credentials.
+
+`POST /v1/links` accepts `linkAgentsInput` (`left` and `right` agent IDs). The link is symmetric, and repeating an existing link succeeds. `POST /v1/messages/ack` accepts `acknowledgeMessagesInput` and returns `acknowledgeMessagesResult`; `acknowledged` counts messages this call moved from delivered to acknowledged, so a repeated acknowledgement returns 0.
 
 `POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
 

--- a/spec/0.1/schemas/protocol.schema.json
+++ b/spec/0.1/schemas/protocol.schema.json
@@ -178,6 +178,15 @@
         "updatedAt": { "$ref": "#/$defs/instant" }
       }
     },
+    "linkAgentsInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["left", "right"],
+      "properties": {
+        "left": { "$ref": "#/$defs/identifier" },
+        "right": { "$ref": "#/$defs/identifier" }
+      }
+    },
     "sendMessageInput": {
       "type": "object",
       "additionalProperties": false,
@@ -246,6 +255,25 @@
         "acknowledgedAt": { "$ref": "#/$defs/instant" },
         "repliedAt": { "$ref": "#/$defs/instant" },
         "responseMessageId": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "acknowledgeMessagesInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "messageIds": {
+          "type": "array",
+          "maxItems": 100,
+          "items": { "$ref": "#/$defs/identifier" }
+        }
+      }
+    },
+    "acknowledgeMessagesResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["acknowledged"],
+      "properties": {
+        "acknowledged": { "type": "integer", "minimum": 0 }
       }
     },
     "reserveInboxInput": {

--- a/spec/schema_test.go
+++ b/spec/schema_test.go
@@ -97,6 +97,12 @@ func TestProtocolSchemas(t *testing.T) {
 	requireInvalid(t, register, map[string]any{"id": "bad id", "displayName": "Reviewer"})
 	requireInvalid(t, register, map[string]any{"displayName": "Reviewer", "unknown": true})
 
+	link := resolvedSchema(t, path, "linkAgentsInput")
+	requireValid(t, link, map[string]any{"left": "planner", "right": "reviewer"})
+	requireInvalid(t, link, map[string]any{"left": "planner"})
+	requireInvalid(t, link, map[string]any{"left": "bad id", "right": "reviewer"})
+	requireInvalid(t, link, map[string]any{"left": "planner", "right": "reviewer", "unknown": true})
+
 	send := resolvedSchema(t, path, "sendMessageInput")
 	requireValid(t, send, map[string]any{
 		"to": "reviewer", "body": "Review this", "mode": "request",
@@ -111,6 +117,25 @@ func TestProtocolSchemas(t *testing.T) {
 	requireInvalid(t, send, map[string]any{
 		"to": "planner", "body": "Unexpected correlation", "mode": "notify", "responseTo": "msg_123",
 	})
+
+	acknowledgeInput := resolvedSchema(t, path, "acknowledgeMessagesInput")
+	requireValid(t, acknowledgeInput, map[string]any{"messageIds": []any{"msg_123"}})
+	requireValid(t, acknowledgeInput, map[string]any{})
+	requireValid(t, acknowledgeInput, map[string]any{"messageIds": []any{}})
+	tooManyMessageIDs := make([]any, 101)
+	for index := range tooManyMessageIDs {
+		tooManyMessageIDs[index] = "msg_123"
+	}
+	requireInvalid(t, acknowledgeInput, map[string]any{"messageIds": tooManyMessageIDs})
+	requireInvalid(t, acknowledgeInput, map[string]any{"messageIds": []any{"bad id"}})
+	requireInvalid(t, acknowledgeInput, map[string]any{"messageIds": []any{}, "unknown": true})
+
+	acknowledgeResult := resolvedSchema(t, path, "acknowledgeMessagesResult")
+	requireValid(t, acknowledgeResult, map[string]any{"acknowledged": float64(0)})
+	requireInvalid(t, acknowledgeResult, map[string]any{})
+	requireInvalid(t, acknowledgeResult, map[string]any{"acknowledged": float64(-1)})
+	requireInvalid(t, acknowledgeResult, map[string]any{"acknowledged": 1.5})
+	requireInvalid(t, acknowledgeResult, map[string]any{"acknowledged": float64(0), "unknown": true})
 
 	reserve := resolvedSchema(t, path, "reserveInboxInput")
 	requireValid(t, reserve, map[string]any{"limit": float64(50), "waitMs": float64(25000)})
@@ -420,6 +445,34 @@ func TestReferenceRuntimeResponsesMatchProtocolSchemas(t *testing.T) {
 		t.Fatalf("unexpected messages: %#v, %v", messages, err)
 	}
 	requireValid(t, resolvedSchema(t, path, "message"), jsonValue(t, messages[0]))
+	acknowledgeSchema := resolvedSchema(t, path, "acknowledgeMessagesResult")
+	acknowledge := func(expected float64) {
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, address+"/v1/messages/ack", strings.NewReader(`{"messageIds":["`+messages[0].ID+`"]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Header.Set("Authorization", "Bearer "+reviewerRegistration.AgentToken)
+		request.Header.Set("Content-Type", "application/json")
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var envelope struct {
+			OK     bool           `json:"ok"`
+			Result map[string]any `json:"result"`
+		}
+		decodeErr := json.NewDecoder(response.Body).Decode(&envelope)
+		response.Body.Close()
+		if response.StatusCode != http.StatusOK || decodeErr != nil || !envelope.OK {
+			t.Fatalf("unexpected acknowledgement response: HTTP %d, %#v, %v", response.StatusCode, envelope, decodeErr)
+		}
+		requireValid(t, acknowledgeSchema, envelope.Result)
+		if envelope.Result["acknowledged"] != expected {
+			t.Fatalf("acknowledged = %#v, want %v", envelope.Result["acknowledged"], expected)
+		}
+	}
+	acknowledge(1)
+	acknowledge(0)
 	task, err := planner.AddTask(ctx, bus.AddTaskInput{Title: "Review"})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Document route-specific success handling, including the reference runtime's 201 agent registration and 202 message acceptance responses. Clarify that health endpoints return bare JSON objects with probe-safe response headers.

Define the linkAgentsInput, acknowledgeMessagesInput, and acknowledgeMessagesResult schemas. Specify the agent-list array and the links and acknowledgement result shapes.

Add schema boundary cases, raw acknowledgement schema coupling, and focused HTTP regression tests for health, registration, agent listing, links, and message submission.

Tests: go test ./bus/ ./spec/

Fixes #99