### PR TITLE
feat: allow configured MCP hosts

### DIFF
--- a/bus/daemon.go
+++ b/bus/daemon.go
@@ -250,7 +250,13 @@ func StartDaemon(ctx context.Context, port int, paths *DaemonPaths) (*RunningDae
 			allowedOrigins = append(allowedOrigins, origin)
 		}
 	}
-	server := NewServer(runtimeValue, ServerOptions{Port: port, AdminToken: adminToken, StartedAt: startedAt, AllowedOrigins: unique(allowedOrigins)})
+	allowedHosts := []string{}
+	for _, host := range strings.Split(os.Getenv("OCTOBER_BUS_ALLOWED_HOSTS"), ",") {
+		if host = strings.TrimSpace(host); host != "" {
+			allowedHosts = append(allowedHosts, host)
+		}
+	}
+	server := NewServer(runtimeValue, ServerOptions{Port: port, AdminToken: adminToken, StartedAt: startedAt, AllowedOrigins: unique(allowedOrigins), AllowedHosts: unique(allowedHosts)})
 	address, err := server.Start()
 	if err != nil {
 		runtimeValue.Close()

--- a/bus/mcp_host_test.go
+++ b/bus/mcp_host_test.go
@@ -1,0 +1,123 @@
+package bus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMCPHostAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		allowed []string
+		want    bool
+	}{
+		{name: "IPv4 with port", host: "127.0.0.1:4765", want: true},
+		{name: "IPv4 without port", host: "127.0.0.1", want: true},
+		{name: "IPv4 loopback range", host: "127.5.5.5:1", want: true},
+		{name: "localhost with port", host: "localhost:4765", want: true},
+		{name: "localhost without port", host: "localhost", want: true},
+		{name: "localhost case insensitive", host: "LOCALHOST:4765", want: true},
+		{name: "IPv6 with port", host: "[::1]:4765", want: true},
+		{name: "IPv6 without brackets", host: "::1", want: true},
+		{name: "IPv6 with brackets", host: "[::1]", want: true},
+		{name: "bracketed IPv4", host: "[127.0.0.1]", want: true},
+		{name: "exact allowlist entry", host: "192.168.1.20:4765", allowed: []string{"192.168.1.20:4765"}, want: true},
+		{name: "empty Host", host: "", want: false},
+		{name: "empty Host cannot be allowlisted", host: "", allowed: []string{""}, want: false},
+		{name: "remote IP", host: "192.168.1.20:4765", want: false},
+		{name: "allowlist port differs", host: "192.168.1.20:4766", allowed: []string{"192.168.1.20:4765"}, want: false},
+		{name: "allowlist includes port", host: "192.168.1.20", allowed: []string{"192.168.1.20:4765"}, want: false},
+		{name: "allowlist is case sensitive", host: "Bus.Internal:4765", allowed: []string{"bus.internal:4765"}, want: false},
+		{name: "remote name", host: "example.com", want: false},
+		{name: "loopback suffix attack", host: "127.0.0.1.evil.example:4765", want: false},
+		{name: "nested brackets", host: "[[::1]]", want: false},
+		{name: "unmatched opening bracket", host: "[127.0.0.1", want: false},
+		{name: "unmatched closing bracket", host: "localhost]", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := &Server{options: ServerOptions{AllowedHosts: test.allowed}}
+			if got := server.mcpHostAllowed(test.host); got != test.want {
+				t.Fatalf("mcpHostAllowed(%q) = %t, want %t", test.host, got, test.want)
+			}
+		})
+	}
+}
+
+func TestServeMCPHostPolicy(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+
+	request := func(server *Server, host string, authorized bool) *httptest.ResponseRecorder {
+		httpRequest := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+		httpRequest.Host = host
+		httpRequest.Header.Set("Content-Type", "application/json")
+		httpRequest.Header.Set("Accept", "application/json, text/event-stream")
+		if authorized {
+			httpRequest.Header.Set("Authorization", "Bearer "+agents.plannerToken)
+		}
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, httpRequest)
+		return response
+	}
+
+	assertFailure := func(response *httptest.ResponseRecorder, status int, code ErrorCode) {
+		t.Helper()
+		var payload struct {
+			OK    bool `json:"ok"`
+			Error struct {
+				Code ErrorCode `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+			t.Fatal(err)
+		}
+		if response.Code != status || payload.OK || payload.Error.Code != code {
+			t.Fatalf("unexpected failure: status=%d payload=%#v", response.Code, payload)
+		}
+	}
+
+	server := NewServer(agents.runtime, ServerOptions{})
+	assertFailure(request(server, "192.168.1.20:4765", true), http.StatusForbidden, CodePermissionDenied)
+
+	response := request(server, "127.0.0.1:4765", true)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "list_peers") {
+		t.Fatalf("loopback MCP request failed: status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	server = NewServer(agents.runtime, ServerOptions{AllowedHosts: []string{"192.168.1.20:4765"}})
+	response = request(server, "192.168.1.20:4765", true)
+	if response.Code != http.StatusOK || !strings.Contains(response.Body.String(), "list_peers") {
+		t.Fatalf("allowlisted MCP request failed: status=%d body=%s", response.Code, response.Body.String())
+	}
+	assertFailure(request(server, "192.168.1.20:4766", true), http.StatusForbidden, CodePermissionDenied)
+
+	server = NewServer(agents.runtime, ServerOptions{})
+	assertFailure(request(server, "192.168.1.20:4765", false), http.StatusUnauthorized, CodeUnauthenticated)
+}
+
+func TestDaemonAllowedHostsEnvironment(t *testing.T) {
+	t.Setenv("OCTOBER_BUS_ALLOWED_HOSTS", " a:1 , , b:2 ,a:1 ")
+	root := t.TempDir()
+	paths := DaemonPaths{
+		DataDir: filepath.Join(root, "data"), RuntimeDir: filepath.Join(root, "run"),
+		Database: filepath.Join(root, "data", "bus.db"), RunFile: filepath.Join(root, "run", "bus.json"),
+		LockFile: filepath.Join(root, "run", "bus.lock"),
+	}
+	daemon, err := StartDaemon(context.Background(), 0, &paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer daemon.Stop(context.Background())
+	want := []string{"a:1", "b:2"}
+	if !reflect.DeepEqual(daemon.Server.options.AllowedHosts, want) {
+		t.Fatalf("allowed Hosts = %#v, want %#v", daemon.Server.options.AllowedHosts, want)
+	}
+}

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -2,7 +2,9 @@ package bus
 
 import (
 	"context"
+	"net"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"strings"
 	"time"
@@ -275,8 +277,39 @@ func (s *Server) serveMCP(response http.ResponseWriter, request *http.Request) {
 		writeFailure(response, err)
 		return
 	}
+	if !s.mcpHostAllowed(request.Host) {
+		writeFailure(response, Errorf(CodePermissionDenied, "MCP Host is not allowed"))
+		return
+	}
 	request = request.WithContext(context.WithValue(request.Context(), mcpTokenKey{}, token))
 	s.mcpHandler.ServeHTTP(response, request)
+}
+
+// mcpHostAllowed is the Bus DNS-rebinding policy for /mcp. Loopback authorities are
+// always accepted. Any other Host must match a configured entry exactly, including port.
+func (s *Server) mcpHostAllowed(host string) bool {
+	if host == "" {
+		return false
+	}
+	name, _, err := net.SplitHostPort(host)
+	if err != nil {
+		name = host
+		if strings.HasPrefix(name, "[") && strings.HasSuffix(name, "]") {
+			name = name[1 : len(name)-1]
+		}
+	}
+	if strings.EqualFold(name, "localhost") {
+		return true
+	}
+	if ip, parseErr := netip.ParseAddr(name); parseErr == nil && ip.IsLoopback() {
+		return true
+	}
+	for _, candidate := range s.options.AllowedHosts {
+		if host == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) shutdownServer(response http.ResponseWriter, request *http.Request) error {

--- a/bus/server.go
+++ b/bus/server.go
@@ -27,6 +27,9 @@ type ServerOptions struct {
 	StartedAt      string
 	PublicBaseURL  string
 	AllowedOrigins []string
+	// AllowedHosts lists exact HTTP Host authorities, including the port as sent,
+	// that may reach /mcp in addition to loopback. It does not affect /v1 routes.
+	AllowedHosts []string
 }
 
 type Server struct {
@@ -69,6 +72,10 @@ func NewServer(runtime *Runtime, options ServerOptions) *Server {
 	}, &mcp.StreamableHTTPOptions{
 		Stateless: true, JSONResponse: true, MaxRequestBodyBytes: maxBodyBytes,
 		PropagateRequestCancellation: true,
+		// The go-sdk DNS-rebinding guard is disabled because Server.serveMCP owns the
+		// Host policy: it honours AllowedHosts, returns the JSON failure envelope, and
+		// is covered by this package's tests. Do not re-enable without removing that check.
+		DisableLocalhostProtection: true,
 	})
 	server.router = server.newRouter()
 	server.httpServer = &http.Server{

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -29,6 +29,39 @@ october-bus mcp stdio
 
 The bridge reads `OCTOBER_BUS_ADDRESS` and `OCTOBER_BUS_AGENT_TOKEN`, discovers the daemon's MCP tools, and forwards calls without keeping its own state. `october-bus agent run` supplies both values to the managed harness process. If either value is absent, the bridge starts without tools and does not contact a daemon.
 
+## Reaching /mcp from another machine
+
+The daemon always binds `127.0.0.1`. Remote access needs a bridge or reverse proxy on the daemon's machine; the allowlist alone changes nothing about reachability.
+
+`/mcp` additionally checks the request `Host`. Loopback Hosts pass at any port; anything else receives HTTP 403 `PERMISSION_DENIED`. This is DNS-rebinding protection. `/v1` has no such check.
+
+Option A is an HTTP-aware proxy. Terminate the remote connection in a proxy that validates its own incoming `Host` and restricts clients, then configure it with:
+
+```nginx
+proxy_set_header Host 127.0.0.1:4765;
+```
+
+A proxy that rewrites every `Host` it receives removes the protection instead of enforcing it. A plain TCP bridge such as `socat` forwards the client's `Host` unchanged, which is why it is rejected.
+
+Option B is to pass the real authority through the bridge and allowlist it exactly:
+
+```sh
+OCTOBER_BUS_ALLOWED_HOSTS=192.168.1.20:4765,bus.internal:4765 october-bus start
+```
+
+PowerShell uses the same setting:
+
+```powershell
+$env:OCTOBER_BUS_ALLOWED_HOSTS = "192.168.1.20:4765,bus.internal:4765"
+october-bus start
+```
+
+The value is a comma-separated list of exact `Host` authorities, including the port as sent. Wildcards and suffixes are not supported.
+
+Each entry gives up rebinding protection for that name, so list only authorities you control and pair remote exposure with authenticated, encrypted transport as described in the README under "Remote transport needs separate trust". This setting applies only to `/mcp`; other routes retain their existing authentication and authorization controls.
+
+socat passes a backlog of 5 to listen(2) by default. This bounds queued, not-yet-accepted connections rather than established MCP concurrency; connection bursts may therefore be delayed or fail. Raise it with backlog=64 or use a reverse proxy. This tunes the bridge, not the Bus.
+
 ## Inspect message delivery state
 
 Agents can inspect the durable delivery state of a message they sent or

--- a/spec/0.1/mcp.md
+++ b/spec/0.1/mcp.md
@@ -4,6 +4,8 @@ October Bus uses MCP Streamable HTTP as an agent-facing integration surface. MCP
 
 The endpoint is `/mcp` and requires an execution-bound agent Bearer token. An MCP session does not register an agent or renew its lease. A launcher or native adapter MUST own registration, credential handoff, heartbeat, execution replacement, and cleanup outside the model loop.
 
+A runtime MAY restrict `/mcp` by the request `Host`. A runtime that does so MUST default to accepting only loopback Hosts, and MUST require explicit operator configuration to accept any other Host.
+
 The reference CLI can forward this same MCP surface over stdio with `october-bus mcp stdio`. The bridge does not add authority or keep separate Bus state.
 
 ## Required tools


### PR DESCRIPTION
Own the /mcp Host policy so loopback remains the default while operators can explicitly allow exact remote authorities. Preserve the Bus JSON error envelope and document safe bridge and proxy configurations.