### PR TITLE
fix(auth): return forbidden for wrong scope authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ go run ./cmd/october-bus scope create my-project
 
 The command returns a scope token. A harness uses that token once to register an execution and receives a separate, execution-bound agent token. The TypeScript client lives in `sdk/typescript`. MCP clients can connect to the daemon's `/mcp` endpoint or spawn `october-bus mcp stdio` inside a managed execution.
 
+Migration note: scope-authority endpoints now distinguish a valid credential of the wrong authority from an invalid credential. Agent, A2A-principal, and output-principal credentials receive `PERMISSION_DENIED` (HTTP 403) on scope-only routes; missing, malformed, expired, disabled, and replaced credentials continue to receive `UNAUTHENTICATED` (HTTP 401). Clients should correct the credential type on 403 and only treat 401 as failed authentication.
+
 Use the scope as a persistent project todo board:
 
 ```bash

--- a/bus/a2a_principals.go
+++ b/bus/a2a_principals.go
@@ -205,7 +205,7 @@ func (s *Store) AuthenticateA2APrincipal(ctx context.Context, credential, public
 }
 
 func (r *Runtime) CreateA2APrincipal(ctx context.Context, scopeToken string, input CreateA2APrincipalInput) (IssuedA2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return IssuedA2APrincipal{}, err
 	}
@@ -223,7 +223,7 @@ func (r *Runtime) CreateA2APrincipal(ctx context.Context, scopeToken string, inp
 }
 
 func (r *Runtime) ListA2APrincipals(ctx context.Context, scopeToken string) ([]A2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (r *Runtime) ListA2APrincipals(ctx context.Context, scopeToken string) ([]A
 }
 
 func (r *Runtime) ListA2APrincipalUsage(ctx context.Context, scopeToken string) ([]A2APrincipalUsage, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (r *Runtime) ListA2APrincipalUsage(ctx context.Context, scopeToken string) 
 }
 
 func (r *Runtime) RotateA2APrincipal(ctx context.Context, scopeToken, principalID string) (IssuedA2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return IssuedA2APrincipal{}, err
 	}
@@ -254,7 +254,7 @@ func (r *Runtime) RotateA2APrincipal(ctx context.Context, scopeToken, principalI
 }
 
 func (r *Runtime) SetA2APrincipalEnabled(ctx context.Context, scopeToken, principalID string, enabled bool) (A2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return A2APrincipal{}, err
 	}

--- a/bus/a2a_principals_test.go
+++ b/bus/a2a_principals_test.go
@@ -132,7 +132,7 @@ func TestA2APrincipalAuthorityAndRetention(t *testing.T) {
 	if _, err := agents.runtime.CreateA2APrincipal(ctx, agents.plannerToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Denied"}); err == nil {
 		t.Fatal("agent authority created a remote principal")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	otherScope, err := agents.runtime.CreateScope(ctx, CreateScopeInput{ID: "other"})
 	if err != nil {
@@ -178,12 +178,12 @@ func TestA2APrincipalPersistsWithoutExposingSecretToBusAPIs(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := NewServer(agents.runtime, ServerOptions{})
-	for _, path := range []string{"/v1/agents", "/mcp"} {
+	for path, want := range map[string]int{"/v1/agents": http.StatusForbidden, "/mcp": http.StatusUnauthorized} {
 		request := httptest.NewRequest(http.MethodGet, path, nil)
 		request.Header.Set("Authorization", "Bearer "+issued.Credential)
 		response := httptest.NewRecorder()
 		server.ServeHTTP(response, request)
-		if response.Code != http.StatusUnauthorized {
+		if response.Code != want {
 			t.Fatalf("scoped credential accessed %s: %d %s", path, response.Code, response.Body.String())
 		}
 	}

--- a/bus/a2a_publications.go
+++ b/bus/a2a_publications.go
@@ -140,7 +140,7 @@ func (s *Store) PublishedAgent(ctx context.Context, publicationID string) (agent
 }
 
 func (r *Runtime) CreateAgentCardPublication(ctx context.Context, scopeToken string, input PublishAgentCardInput) (agentCardPublication, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return agentCardPublication{}, err
 	}
@@ -155,7 +155,7 @@ func (r *Runtime) CreateAgentCardPublication(ctx context.Context, scopeToken str
 }
 
 func (r *Runtime) ListAgentCardPublications(ctx context.Context, scopeToken string) ([]agentCardPublication, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (r *Runtime) ListAgentCardPublications(ctx context.Context, scopeToken stri
 }
 
 func (r *Runtime) SetAgentCardPublicationEnabled(ctx context.Context, scopeToken, publicationID string, enabled bool) (agentCardPublication, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return agentCardPublication{}, err
 	}

--- a/bus/a2a_publications_test.go
+++ b/bus/a2a_publications_test.go
@@ -29,7 +29,7 @@ func TestAgentCardPublicationPersistsAndKeepsStableIdentity(t *testing.T) {
 	if _, err := agents.runtime.CreateAgentCardPublication(ctx, agents.plannerToken, PublishAgentCardInput{AgentID: agents.planner.AgentID}); err == nil {
 		t.Fatal("agent credential created a publication")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	if err := agents.runtime.Close(); err != nil {
 		t.Fatal(err)

--- a/bus/a2a_tasks_test.go
+++ b/bus/a2a_tasks_test.go
@@ -193,7 +193,7 @@ func TestA2APrincipalMessageLimitsAreIndependentAndAtomic(t *testing.T) {
 	if _, err := agents.runtime.ListA2APrincipalUsage(ctx, agents.plannerToken); err == nil {
 		t.Fatal("agent authority inspected remote principal usage")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	byPrincipal := map[string]A2APrincipalUsage{}
 	for _, item := range usage {

--- a/bus/credential_kind_test.go
+++ b/bus/credential_kind_test.go
@@ -1,0 +1,111 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCredentialKindClassifiesOnlyCurrentNonScopeCredentials(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	store := sqliteStore(t, agents.runtime)
+
+	publication, a2aPrincipal := setupA2APrincipal(t, agents)
+	if _, err := agents.runtime.SetAgentCardPublicationEnabled(ctx, agents.scope.ScopeToken, publication.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{Name: "credential-kind"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputPrincipal, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Credential classifier", Permissions: []OutputPermission{OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, testCase := range map[string]struct {
+		token string
+		want  CredentialKind
+	}{
+		"current agent":               {token: agents.plannerToken, want: CredentialKindAgent},
+		"a2a principal":               {token: a2aPrincipal.Credential, want: CredentialKindScopedPrincipal},
+		"output principal":            {token: outputPrincipal.Credential, want: CredentialKindScopedPrincipal},
+		"scope token is not resolved": {token: agents.scope.ScopeToken, want: CredentialKindUnknown},
+		"malformed":                   {token: "malformed", want: CredentialKindUnknown},
+		"unknown id":                  {token: "cred_unknown.secret", want: CredentialKindUnknown},
+		"wrong secret":                {token: a2aPrincipal.Principal.ID + ".wrong-secret", want: CredentialKindUnknown},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := store.CredentialKind(ctx, testCase.token)
+			if err != nil || got != testCase.want {
+				t.Fatalf("CredentialKind() = %v, %v; want %v, nil", got, err, testCase.want)
+			}
+		})
+	}
+
+	boundary := nowMillis()
+	if _, err := store.db.ExecContext(ctx, `UPDATE agents SET lease_expires_at=?,lifecycle='offline' WHERE token_hash=?`, boundary, tokenDigest(agents.reviewerToken)); err != nil {
+		t.Fatal(err)
+	}
+	if kind, err := store.CredentialKind(ctx, agents.reviewerToken); err != nil || kind != CredentialKindUnknown {
+		t.Fatalf("expired boundary credential = %v, %v; want unknown", kind, err)
+	}
+
+	replacement, err := agents.runtime.RegisterAgent(ctx, agents.scope.ScopeToken, RegisterAgentInput{ID: agents.planner.AgentID, DisplayName: "Replacement"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE agents SET lifecycle='offline' WHERE token_hash=?`, tokenDigest(replacement.AgentToken)); err != nil {
+		t.Fatal(err)
+	}
+	for name, testCase := range map[string]struct {
+		token string
+		want  CredentialKind
+	}{
+		"replaced execution":    {token: agents.plannerToken, want: CredentialKindUnknown},
+		"offline current agent": {token: replacement.AgentToken, want: CredentialKindAgent},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := store.CredentialKind(ctx, testCase.token)
+			if err != nil || got != testCase.want {
+				t.Fatalf("CredentialKind() = %v, %v; want %v, nil", got, err, testCase.want)
+			}
+		})
+	}
+
+	if _, err := agents.runtime.SetOutputPrincipalEnabled(ctx, agents.scope.ScopeToken, outputPrincipal.Principal.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	if kind, err := store.CredentialKind(ctx, outputPrincipal.Credential); err != nil || kind != CredentialKindUnknown {
+		t.Fatalf("disabled principal credential = %v, %v; want unknown", kind, err)
+	}
+
+	rotated, err := agents.runtime.RotateA2APrincipal(ctx, agents.scope.ScopeToken, a2aPrincipal.Principal.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, testCase := range map[string]struct {
+		token string
+		want  CredentialKind
+	}{
+		"rotated old secret": {token: a2aPrincipal.Credential, want: CredentialKindUnknown},
+		"rotated new secret": {token: rotated.Credential, want: CredentialKindScopedPrincipal},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := store.CredentialKind(ctx, testCase.token)
+			if err != nil || got != testCase.want {
+				t.Fatalf("CredentialKind() = %v, %v; want %v, nil", got, err, testCase.want)
+			}
+		})
+	}
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := store.CredentialKind(canceled, replacement.AgentToken); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled classifier returned %v, want context cancellation", err)
+	}
+}

