### PR TITLE
fix(runtime): return 403 PERMISSION_DENIED for valid agent token on scope routes

### DIFF
--- a/.october/canvas.json
+++ b/.october/canvas.json
@@ -1,0 +1,297 @@
+{
+  "screens": [],
+  "chatBoxes": [],
+  "stickies": [
+    {
+      "id": "sticky-mtlnjtso-0",
+      "position": {
+        "x": -2310.9466065640363,
+        "y": -2443.8249326631394
+      },
+      "text": "📁 october-bus\nDetected: No previewable app found\nNot previewable on the canvas — no web or phone screens were added.\nOpened for terminals & agents — drop a terminal or chat to work here.\n\nCouldn’t determine how to preview this folder.",
+      "color": "#fef3c7",
+      "size": {
+        "width": 300,
+        "height": 220
+      }
+    }
+  ],
+  "analytics": [],
+  "experiments": [],
+  "terminals": [
+    {
+      "ownerUserId": "7bdd92e0-79e7-4f72-aa05-b9a68259e2a1",
+      "ownerDeviceId": "13caae0f-2b0a-4a71-ae88-aa2a67d00539",
+      "ownerName": "contact",
+      "id": "term-mtlzb4dk-2",
+      "title": "Terminal",
+      "agentName": "Atlas",
+      "position": {
+        "x": 2627.6774478137377,
+        "y": 280.1503877881057
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "cwd": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/atlas-1788467393303",
+      "launchPending": false,
+      "permissionMode": "default",
+      "startCommand": "cursor-agent",
+      "harness": "cursor",
+      "worktreeId": "session:atlas-1788467393303",
+      "worktreeShared": false,
+      "worktreePath": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/atlas-1788467393303",
+      "branch": "october/atlas-1788467393303",
+      "baseRepoPath": "/Users/marcelspatz/october-bus"
+    },
+    {
+      "ownerUserId": "7bdd92e0-79e7-4f72-aa05-b9a68259e2a1",
+      "ownerDeviceId": "13caae0f-2b0a-4a71-ae88-aa2a67d00539",
+      "ownerName": "contact",
+      "id": "term-mtm05g36-7",
+      "title": "Terminal",
+      "agentName": "Apollo",
+      "position": {
+        "x": 3262.6774478137377,
+        "y": 287.1503877881057
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "cwd": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/apollo-1788468808181",
+      "launchPending": false,
+      "permissionMode": "bypassPermissions",
+      "startCommand": "hermes",
+      "harness": "hermes",
+      "worktreeId": "session:apollo-1788468808181",
+      "worktreeShared": false,
+      "worktreePath": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/apollo-1788468808181",
+      "branch": "october/apollo-1788468808181",
+      "baseRepoPath": "/Users/marcelspatz/october-bus"
+    }
+  ],
+  "closedTerminals": [
+    {
+      "id": "term-mtlzyfn2-5",
+      "agentName": "Apollo",
+      "harness": "hermes",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 2975.6774478137377,
+        "y": 921.1503877881057
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "hermes"
+      },
+      "permissionMode": "bypassPermissions",
+      "closedAt": 1788468495378
+    },
+    {
+      "id": "term-mtlzkay4-4",
+      "agentName": "Apollo",
+      "harness": "hermes",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 2619.6774478137377,
+        "y": 742.1503877881057
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "hermes"
+      },
+      "permissionMode": "bypassPermissions",
+      "closedAt": 1788467860294
+    },
+    {
+      "id": "term-mtlzb07t-1",
+      "agentName": "Apollo",
+      "harness": "hermes",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 1957.677447813738,
+        "y": 280.1503877881058
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "hermes"
+      },
+      "permissionMode": "bypassPermissions",
+      "closedAt": 1788467817050
+    },
+    {
+      "id": "term-mtlz96em-0",
+      "agentName": "Orion",
+      "harness": "hermes",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 1839.5414182011145,
+        "y": 222.4831600680206
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "hermes"
+      },
+      "permissionMode": "bypassPermissions",
+      "closedAt": 1788467382570
+    },
+    {
+      "id": "term-mtlnok4g-2",
+      "agentName": "Atlas",
+      "harness": "cursor",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/atlas-1788447864841",
+      "position": {
+        "x": 1831.0414182011145,
+        "y": -182.7168399319794
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "claude",
+        "sessionId": "62c83171-e56f-4128-8e3d-014ceaca2392",
+        "cwd": "/Users/marcelspatz/YURI-OS-MUSUBI/.claude"
+      },
+      "permissionMode": "default",
+      "closedAt": 1788467379362
+    },
+    {
+      "id": "term-mtlo9y9x-6",
+      "agentName": "Apollo",
+      "harness": "cursor",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/apollo-1788448862937",
+      "position": {
+        "x": 1207.0414182011145,
+        "y": -181.5168399319794
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "cursor"
+      },
+      "permissionMode": "default",
+      "closedAt": 1788467378972
+    },
+    {
+      "id": "term-mtlnliqi-1",
+      "agentName": "Apollo",
+      "harness": "hermes",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 897.0414182011147,
+        "y": -199.7168399319794
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "hermes"
+      },
+      "permissionMode": "bypassPermissions",
+      "closedAt": 1788448857314
+    },
+    {
+      "id": "term-mtlo6t9z-5",
+      "agentName": "Orion",
+      "harness": "claude-code",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 1862.0414182011145,
+        "y": 284.2831600680206
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "claude",
+        "sessionId": "4e54b11e-baeb-4d62-93fc-44470b0c5b82",
+        "file": "/Users/marcelspatz/.claude/projects/-Users-marcelspatz-Library-Application-Support-October-worktrees-october-bus-orion-1788448716474/4e54b11e-baeb-4d62-93fc-44470b0c5b82.jsonl",
+        "cwd": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/orion-1788448716474"
+      },
+      "permissionMode": "auto",
+      "closedAt": 1788448769054
+    },
+    {
+      "id": "term-mtlo37l6-4",
+      "agentName": "Orion",
+      "harness": "hermes",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/october-bus",
+      "position": {
+        "x": 1756.0414182011145,
+        "y": 228.2831600680206
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "hermes"
+      },
+      "permissionMode": "bypassPermissions",
+      "closedAt": 1788448583536
+    },
+    {
+      "id": "term-mtlnoo32-3",
+      "agentName": "Orion",
+      "harness": "cursor",
+      "title": "Terminal",
+      "cwd": "/Users/marcelspatz/Library/Application Support/October/worktrees/october-bus/orion-1788447870004",
+      "position": {
+        "x": 2227.0414182011145,
+        "y": 257.2831600680206
+      },
+      "size": {
+        "width": 560,
+        "height": 360
+      },
+      "session": {
+        "agent": "cursor"
+      },
+      "permissionMode": "default",
+      "closedAt": 1788447876050
+    }
+  ],
+  "connections": [
+    {
+      "id": "conn-mtm1052b-8",
+      "source": "term-mtm05g36-7",
+      "target": "term-mtlzb4dk-2",
+      "sourceHandle": "l",
+      "targetHandle": "r"
+    }
+  ],
+  "viewport": {
+    "x": -2623.6774478137377,
+    "y": -142.65038778810572,
+    "zoom": 1
+  },
+  "busCanvasId": "e3a2d49a-a03d-47b2-bf30-49a849f5e9c9"
+}

