### PR TITLE
docs(spec): document route-specific HTTP success codes

### DIFF
--- a/spec/0.1/http.md
+++ b/spec/0.1/http.md
@@ -105,7 +105,26 @@ For Bus API responses using the envelope above, success status codes are route-s
 
 `POST /v1/links` accepts `linkAgentsInput` (`left` and `right` agent IDs). The link is symmetric, and repeating an existing link succeeds. `POST /v1/messages/ack` accepts `acknowledgeMessagesInput` and returns `acknowledgeMessagesResult`; `acknowledged` counts messages this call moved from delivered to acknowledged, so a repeated acknowledgement returns 0.
 
-`POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
+The following routes return HTTP status codes other than `200 OK` on success:
+
+| Method | Route | Success code |
+| --- | --- | ---: |
+| `POST` | `/v1/scopes` | `201 Created` |
+| `POST` | `/v1/admin/scopes/import` (new import) | `201 Created` |
+| `POST` | `/v1/admin/scopes/import` (retry) | `200 OK` |
+| `POST` | `/v1/admin/shutdown` | `202 Accepted` |
+| `POST` | `/v1/agents` | `201 Created` |
+| `POST` | `/v1/messages` | `202 Accepted` |
+| `POST` | `/v1/tasks` | `201 Created` |
+| `POST` | `/v1/tasks/{taskId}/progress` | `201 Created` |
+| `POST` | `/v1/escalations` | `201 Created` |
+| `POST` | `/v1/a2a/publications` | `201 Created` |
+| `POST` | `/v1/a2a/principals` | `201 Created` |
+| `POST` | `/v1/output-streams` | `201 Created` |
+| `POST` | `/v1/output-principals` | `201 Created` |
+| `POST` | `/outputs/{streamId}/values` | `201 Created` |
+
+All other successful `POST`, `GET`, `PATCH`, `PUT`, and `DELETE` routes return `200 OK`. `POST /v1/inbox/reserve` accepts an optional `limit` from 1 through 100; omission or 0 selects the default of 50. It also accepts an optional `waitMs` value from 0 through 25000. When no message is immediately reservable, a positive value waits until work arrives, the wait expires, the request is canceled, the server stops, or the execution loses authority. The default is 0 and returns immediately. A successful timeout returns `null` and does not reserve a message.
 
 `GET /v1/tasks?ready=true` returns only open, unclaimed tasks whose dependencies are complete. The default returns every task in the scope.
 


### PR DESCRIPTION
Rebased on main after #102 merged.

**What remains:** A complete table of every route returning a non-200 success code (201 Created / 202 Accepted), grounded in the reference runtime source.

**Removed (now in #102):** The `linkAgentsInput`, `acknowledgeMessagesInput`, and `acknowledgeMessagesResult` schema definitions, and the Go HTTP contract tests — #102 merged those with runtime-coupled boundary tests.

**Verified against source:** every `StatusCreated` and `StatusAccepted` call in `bus/routes.go`, `bus/a2a_routes.go`, `bus/a2a_principal_routes.go`, and `bus/output_routes.go` is listed in the table.

Addresses issue #99.