--- a/bus/events.go
+++ b/bus/events.go
@@ -143,7 +143,7 @@ func (r *Runtime) Events(ctx context.Context, scopeToken string, after int64, li
 	if waitMS < 0 || waitMS > maxEventWaitMS {
 		return EventBatch{}, Errorf(CodeInvalidArgument, "wait must be between 0 and 25 seconds")
 	}
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return EventBatch{}, err
 	}
@@ -157,7 +157,7 @@ func (r *Runtime) Events(ctx context.Context, scopeToken string, after int64, li
 		if !subscribed {
 			return EventBatch{}, Errorf(CodeBackpressure, "Scope event wait limit is full")
 		}
-		if _, err := r.store.AuthenticateScope(ctx, scopeToken); err != nil {
+		if _, err := r.scopeAuthority(ctx, scopeToken); err != nil {
 			unsubscribe()
 			return EventBatch{}, err
 		}

--- a/bus/events_test.go
+++ b/bus/events_test.go
@@ -127,7 +127,7 @@ func TestScopeEventsAreOrderedAndDoNotContainRecordBodies(t *testing.T) {
 	if _, err := agents.runtime.Events(ctx, agents.plannerToken, 0, 50, 0); err == nil {
 		t.Fatal("agent token read the scope event stream")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 }
 

--- a/bus/output_principals.go
+++ b/bus/output_principals.go
@@ -205,7 +205,7 @@ func (s *Store) SetOutputPrincipalEnabled(ctx context.Context, scopeID, principa
 }
 
 func (r *Runtime) CreateOutputPrincipal(ctx context.Context, scopeToken string, input CreateOutputPrincipalInput) (IssuedOutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return IssuedOutputPrincipal{}, err
 	}
@@ -227,7 +227,7 @@ func (r *Runtime) CreateOutputPrincipal(ctx context.Context, scopeToken string, 
 }
 
 func (r *Runtime) ListOutputPrincipals(ctx context.Context, scopeToken string) ([]OutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (r *Runtime) ListOutputPrincipals(ctx context.Context, scopeToken string) (
 }
 
 func (r *Runtime) RotateOutputPrincipal(ctx context.Context, scopeToken, principalID string) (IssuedOutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return IssuedOutputPrincipal{}, err
 	}
@@ -250,7 +250,7 @@ func (r *Runtime) RotateOutputPrincipal(ctx context.Context, scopeToken, princip
 }
 
 func (r *Runtime) SetOutputPrincipalEnabled(ctx context.Context, scopeToken, principalID string, enabled bool) (OutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return OutputPrincipal{}, err
 	}

--- a/bus/output_streams.go
+++ b/bus/output_streams.go
@@ -614,7 +614,7 @@ func validatePublishOutput(input PublishOutputInput) (string, string, error) {
 }
 
 func (r *Runtime) CreateOutputStream(ctx context.Context, scopeToken string, input CreateOutputStreamInput) (OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return OutputStream{}, err
 	}
@@ -637,7 +637,7 @@ func (r *Runtime) CreateOutputStream(ctx context.Context, scopeToken string, inp
 }
 
 func (r *Runtime) ListOutputStreams(ctx context.Context, scopeToken string) ([]OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -645,7 +645,7 @@ func (r *Runtime) ListOutputStreams(ctx context.Context, scopeToken string) ([]O
 }
 
 func (r *Runtime) OutputStream(ctx context.Context, scopeToken, streamID string) (OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return OutputStream{}, err
 	}
@@ -656,7 +656,7 @@ func (r *Runtime) OutputStream(ctx context.Context, scopeToken, streamID string)
 }
 
 func (r *Runtime) RemoveOutputStream(ctx context.Context, scopeToken, streamID string) error {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return err
 	}
@@ -671,7 +671,7 @@ func (r *Runtime) RemoveOutputStream(ctx context.Context, scopeToken, streamID s
 }
 
 func (r *Runtime) SetOutputPublisher(ctx context.Context, scopeToken, streamID, agentID string, allowed bool) (OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return OutputStream{}, err
 	}

--- a/bus/output_streams_test.go
+++ b/bus/output_streams_test.go
@@ -130,7 +130,7 @@ func TestOutputPrincipalsHaveNarrowIndependentPermissions(t *testing.T) {
 	_, err = agents.runtime.LatestOutput(ctx, reader.Credential, otherStream.ID)
 	requireCode(t, err, CodeUnauthenticated)
 	_, err = agents.runtime.ListAgents(ctx, reader.Credential)
-	requireCode(t, err, CodeUnauthenticated)
+	requireCode(t, err, CodePermissionDenied)
 	principals, err := agents.runtime.ListOutputPrincipals(ctx, agents.scope.ScopeToken)
 	if err != nil || len(principals) != 2 {
 		t.Fatalf("unexpected output principals: %#v, %v", principals, err)

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -83,7 +83,7 @@ func (r *Runtime) CreateScope(ctx context.Context, input CreateScopeInput) (Crea
 }
 
 func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input RegisterAgentInput) (RegisterAgentResult, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return RegisterAgentResult{}, err
 	}
@@ -120,7 +120,7 @@ func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input Re
 }
 
 func (r *Runtime) ListAgents(ctx context.Context, scopeToken string) ([]Agent, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (r *Runtime) ListAgents(ctx context.Context, scopeToken string) ([]Agent, e
 }
 
 func (r *Runtime) LinkAgents(ctx context.Context, scopeToken, left, right string) error {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return err
 	}
@@ -502,7 +502,7 @@ func (r *Runtime) ListTasks(ctx context.Context, token string, readyOnly bool) (
 }
 
 func (r *Runtime) StorageSummary(ctx context.Context, scopeToken string) (StorageSummary, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return StorageSummary{}, err
 	}
@@ -514,7 +514,7 @@ func (r *Runtime) StorageSummary(ctx context.Context, scopeToken string) (Storag
 }
 
 func (r *Runtime) PruneScope(ctx context.Context, scopeToken string, input PruneScopeInput) (PruneScopeResult, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return PruneScopeResult{}, err
 	}
@@ -539,6 +539,24 @@ func (r *Runtime) taskAuthority(ctx context.Context, token string) (scopeID, cre
 		return scopeID, "", nil
 	}
 	return "", "", agentErr
+}
+
+func (r *Runtime) scopeAuthority(ctx context.Context, token string) (string, error) {
+	scopeID, err := r.store.AuthenticateScope(ctx, token)
+	if err == nil {
+		return scopeID, nil
+	}
+	if AsBusError(err).Code != CodeUnauthenticated {
+		return "", err
+	}
+	kind, kindErr := r.store.CredentialKind(ctx, token)
+	if kindErr != nil {
+		return "", kindErr
+	}
+	if kind != CredentialKindUnknown {
+		return "", Errorf(CodePermissionDenied, "Scope authority is required")
+	}
+	return "", err
 }
 
 func (r *Runtime) AskHuman(ctx context.Context, agentToken string, input AskHumanInput) (HumanEscalation, error) {
@@ -576,7 +594,7 @@ func (r *Runtime) Escalation(ctx context.Context, agentToken, escalationID strin
 }
 
 func (r *Runtime) ListEscalations(ctx context.Context, scopeToken string) ([]HumanEscalation, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +602,7 @@ func (r *Runtime) ListEscalations(ctx context.Context, scopeToken string) ([]Hum
 }
 
 func (r *Runtime) ResolveEscalation(ctx context.Context, scopeToken, escalationID, answer string) (HumanEscalation, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	if err != nil {
 		return HumanEscalation{}, err
 	}

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -72,6 +72,131 @@ func requireCode(t *testing.T, err error, code ErrorCode) {
 	}
 }
 
+type authorityFailureStore struct {
+	storageBackend
+	authErr    error
+	kindErr    error
+	kindCalled bool
+}
+
+func (s *authorityFailureStore) AuthenticateScope(ctx context.Context, token string) (string, error) {
+	if s.authErr != nil {
+		return "", s.authErr
+	}
+	return s.storageBackend.AuthenticateScope(ctx, token)
+}
+
+func (s *authorityFailureStore) CredentialKind(context.Context, string) (CredentialKind, error) {
+	s.kindCalled = true
+	return CredentialKindUnknown, s.kindErr
+}
+
+func TestScopeAuthorityClassifiesCredentialsAndPreservesTaskFallbacks(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	_, a2aPrincipal := setupA2APrincipal(t, agents)
+	stream, err := agents.runtime.CreateOutputStream(ctx, agents.scope.ScopeToken, CreateOutputStreamInput{Name: "scope-authority"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputPrincipal, err := agents.runtime.CreateOutputPrincipal(ctx, agents.scope.ScopeToken, CreateOutputPrincipalInput{
+		StreamID: stream.ID, Label: "Scope authority test", Permissions: []OutputPermission{OutputRead},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := agents.runtime.ListAgents(ctx, agents.scope.ScopeToken); err != nil {
+		t.Fatalf("scope credential was rejected: %v", err)
+	}
+	for name, testCase := range map[string]struct {
+		token string
+		want  ErrorCode
+	}{
+		"garbage":          {token: "not-a-credential", want: CodeUnauthenticated},
+		"agent":            {token: agents.plannerToken, want: CodePermissionDenied},
+		"a2a principal":    {token: a2aPrincipal.Credential, want: CodePermissionDenied},
+		"output principal": {token: outputPrincipal.Credential, want: CodePermissionDenied},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := agents.runtime.ListAgents(ctx, testCase.token)
+			requireCode(t, err, testCase.want)
+		})
+	}
+
+	if _, err := agents.runtime.AddTask(ctx, agents.scope.ScopeToken, AddTaskInput{Title: "Scope task"}); err != nil {
+		t.Fatalf("scope credential could not create task: %v", err)
+	}
+	if _, err := agents.runtime.AddTask(ctx, agents.plannerToken, AddTaskInput{Title: "Agent task"}); err != nil {
+		t.Fatalf("agent credential could not create task: %v", err)
+	}
+	for name, token := range map[string]string{
+		"garbage":          "not-a-credential",
+		"a2a principal":    a2aPrincipal.Credential,
+		"output principal": outputPrincipal.Credential,
+	} {
+		t.Run("task route "+name, func(t *testing.T) {
+			_, err := agents.runtime.ListTasks(ctx, token, false)
+			requireCode(t, err, CodeUnauthenticated)
+		})
+	}
+
+	if _, err := sqliteStore(t, agents.runtime).db.ExecContext(ctx, `UPDATE agents SET lease_expires_at=? WHERE token_hash=?`, nowMillis(), tokenDigest(agents.reviewerToken)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.ListAgents(ctx, agents.reviewerToken); err == nil {
+		t.Fatal("expired agent credential accessed a scope route")
+	} else {
+		requireCode(t, err, CodeUnauthenticated)
+	}
+	if _, err := agents.runtime.SetOutputPrincipalEnabled(ctx, agents.scope.ScopeToken, outputPrincipal.Principal.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := agents.runtime.ListAgents(ctx, outputPrincipal.Credential); err == nil {
+		t.Fatal("disabled principal credential accessed a scope route")
+	} else {
+		requireCode(t, err, CodeUnauthenticated)
+	}
+
+	server := NewServer(agents.runtime, ServerOptions{})
+	request := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
+	request.Header.Set("Authorization", "Bearer "+agents.plannerToken)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("agent credential returned HTTP %d, want 403: %s", response.Code, response.Body.String())
+	}
+
+}
+
+func TestScopeAuthorityPropagatesAuthenticationAndClassifierErrors(t *testing.T) {
+	store, err := OpenStore(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	sentinel := errors.New("credential classifier failed")
+
+	classifierFailure := &authorityFailureStore{storageBackend: store, kindErr: sentinel}
+	runtimeValue := openWithStorage(classifierFailure, A2APrincipalLimits{})
+	if _, err := runtimeValue.ListAgents(context.Background(), "invalid"); !errors.Is(err, sentinel) {
+		t.Fatalf("classifier error was not propagated: %v", err)
+	}
+
+	authFailure := &authorityFailureStore{
+		storageBackend: store,
+		authErr:        Errorf(CodeBackpressure, "scope authentication unavailable"),
+		kindErr:        errors.New("must not be returned"),
+	}
+	runtimeValue = openWithStorage(authFailure, A2APrincipalLimits{})
+	_, err = runtimeValue.ListAgents(context.Background(), "invalid")
+	requireCode(t, err, CodeBackpressure)
+	if authFailure.kindCalled {
+		t.Fatal("classifier ran after a non-authentication failure")
+	}
+}
+
 func TestA2APrincipalLimitsLoadFromEnvironment(t *testing.T) {
 	t.Setenv("OCTOBER_BUS_A2A_PRINCIPAL_MESSAGE_LIMIT", "12")
 	t.Setenv("OCTOBER_BUS_A2A_PRINCIPAL_BYTE_LIMIT", "4096")
@@ -755,7 +880,7 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = plannerClient.ListEscalations(ctx)
-	requireCode(t, err, CodeUnauthenticated)
+	requireCode(t, err, CodePermissionDenied)
 	receipt, err := plannerClient.SendMessage(ctx, SendMessageInput{To: "reviewer", Body: "Reserve me"})
 	if err != nil {
 		t.Fatal(err)

--- a/bus/storage_backend.go
+++ b/bus/storage_backend.go
@@ -13,6 +13,7 @@ type storageBackend interface {
 
 	CreateScope(context.Context, string) (CreateScopeResult, error)
 	AuthenticateScope(context.Context, string) (string, error)
+	CredentialKind(context.Context, string) (CredentialKind, error)
 	RegisterAgent(context.Context, string, RegisterAgentInput) (RegisterAgentResult, error)
 	AuthenticateAgent(context.Context, string) (Principal, error)
 	Agent(context.Context, string, string) (Agent, error)

--- a/bus/storage_test.go
+++ b/bus/storage_test.go
@@ -115,7 +115,7 @@ func TestRetentionRequiresScopeAuthorityAndValidCutoff(t *testing.T) {
 	if _, err := agents.runtime.StorageSummary(ctx, agents.plannerToken); err == nil {
 		t.Fatal("agent authority inspected scope storage")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	_, err := agents.runtime.PruneScope(ctx, agents.scope.ScopeToken, PruneScopeInput{Before: "yesterday"})
 	requireCode(t, err, CodeInvalidArgument)

--- a/bus/store.go
+++ b/bus/store.go
@@ -34,6 +34,15 @@ type Principal struct {
 	LeaseExpiresAt int64 `json:"-"`
 }
 
+// CredentialKind identifies a currently valid non-scope bearer credential.
+type CredentialKind int
+
+const (
+	CredentialKindUnknown CredentialKind = iota
+	CredentialKindAgent
+	CredentialKindScopedPrincipal
+)
+
 type Store struct {
 	db *sql.DB
 }
@@ -397,6 +406,45 @@ func (s *Store) AuthenticateScope(ctx context.Context, supplied string) (string,
 		return "", err
 	}
 	return scopeID, nil
+}
+
+// CredentialKind classifies a non-scope bearer credential after scope
+// authentication has failed. It intentionally does not resolve scope tokens.
+func (s *Store) CredentialKind(ctx context.Context, supplied string) (CredentialKind, error) {
+	var leaseExpiresAt int64
+	err := s.db.QueryRowContext(ctx, `SELECT lease_expires_at FROM agents WHERE token_hash=?`, tokenDigest(supplied)).Scan(&leaseExpiresAt)
+	if err == nil {
+		if leaseExpiresAt > nowMillis() {
+			return CredentialKindAgent, nil
+		}
+		return CredentialKindUnknown, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return CredentialKindUnknown, err
+	}
+
+	credentialID, secret, valid := splitScopedCredential(supplied)
+	if !valid {
+		secureEqual(tokenDigest("invalid"), tokenDigest(supplied))
+		return CredentialKindUnknown, nil
+	}
+	var expectedHash string
+	var enabled int
+	err = s.db.QueryRowContext(ctx, `SELECT token_hash,enabled FROM scoped_credentials WHERE credential_id=?`, credentialID).
+		Scan(&expectedHash, &enabled)
+	actualHash := tokenDigest(secret)
+	if errors.Is(err, sql.ErrNoRows) {
+		secureEqual(tokenDigest("invalid"), actualHash)
+		return CredentialKindUnknown, nil
+	}
+	if err != nil {
+		return CredentialKindUnknown, err
+	}
+	match := secureEqual(expectedHash, actualHash)
+	if enabled == 1 && match {
+		return CredentialKindScopedPrincipal, nil
+	}
+	return CredentialKindUnknown, nil
 }
 
 func (s *Store) RegisterAgent(ctx context.Context, scopeID string, input RegisterAgentInput) (RegisterAgentResult, error) {

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -600,18 +600,35 @@ func TestListAgentsRejectsInvalidOrAgentCredential(t *testing.T) {
 	address, _, senderToken, _, cleanup := startTestServer(t, ctx, "agent-list-auth")
 	defer cleanup()
 
-	for name, token := range map[string]string{
-		"invalid":     "not-a-real-token",
-		"agent-token": senderToken,
+	for name, testCase := range map[string]struct {
+		token string
+		code  bus.ErrorCode
+	}{
+		"invalid":     {token: "not-a-real-token", code: bus.CodeUnauthenticated},
+		"agent-token": {token: senderToken, code: bus.CodePermissionDenied},
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", token)
+			t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", testCase.token)
 			err := runListAgentsCapturing(&bytes.Buffer{}, "--address", address)
 			var busErr *bus.BusError
-			if !errors.As(err, &busErr) || busErr.Code != bus.CodeUnauthenticated {
-				t.Fatalf("expected CodeUnauthenticated, got %v", err)
+			if !errors.As(err, &busErr) || busErr.Code != testCase.code {
+				t.Fatalf("expected %s, got %v", testCase.code, err)
 			}
 		})
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, address+"/v1/agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+senderToken)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("agent credential returned HTTP %d, want 403", response.StatusCode)
 	}
 }
 

--- a/conformance/mcp_adapter.go
+++ b/conformance/mcp_adapter.go
@@ -497,7 +497,7 @@ func RunMCPAdapter(ctx context.Context, options MCPAdapterOptions) (result Resul
 		if err != nil {
 			return err
 		}
-		if _, err := workerSession.Client.ResolveEscalation(ctx, escalation.ID, "yes"); requireCode(err, bus.CodeUnauthenticated) != nil {
+		if _, err := workerSession.Client.ResolveEscalation(ctx, escalation.ID, "yes"); requireCode(err, bus.CodePermissionDenied) != nil {
 			return fmt.Errorf("agent resolved its own escalation: %v", err)
 		}
 		resolved, err := owner.ResolveEscalation(ctx, escalation.ID, "yes")

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -172,6 +172,15 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 	}
 	planner := bus.Client{Address: options.Address, Token: plannerRegistration.AgentToken}
 	reviewer := bus.Client{Address: options.Address, Token: reviewerRegistration.AgentToken}
+	if err := record.check("scope-route-authority-errors", func() error {
+		if _, err := planner.ListAgents(ctx); requireCode(err, bus.CodePermissionDenied) != nil {
+			return fmt.Errorf("agent credential on scope route: %v", err)
+		}
+		_, err := (bus.Client{Address: options.Address}).ListAgents(ctx)
+		return requireCode(err, bus.CodeUnauthenticated)
+	}); err != nil {
+		return result, err
+	}
 
 	var reviewerPublication bus.AgentCardPublication
 	if err := record.check("owner-controlled-agent-card-publication", func() error {
@@ -216,7 +225,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return fmt.Errorf("unexpected enabled publication: %#v, %v", enabled, err)
 		}
 		_, err = planner.CreateAgentCardPublication(ctx, bus.PublishAgentCardInput{AgentID: "planner"})
-		return requireCode(err, bus.CodeUnauthenticated)
+		return requireCode(err, bus.CodePermissionDenied)
 	}); err != nil {
 		return result, err
 	}
@@ -233,7 +242,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return fmt.Errorf("unexpected principals: %#v, %v", listed, err)
 		}
 		remote := bus.Client{Address: options.Address, Token: issued.Credential}
-		if _, err := remote.ListAgents(ctx); requireCode(err, bus.CodeUnauthenticated) != nil {
+		if _, err := remote.ListAgents(ctx); requireCode(err, bus.CodePermissionDenied) != nil {
 			return fmt.Errorf("scoped credential accessed Bus APIs: %v", err)
 		}
 		disabled, err := owner.SetA2APrincipalEnabled(ctx, issued.Principal.ID, false)
@@ -537,7 +546,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return err
 		}
 		_, err = planner.ResolveEscalation(ctx, escalation.ID, "yes")
-		if err := requireCode(err, bus.CodeUnauthenticated); err != nil {
+		if err := requireCode(err, bus.CodePermissionDenied); err != nil {
 			return err
 		}
 		escalations, err := owner.ListEscalations(ctx)
@@ -587,7 +596,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return ctx.Err()
 		}
 		_, err = planner.Events(ctx, 0, 10, 0)
-		return requireCode(err, bus.CodeUnauthenticated)
+		return requireCode(err, bus.CodePermissionDenied)
 	}); err != nil {
 		return result, err
 	}
@@ -598,7 +607,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return fmt.Errorf("unexpected storage summary: %#v, %v", summary, err)
 		}
 		_, err = planner.StorageSummary(ctx)
-		if err := requireCode(err, bus.CodeUnauthenticated); err != nil {
+		if err := requireCode(err, bus.CodePermissionDenied); err != nil {
 			return err
 		}
 		before := time.Now().Add(time.Minute).UTC().Format(time.RFC3339Nano)

--- a/sdk/typescript/test/integration.mjs
+++ b/sdk/typescript/test/integration.mjs
@@ -99,7 +99,7 @@ try {
   const scopedAccess = await fetch(`${run.address}/v1/agents`, {
     headers: { authorization: `Bearer ${issuedPrincipal.credential}` }
   })
-  assert.equal(scopedAccess.status, 401)
+  assert.equal(scopedAccess.status, 403)
   const disabledPrincipal = await owner.setA2APrincipalEnabled(issuedPrincipal.principal.id, false)
   assert.equal(disabledPrincipal.enabled, false)
   const rotatedPrincipal = await owner.rotateA2APrincipal(issuedPrincipal.principal.id)

--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -6,6 +6,7 @@ The reference transport is JSON over HTTP. The local runtime listens on loopback
 
 - Base URL example: `http://127.0.0.1:4765`
 - Authenticated requests use `Authorization: Bearer <token>`.
+- Scope-authority routes return `PERMISSION_DENIED` (HTTP 403) when the bearer is a recognized, currently valid agent, A2A-principal, or output-principal credential. Missing, malformed, expired, disabled, replaced, and otherwise invalid credentials return `UNAUTHENTICATED` (HTTP 401). Task routes that accept either scope or agent authority and scoped output-read fallbacks retain their documented authority behavior.
 - Request bodies contain one JSON value and reject unknown fields.
 - Request bodies are limited to 1 MiB. Scope archive imports are limited to 64 MiB.
 - Responses set `Content-Type: application/json` and `Cache-Control: no-store`.
@@ -110,7 +111,7 @@ Clients resume from `nextRevision`. `minimumCursor` is the oldest cursor that ca
 
 Agent Card publications are absent by default. A scope owner publishes one registered agent by sending its exact `agentId`. The returned opaque publication ID and URLs remain stable while the publication is disabled and re-enabled. Public card requests for unknown and disabled IDs return the same `NOT_FOUND` response. Card and interface URLs come from the runtime's trusted address configuration, never the request `Host` header.
 
-`POST /v1/a2a/principals` accepts a publication ID and label. Create and rotate responses are the only responses that contain the bearer credential. List, enable, and disable responses return principal metadata only. A principal credential is restricted to its publication and cannot authenticate to any `/v1` or `/mcp` operation.
+`POST /v1/a2a/principals` accepts a publication ID and label. Create and rotate responses are the only responses that contain the bearer credential. List, enable, and disable responses return principal metadata only. A principal credential is restricted to its publication and cannot authorize scope or agent operations. Presenting an enabled principal credential to a scope-authority route returns `PERMISSION_DENIED`; `/mcp` and other agent-authority routes continue to return `UNAUTHENTICATED`.
 
 `GET /v1/a2a/principals/usage` returns unfinished message counts, text bytes, and effective limits for every A2A principal in the scope. It does not return message content. Terminal tasks and undelivered expired requests do not consume capacity.
 


### PR DESCRIPTION
Classify active agent and scoped-principal credentials only after scope authentication fails, returning PERMISSION_DENIED while preserving UNAUTHENTICATED for invalid, expired, disabled, and replaced credentials.

Route pure scope-authority entry points through the new wrapper while leaving task and output-read fallback semantics unchanged. Document the 401/403 contract and expand storage, runtime, HTTP, CLI, and conformance coverage.