--- a/.october/preview.json
+++ b/.october/preview.json
@@ -1,0 +1,6 @@
+{
+  "previewable": false,
+  "reason": "Couldn’t determine how to preview this folder.",
+  "harness": "hermes",
+  "detectedAt": 1788242480900
+}

--- a/.october/workspace.json
+++ b/.october/workspace.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "workspace": {
+    "name": "october-bus",
+    "kind": "folder"
+  },
+  "apps": [
+    {
+      "id": "app",
+      "name": "october-bus",
+      "folder": ".",
+      "framework": "Unknown",
+      "platform": "web",
+      "default": true
+    }
+  ]
+}

--- a/bus/a2a_principals.go
+++ b/bus/a2a_principals.go
@@ -205,7 +205,7 @@ func (s *Store) AuthenticateA2APrincipal(ctx context.Context, credential, public
 }
 
 func (r *Runtime) CreateA2APrincipal(ctx context.Context, scopeToken string, input CreateA2APrincipalInput) (IssuedA2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return IssuedA2APrincipal{}, err
 	}
@@ -223,7 +223,7 @@ func (r *Runtime) CreateA2APrincipal(ctx context.Context, scopeToken string, inp
 }
 
 func (r *Runtime) ListA2APrincipals(ctx context.Context, scopeToken string) ([]A2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (r *Runtime) ListA2APrincipals(ctx context.Context, scopeToken string) ([]A
 }
 
 func (r *Runtime) ListA2APrincipalUsage(ctx context.Context, scopeToken string) ([]A2APrincipalUsage, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (r *Runtime) ListA2APrincipalUsage(ctx context.Context, scopeToken string) 
 }
 
 func (r *Runtime) RotateA2APrincipal(ctx context.Context, scopeToken, principalID string) (IssuedA2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return IssuedA2APrincipal{}, err
 	}
@@ -254,7 +254,7 @@ func (r *Runtime) RotateA2APrincipal(ctx context.Context, scopeToken, principalI
 }
 
 func (r *Runtime) SetA2APrincipalEnabled(ctx context.Context, scopeToken, principalID string, enabled bool) (A2APrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return A2APrincipal{}, err
 	}

--- a/bus/a2a_principals_test.go
+++ b/bus/a2a_principals_test.go
@@ -132,7 +132,7 @@ func TestA2APrincipalAuthorityAndRetention(t *testing.T) {
 	if _, err := agents.runtime.CreateA2APrincipal(ctx, agents.plannerToken, CreateA2APrincipalInput{PublicationID: publication.ID, Label: "Denied"}); err == nil {
 		t.Fatal("agent authority created a remote principal")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	otherScope, err := agents.runtime.CreateScope(ctx, CreateScopeInput{ID: "other"})
 	if err != nil {

--- a/bus/a2a_publications.go
+++ b/bus/a2a_publications.go
@@ -140,7 +140,7 @@ func (s *Store) PublishedAgent(ctx context.Context, publicationID string) (agent
 }
 
 func (r *Runtime) CreateAgentCardPublication(ctx context.Context, scopeToken string, input PublishAgentCardInput) (agentCardPublication, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return agentCardPublication{}, err
 	}
@@ -155,7 +155,7 @@ func (r *Runtime) CreateAgentCardPublication(ctx context.Context, scopeToken str
 }
 
 func (r *Runtime) ListAgentCardPublications(ctx context.Context, scopeToken string) ([]agentCardPublication, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (r *Runtime) ListAgentCardPublications(ctx context.Context, scopeToken stri
 }
 
 func (r *Runtime) SetAgentCardPublicationEnabled(ctx context.Context, scopeToken, publicationID string, enabled bool) (agentCardPublication, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return agentCardPublication{}, err
 	}

--- a/bus/a2a_publications_test.go
+++ b/bus/a2a_publications_test.go
@@ -29,7 +29,7 @@ func TestAgentCardPublicationPersistsAndKeepsStableIdentity(t *testing.T) {
 	if _, err := agents.runtime.CreateAgentCardPublication(ctx, agents.plannerToken, PublishAgentCardInput{AgentID: agents.planner.AgentID}); err == nil {
 		t.Fatal("agent credential created a publication")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	if err := agents.runtime.Close(); err != nil {
 		t.Fatal(err)

--- a/bus/a2a_tasks_test.go
+++ b/bus/a2a_tasks_test.go
@@ -193,7 +193,7 @@ func TestA2APrincipalMessageLimitsAreIndependentAndAtomic(t *testing.T) {
 	if _, err := agents.runtime.ListA2APrincipalUsage(ctx, agents.plannerToken); err == nil {
 		t.Fatal("agent authority inspected remote principal usage")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	byPrincipal := map[string]A2APrincipalUsage{}
 	for _, item := range usage {

--- a/bus/events.go
+++ b/bus/events.go
@@ -143,7 +143,7 @@ func (r *Runtime) Events(ctx context.Context, scopeToken string, after int64, li
 	if waitMS < 0 || waitMS > maxEventWaitMS {
 		return EventBatch{}, Errorf(CodeInvalidArgument, "wait must be between 0 and 25 seconds")
 	}
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return EventBatch{}, err
 	}
@@ -157,7 +157,7 @@ func (r *Runtime) Events(ctx context.Context, scopeToken string, after int64, li
 		if !subscribed {
 			return EventBatch{}, Errorf(CodeBackpressure, "Scope event wait limit is full")
 		}
-		if _, err := r.store.AuthenticateScope(ctx, scopeToken); err != nil {
+		if _, err := r.resolveScopeToken(ctx, scopeToken); err != nil {
 			unsubscribe()
 			return EventBatch{}, err
 		}

--- a/bus/events_test.go
+++ b/bus/events_test.go
@@ -127,7 +127,7 @@ func TestScopeEventsAreOrderedAndDoNotContainRecordBodies(t *testing.T) {
 	if _, err := agents.runtime.Events(ctx, agents.plannerToken, 0, 50, 0); err == nil {
 		t.Fatal("agent token read the scope event stream")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 }
 

--- a/bus/evidence_ready_test.go
+++ b/bus/evidence_ready_test.go
@@ -1,0 +1,49 @@
+package bus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestEnqueueWakesNotReadyBlockedReserve documents why the runtime needs no
+// ready-edge inbox notification: a host blocked in a waitMs reserve while NOT
+// ready is already woken by the message enqueue notify (SendMessage). Queued
+// deliveries therefore reach the host's own reservation loop without any
+// server-side wake on the false->true ready transition. The host's obligation
+// (per spec) is only to resume its reservation loop after reporting ready.
+func TestEnqueueWakesNotReadyBlockedReserve(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// reviewer is NOT ready (setupAgents registers with ready=0) and blocks in
+	// a waitMs reserve on an empty inbox.
+	result := make(chan *InboxReservation, 1)
+	failure := make(chan error, 1)
+	go func() {
+		reservation, err := agents.runtime.ReserveInbox(ctx, agents.reviewerToken, 10, 2000)
+		if err != nil {
+			failure <- err
+			return
+		}
+		result <- reservation
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	receipt, err := agents.runtime.SendMessage(ctx, agents.plannerToken, SendMessageInput{To: "reviewer", Body: "queued while not-ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-failure:
+		t.Fatal(err)
+	case reservation := <-result:
+		if reservation == nil || len(reservation.Messages) != 1 || reservation.Messages[0].ID != receipt.MessageID {
+			t.Fatalf("enqueue did not wake not-ready blocked reserve: %#v", reservation)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}

--- a/bus/output_principals.go
+++ b/bus/output_principals.go
@@ -205,7 +205,7 @@ func (s *Store) SetOutputPrincipalEnabled(ctx context.Context, scopeID, principa
 }
 
 func (r *Runtime) CreateOutputPrincipal(ctx context.Context, scopeToken string, input CreateOutputPrincipalInput) (IssuedOutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return IssuedOutputPrincipal{}, err
 	}
@@ -227,7 +227,7 @@ func (r *Runtime) CreateOutputPrincipal(ctx context.Context, scopeToken string, 
 }
 
 func (r *Runtime) ListOutputPrincipals(ctx context.Context, scopeToken string) ([]OutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (r *Runtime) ListOutputPrincipals(ctx context.Context, scopeToken string) (
 }
 
 func (r *Runtime) RotateOutputPrincipal(ctx context.Context, scopeToken, principalID string) (IssuedOutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return IssuedOutputPrincipal{}, err
 	}
@@ -250,7 +250,7 @@ func (r *Runtime) RotateOutputPrincipal(ctx context.Context, scopeToken, princip
 }
 
 func (r *Runtime) SetOutputPrincipalEnabled(ctx context.Context, scopeToken, principalID string, enabled bool) (OutputPrincipal, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return OutputPrincipal{}, err
 	}

--- a/bus/output_streams.go
+++ b/bus/output_streams.go
@@ -614,7 +614,7 @@ func validatePublishOutput(input PublishOutputInput) (string, string, error) {
 }
 
 func (r *Runtime) CreateOutputStream(ctx context.Context, scopeToken string, input CreateOutputStreamInput) (OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return OutputStream{}, err
 	}
@@ -637,7 +637,7 @@ func (r *Runtime) CreateOutputStream(ctx context.Context, scopeToken string, inp
 }
 
 func (r *Runtime) ListOutputStreams(ctx context.Context, scopeToken string) ([]OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -645,7 +645,7 @@ func (r *Runtime) ListOutputStreams(ctx context.Context, scopeToken string) ([]O
 }
 
 func (r *Runtime) OutputStream(ctx context.Context, scopeToken, streamID string) (OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return OutputStream{}, err
 	}
@@ -656,7 +656,7 @@ func (r *Runtime) OutputStream(ctx context.Context, scopeToken, streamID string)
 }
 
 func (r *Runtime) RemoveOutputStream(ctx context.Context, scopeToken, streamID string) error {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return err
 	}
@@ -671,7 +671,7 @@ func (r *Runtime) RemoveOutputStream(ctx context.Context, scopeToken, streamID s
 }
 
 func (r *Runtime) SetOutputPublisher(ctx context.Context, scopeToken, streamID, agentID string, allowed bool) (OutputStream, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return OutputStream{}, err
 	}

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -519,7 +519,7 @@ func (r *Runtime) ListTasks(ctx context.Context, token string, readyOnly bool) (
 }
 
 func (r *Runtime) StorageSummary(ctx context.Context, scopeToken string) (StorageSummary, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return StorageSummary{}, err
 	}
@@ -531,7 +531,7 @@ func (r *Runtime) StorageSummary(ctx context.Context, scopeToken string) (Storag
 }
 
 func (r *Runtime) PruneScope(ctx context.Context, scopeToken string, input PruneScopeInput) (PruneScopeResult, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return PruneScopeResult{}, err
 	}

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -82,8 +82,25 @@ func (r *Runtime) CreateScope(ctx context.Context, input CreateScopeInput) (Crea
 	return r.store.CreateScope(ctx, input.ID)
 }
 
-func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input RegisterAgentInput) (RegisterAgentResult, error) {
+// resolveScopeToken authenticates a scope credential. A token that authenticates
+// as an agent but not a scope is a valid credential with the wrong authority
+// level, which is PERMISSION_DENIED rather than UNAUTHENTICATED per spec/0.1/http.md.
+func (r *Runtime) resolveScopeToken(ctx context.Context, scopeToken string) (string, error) {
 	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	if err == nil {
+		return scopeID, nil
+	}
+	if AsBusError(err).Code != CodeUnauthenticated {
+		return "", err
+	}
+	if _, agentErr := r.store.AuthenticateAgent(ctx, scopeToken); agentErr == nil {
+		return "", Errorf(CodePermissionDenied, "Scope authority required")
+	}
+	return "", err
+}
+
+func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input RegisterAgentInput) (RegisterAgentResult, error) {
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return RegisterAgentResult{}, err
 	}
@@ -120,7 +137,7 @@ func (r *Runtime) RegisterAgent(ctx context.Context, scopeToken string, input Re
 }
 
 func (r *Runtime) ListAgents(ctx context.Context, scopeToken string) ([]Agent, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +145,7 @@ func (r *Runtime) ListAgents(ctx context.Context, scopeToken string) ([]Agent, e
 }
 
 func (r *Runtime) LinkAgents(ctx context.Context, scopeToken, left, right string) error {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return err
 	}
@@ -576,7 +593,7 @@ func (r *Runtime) Escalation(ctx context.Context, agentToken, escalationID strin
 }
 
 func (r *Runtime) ListEscalations(ctx context.Context, scopeToken string) ([]HumanEscalation, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +601,7 @@ func (r *Runtime) ListEscalations(ctx context.Context, scopeToken string) ([]Hum
 }
 
 func (r *Runtime) ResolveEscalation(ctx context.Context, scopeToken, escalationID, answer string) (HumanEscalation, error) {
-	scopeID, err := r.store.AuthenticateScope(ctx, scopeToken)
+	scopeID, err := r.resolveScopeToken(ctx, scopeToken)
 	if err != nil {
 		return HumanEscalation{}, err
 	}

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -1034,3 +1034,25 @@ func TestOmarchyManifestPointsToHeadlessService(t *testing.T) {
 		t.Fatal("service lifecycle flags or restart backoff are stale")
 	}
 }
+
+// TestScopeAuthorityReturnsPermissionDenied verifies that scope-authority routes
+// return 403 PERMISSION_DENIED (not 401) when presented with a valid agent token
+// that lacks scope authority. Covers routes from events.go, runtime.go, and
+// output_streams.go that were missed in the initial PR #106 fix.
+func TestScopeAuthorityReturnsPermissionDenied(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+
+	// Events (events.go) — agent token on a scope-authority route.
+	_, err := agents.runtime.Events(ctx, agents.plannerToken, 0, 10, 0)
+	requireCode(t, err, CodePermissionDenied)
+
+	// StorageSummary (runtime.go) — agent token on a scope-authority route.
+	_, err = agents.runtime.StorageSummary(ctx, agents.plannerToken)
+	requireCode(t, err, CodePermissionDenied)
+
+	// CreateOutputStream (output_streams.go) — agent token on a scope-authority route.
+	_, err = agents.runtime.CreateOutputStream(ctx, agents.plannerToken, CreateOutputStreamInput{Name: "denied"})
+	requireCode(t, err, CodePermissionDenied)
+}

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -466,6 +466,13 @@ func TestShutdownRequiresAdminAuthority(t *testing.T) {
 	}
 }
 
+func TestAgentTokenOnScopeRouteIsPermissionDenied(t *testing.T) {
+	ctx := context.Background()
+	agents := setupAgents(t, ":memory:")
+	_, err := agents.runtime.ListAgents(ctx, agents.plannerToken)
+	requireCode(t, err, CodePermissionDenied)
+}
+
 func TestHumanEscalationIsDurableAndScopeOwned(t *testing.T) {
 	agents := setupAgents(t, ":memory:")
 	defer agents.runtime.Close()
@@ -755,7 +762,7 @@ func TestHTTPAndMCPUseTheSameAgentAuthority(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = plannerClient.ListEscalations(ctx)
-	requireCode(t, err, CodeUnauthenticated)
+	requireCode(t, err, CodePermissionDenied)
 	receipt, err := plannerClient.SendMessage(ctx, SendMessageInput{To: "reviewer", Body: "Reserve me"})
 	if err != nil {
 		t.Fatal(err)

--- a/bus/storage_test.go
+++ b/bus/storage_test.go
@@ -115,7 +115,7 @@ func TestRetentionRequiresScopeAuthorityAndValidCutoff(t *testing.T) {
 	if _, err := agents.runtime.StorageSummary(ctx, agents.plannerToken); err == nil {
 		t.Fatal("agent authority inspected scope storage")
 	} else {
-		requireCode(t, err, CodeUnauthenticated)
+		requireCode(t, err, CodePermissionDenied)
 	}
 	_, err := agents.runtime.PruneScope(ctx, agents.scope.ScopeToken, PruneScopeInput{Before: "yesterday"})
 	requireCode(t, err, CodeInvalidArgument)

--- a/cmd/october-bus/main_test.go
+++ b/cmd/october-bus/main_test.go
@@ -600,16 +600,19 @@ func TestListAgentsRejectsInvalidOrAgentCredential(t *testing.T) {
 	address, _, senderToken, _, cleanup := startTestServer(t, ctx, "agent-list-auth")
 	defer cleanup()
 
-	for name, token := range map[string]string{
-		"invalid":     "not-a-real-token",
-		"agent-token": senderToken,
+	for name, tc := range map[string]struct {
+		token string
+		code  bus.ErrorCode
+	}{
+		"invalid":     {"not-a-real-token", bus.CodeUnauthenticated},
+		"agent-token": {senderToken, bus.CodePermissionDenied},
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", token)
+			t.Setenv("OCTOBER_BUS_SCOPE_TOKEN", tc.token)
 			err := runListAgentsCapturing(&bytes.Buffer{}, "--address", address)
 			var busErr *bus.BusError
-			if !errors.As(err, &busErr) || busErr.Code != bus.CodeUnauthenticated {
-				t.Fatalf("expected CodeUnauthenticated, got %v", err)
+			if !errors.As(err, &busErr) || busErr.Code != tc.code {
+				t.Fatalf("expected %s, got %v", tc.code, err)
 			}
 		})
 	}

--- a/conformance/mcp_adapter.go
+++ b/conformance/mcp_adapter.go
@@ -497,7 +497,7 @@ func RunMCPAdapter(ctx context.Context, options MCPAdapterOptions) (result Resul
 		if err != nil {
 			return err
 		}
-		if _, err := workerSession.Client.ResolveEscalation(ctx, escalation.ID, "yes"); requireCode(err, bus.CodeUnauthenticated) != nil {
+		if _, err := workerSession.Client.ResolveEscalation(ctx, escalation.ID, "yes"); requireCode(err, bus.CodePermissionDenied) != nil {
 			return fmt.Errorf("agent resolved its own escalation: %v", err)
 		}
 		resolved, err := owner.ResolveEscalation(ctx, escalation.ID, "yes")

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -537,7 +537,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return err
 		}
 		_, err = planner.ResolveEscalation(ctx, escalation.ID, "yes")
-		if err := requireCode(err, bus.CodeUnauthenticated); err != nil {
+		if err := requireCode(err, bus.CodePermissionDenied); err != nil {
 			return err
 		}
 		escalations, err := owner.ListEscalations(ctx)

--- a/conformance/runner.go
+++ b/conformance/runner.go
@@ -216,7 +216,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return fmt.Errorf("unexpected enabled publication: %#v, %v", enabled, err)
 		}
 		_, err = planner.CreateAgentCardPublication(ctx, bus.PublishAgentCardInput{AgentID: "planner"})
-		return requireCode(err, bus.CodeUnauthenticated)
+		return requireCode(err, bus.CodePermissionDenied)
 	}); err != nil {
 		return result, err
 	}
@@ -587,7 +587,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return ctx.Err()
 		}
 		_, err = planner.Events(ctx, 0, 10, 0)
-		return requireCode(err, bus.CodeUnauthenticated)
+		return requireCode(err, bus.CodePermissionDenied)
 	}); err != nil {
 		return result, err
 	}
@@ -598,7 +598,7 @@ func Run(ctx context.Context, options Options) (result Result, runErr error) {
 			return fmt.Errorf("unexpected storage summary: %#v, %v", summary, err)
 		}
 		_, err = planner.StorageSummary(ctx)
-		if err := requireCode(err, bus.CodeUnauthenticated); err != nil {
+		if err := requireCode(err, bus.CodePermissionDenied); err != nil {
 			return err
 		}
 		before := time.Now().Add(time.Minute).UTC().Format(time.RFC3339Nano)


### PR DESCRIPTION
Closes #100.

## Problem

When an agent token is used on a scope-authority route (e.g. `GET /v1/agents`), `AuthenticateScope` fails with `CodeUnauthenticated` (401) because the agent token hash is not in the scopes table. The credential is valid (it authenticates as an agent) but the authority level is wrong. Per `spec/0.1/http.md`, this is the `PERMISSION_DENIED` (403) case, not `UNAUTHENTICATED` (401). The current behavior makes it hard for clients to distinguish "my token expired" (re-auth) from "wrong token type" (bug in my code).

## Fix

Added `Runtime.resolveScopeToken`: tries `AuthenticateScope` first; if that fails with `CodeUnauthenticated` and the token authenticates as an agent, returns `CodePermissionDenied`. If both fail, returns the original `CodeUnauthenticated`.

All scope-authority callers across `runtime.go`, `events.go`, `a2a_publications.go`, `a2a_principals.go`, `output_principals.go`, and `output_streams.go` route through it. Dual-authority callers (`taskAuthority`, `outputReadAuthority`) that try both token types are left on `AuthenticateScope`.

## Tests

- `go test ./...` — all 8 packages pass
- `go vet ./...` — clean
- `go test -race ./bus/` — pass
- Updated all existing tests and conformance assertions that expected `CodeUnauthenticated` for agent tokens on scope routes to expect `CodePermissionDenied`
- Tests using invalid tokens ("not-a-real-token") still expect `CodeUnauthenticated` (correct — both auths fail)
- Tests using scoped A2A/output credentials still expect `CodeUnauthenticated` (correct — those are neither scope nor agent tokens)