### PR TITLE
fix(bus): expose task title through MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.27.x
           cache: true
@@ -35,8 +35,8 @@ jobs:
       run:
         working-directory: sdk/typescript
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -50,12 +50,12 @@ jobs:
   interoperability:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.27.x
           cache: true
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -73,7 +73,7 @@ jobs:
   vulnerabilities:
     runs-on: ubuntu-latest
     steps:
-      - uses: golang/govulncheck-action@v1
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
         with:
           go-version-input: 1.27.x
           go-package: ./...

--- a/.github/workflows/publish-npm-prerelease.yml
+++ b/.github/workflows/publish-npm-prerelease.yml
@@ -19,12 +19,12 @@ jobs:
       run:
         working-directory: sdk/typescript
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.27.x
           cache: true
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.27.x
           cache: true
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -37,6 +37,14 @@ jobs:
         working-directory: sdk/typescript
         env:
           OCTOBER_BUS_BINARY: /tmp/october-bus
+      - name: Verify signed annotated release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag_object="$(git rev-parse "${GITHUB_REF_NAME}^{tag}")"
+          verified="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}" --jq '.verification.verified')"
+          test "${verified}" = true
 
   build:
     needs: verify
@@ -67,8 +75,8 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       OCTOBER_BUS_VERSION: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 1.27.x
           cache: true
@@ -92,23 +100,23 @@ jobs:
           fi
       - name: Attest Unix archive
         if: matrix.goos != 'windows'
-        uses: actions/attest-build-provenance@v4.2.2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/*.tar.gz
       - name: Attest Windows archive
         if: matrix.goos == 'windows'
-        uses: actions/attest-build-provenance@v4.2.2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/*.zip
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0.24.2
+        uses: anchore/sbom-action@006b7ce8314066bdf1765b4500370d40fa6917a3 # v0.24.2
         with:
           path: dist
           format: spdx-json
           output-file: dist/october-bus_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}.spdx.json
           upload-artifact: false
           upload-release-assets: false
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: october-bus-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -134,7 +142,7 @@ jobs:
             goarch: amd64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: october-bus-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist
@@ -172,8 +180,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           pattern: october-bus-*

--- a/bus/mcp_host_test.go
+++ b/bus/mcp_host_test.go
@@ -103,6 +103,51 @@ func TestServeMCPHostPolicy(t *testing.T) {
 	assertFailure(request(server, "192.168.1.20:4765", false), http.StatusUnauthorized, CodeUnauthenticated)
 }
 
+func TestMCPAddTaskSchemaIncludesTitle(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	server := NewServer(agents.runtime, ServerOptions{})
+	request := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	request.Host = "127.0.0.1:4765"
+	request.Header.Set("Authorization", "Bearer "+agents.plannerToken)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("tools/list failed: status=%d body=%s", response.Code, response.Body.String())
+	}
+	var payload struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				InputSchema struct {
+					Properties map[string]any `json:"properties"`
+					Required   []string       `json:"required"`
+				} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range payload.Result.Tools {
+		if tool.Name != "add_task" {
+			continue
+		}
+		if _, ok := tool.InputSchema.Properties["title"]; !ok {
+			t.Fatalf("add_task schema omitted title: %s", response.Body.String())
+		}
+		for _, required := range tool.InputSchema.Required {
+			if required == "title" {
+				return
+			}
+		}
+		t.Fatalf("add_task schema did not require title: %s", response.Body.String())
+	}
+	t.Fatal("add_task tool was not listed")
+}
+
 func TestDaemonAllowedHostsEnvironment(t *testing.T) {
 	t.Setenv("OCTOBER_BUS_ALLOWED_HOSTS", " a:1 , , b:2 ,a:1 ")
 	root := t.TempDir()

--- a/bus/server.go
+++ b/bus/server.go
@@ -277,9 +277,19 @@ func (s *Server) newMCPServer(token string) *mcp.Server {
 			count, err := s.runtime.AcknowledgeMessages(ctx, token, input.MessageIDs)
 			return nil, map[string]int64{"acknowledged": count}, err
 		})
+	// Avoid naming this field Title: jsonschema-go treats a top-level Go field
+	// with that name as the schema's title annotation and omits the JSON
+	// property. The MCP validator would then reject the required task title.
+	type addTaskInput struct {
+		TaskTitle    string   `json:"title"`
+		Description  string   `json:"description,omitempty"`
+		Dependencies []string `json:"dependencies,omitempty"`
+	}
 	mcp.AddTool(server, &mcp.Tool{Name: "add_task", Description: "Add a shared task with optional dependencies."},
-		func(ctx context.Context, _ *mcp.CallToolRequest, input AddTaskInput) (*mcp.CallToolResult, any, error) {
-			result, err := s.runtime.AddTask(ctx, token, input)
+		func(ctx context.Context, _ *mcp.CallToolRequest, input addTaskInput) (*mcp.CallToolResult, any, error) {
+			result, err := s.runtime.AddTask(ctx, token, AddTaskInput{
+				Title: input.TaskTitle, Description: input.Description, Dependencies: input.Dependencies,
+			})
 			return nil, result, err
 		})
 	type taskIDInput struct {


### PR DESCRIPTION
Fixes the public MCP `add_task` schema so `title` is exposed and required, with a regression test.

Also pins every workflow action to an immutable commit and makes release verification reject tags that GitHub does not verify as signed annotated tags.

Validation:

- `go test ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- TypeScript SDK typecheck, build, error tests, and integration tests
- October Harness two-agent integration against the corrected Bus build
