### PR TITLE
feat: add maintainer-assisted harness verification tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/harness-verification.yml
+++ b/.github/ISSUE_TEMPLATE/harness-verification.yml
@@ -1,0 +1,60 @@
+name: Maintainer-assisted harness verification
+description: Request a named-harness run without buying an account or owning another platform.
+title: "Verification request: "
+labels: [adapter]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Experimental contributions are welcome without paid accounts or every OS.
+        This request does not approve code execution or certify compatibility.
+        Never post credentials, raw logs, private prompts, or account access links.
+  - type: input
+    id: revision
+    attributes:
+      label: PR and immutable commit
+      description: Link the contribution and supply its full 40-character commit SHA for review. Do not use only a branch name.
+    validations:
+      required: true
+  - type: textarea
+    id: versions
+    attributes:
+      label: Exact versions and target platform
+      description: Harness product/version, adapter ID/version, released Bus version, protocol/profile, OS and architecture. Mark unknown versions explicitly.
+    validations:
+      required: true
+  - type: textarea
+    id: setup
+    attributes:
+      label: Public setup and permission requirements
+      description: Link public installation/configuration instructions and describe expected approvals, authentication, and network access. Use placeholder variable names, never live values.
+    validations:
+      required: true
+  - type: textarea
+    id: scenarios
+    attributes:
+      label: Scenarios to run and observed failures
+      description: Name missing RUNBOOK steps, expected results, reproducible failures, and whether this was a named-harness or generic bridge attempt. Include restart, replacement, and cleanup coverage.
+    validations:
+      required: true
+  - type: textarea
+    id: access
+    attributes:
+      label: Assistance needed
+      description: Describe the missing platform, account, or manual interaction. Maintainers keep control of their own accounts; contributors do not need to share or purchase credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Reviewed artifact links and limitations
+      description: Optional public sanitized log/bundle link and its digest, or say that no shareable artifact exists. Do not paste raw logs. State partial/not-run outcomes honestly.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Disclosure checks
+      options:
+        - label: This request contains no live credentials, private log contents, or access invitations.
+          required: true
+        - label: I understand that experimental status and generic CI do not certify a named harness.
+          required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm run test:errors
+      - run: node --test ../../scripts/verification-bundle.test.mjs
       - run: npm audit --audit-level=high
 
   interoperability:

--- a/compatibility/README.md
+++ b/compatibility/README.md
@@ -2,13 +2,15 @@
 
 October Bus names a harness as verified only when a current public evidence record passes the applicable conformance profile.
 
-The registry starts empty. Experimental adapter manifests do not count as compatibility evidence.
+The registry contains only independently reviewed passing records. Experimental adapter manifests and unreviewed attempt bundles do not count as compatibility evidence.
 
 Each evidence record must validate against [`compatibility-evidence.schema.json`](../spec/0.1/schemas/compatibility-evidence.schema.json) and include the harness version, adapter version, Bus versions, platform, result digest, verification time, repository commit, limitations, and verification mode. The registry itself is validated against [`compatibility-registry.schema.json`](../spec/0.1/schemas/compatibility-registry.schema.json).
 
 `registry.json` contains paths to current passing evidence. Failed or stale records may remain for history but must be removed from the registry.
 
 Use the [harness verification runbook](RUNBOOK.md) to produce a reproducible evidence record.
+
+Missing an account or platform? Use [maintainer-assisted verification](VERIFICATION.md) to request a run and prepare a local, sanitized, unreviewed log bundle. CI validates all formal evidence files, including records not listed in the registry.
 
 The automated `mcp-adapter` runner verifies an adapter executable without asking a model to perform the checks. This establishes the transport and coordination behavior of the adapter. It does not establish compatibility for a named harness. A harness enters this registry only after its released version also completes the runbook through that adapter.
 

--- a/compatibility/RUNBOOK.md
+++ b/compatibility/RUNBOOK.md
@@ -32,6 +32,10 @@ Record every host prompt, approval, limitation, result, and version. A model ret
 
 ## Evidence
 
+Use the [maintainer-assisted verification workflow](VERIFICATION.md) when an account or platform is unavailable, or to package sanitized logs for review. Partial and not-run attempts are observations, not formal passing evidence.
+
 Create one JSON record that validates against [`compatibility-evidence.schema.json`](../spec/0.1/schemas/compatibility-evidence.schema.json). Hash the complete run log with SHA-256 and place that digest in `resultDigest`.
+
+Review and sanitize the log before publication, preserving the scenario evidence. `resultDigest` must hash the exact published sanitized bytes; include an HTTPS `attestation` link to those artifacts. Redaction tooling does not replace manual privacy or compatibility review.
 
 A passing record must use a public repository commit and a released harness version. Add it to `registry.json` only after independent review confirms the required profile passed.

--- a/compatibility/VERIFICATION.md
+++ b/compatibility/VERIFICATION.md
@@ -1,0 +1,54 @@
+# Maintainer-assisted verification
+
+Contributors do not need to buy harness subscriptions or own every operating system to submit safe experimental work. Missing infrastructure can be tracked separately; known correctness failures and unsupported compatibility claims still need correction. This workflow implements the repository-side part of [#108](https://github.com/october-dev/october-bus/issues/108), not account provisioning or automatic certification.
+
+## Request a run
+
+Open a **Maintainer-assisted harness verification** issue using the repository template. Supply the PR and immutable commit, exact versions, target platform, public setup, expected permissions, missing [runbook](RUNBOOK.md) scenarios, and any known failures. State when authentication prevented a run or no sanitized log is available.
+
+A maintainer must explicitly approve the exact revision before running it. Use a disposable environment and a maintainer-operated account or manually run the scenarios on a maintainer-controlled machine. Never ask contributors to send credentials. Do not expose account, repository-write, or release secrets to arbitrary fork code; a passing PR check is not approval to execute it with those privileges. Additional platform runs may remain pending while accurately scoped experimental documentation merges.
+
+## Prepare a local bundle
+
+The dependency-free tool uses Node.js 20 or newer. It does not install or execute a harness, obtain account access, contact the network, upload files, or edit the verified registry.
+
+Keep inputs outside the repository in a private directory. Copy the fields from [attempt.example.json](attempt.example.json) into your private `attempt.json`, replacing **every example value** with the actual attempt metadata. `attemptedAt` is the attempt time in ISO UTC; `repositoryCommit` is the full reviewed SHA, not a branch. `outcome` is a contributor-reported `passed`, `failed`, `partial`, or `not-run`, never an independent verification claim. For `not-run`, record setup observations instead of inventing a transcript. Supply exact versions where known; explicitly record unknown runtime or harness versions and their limitations instead of guessing. Such attempts cannot qualify as formal passing evidence.
+
+From the repository root, with those private paths substituted:
+
+```sh
+node scripts/verification-bundle.mjs \
+  --metadata /private/path/attempt.json \
+  --log /private/path/raw-run.log \
+  --out /private/path/new-bundle \
+  --redact-env CUSTOM_HARNESS_TOKEN
+
+node scripts/verification-bundle.mjs verify /private/path/new-bundle
+```
+
+`--redact-env` is optional and repeatable. Pass **environment variable names, never secret values**; a named variable must exist and be nonempty. Default redaction covers Bus admin/scope/agent tokens and common GitHub, npm, OpenAI, and Anthropic token variables when present. It also handles common bearer/basic headers, JSON credential fields, shell/query credential assignments, URL user/password pairs, terminal controls, and the current home-directory prefix. Supply additional known credentials via environment variables, including any generated during the attempt. Never persist those values in the issue template or example configuration.
+
+The output directory must not exist; its parent must already exist. The tool accepts regular UTF-8 files, up to 64 KiB of metadata and 16 MiB of log text. It refuses symbolic-link inputs and never overwrites inputs or an existing bundle. Output contains only `run.log`, `bundle.json`, and `REVIEW.md`. Files are created with mode `0600` in a `0700` directory on POSIX; use a private directory with appropriate ACLs on Windows. A write failure can leave a partial, private bundle; inspect it and retry with a new output directory.
+
+## Review before sharing
+
+**Redaction is best effort, not a privacy guarantee.** Manually inspect both the sanitized log and metadata for private prompts, project data, arbitrary paths and URLs, unknown or encoded credentials, and secrets split across records. Retain required scenario evidence, exact tool arguments (except secrets), approvals, failures/retries, and limitations. If redaction removes information needed to judge a scenario, repeat it with synthetic non-sensitive data rather than claiming it passed.
+
+The digest covers the exact bytes of the **sanitized** `run.log`, not the private raw source. If either the source or redaction rules change, generate a new bundle and verify it again. The `verify` command checks the log digest/size and basic manifest structure only: it does not authenticate the author, attest the metadata, guarantee privacy, or certify compatibility. Bundle status always remains `unreviewed`, even when the reported outcome is `passed`.
+
+Only after explicit human review should a maintainer publish the sanitized artifacts at a reproducible public HTTPS location. Never upload the raw input. This repository does not automatically upload bundles or provide accounts/runners through the issue template.
+
+## Promote evidence separately
+
+An independent reviewer must compare the complete named-harness run against the [runbook](RUNBOOK.md), exact versions and commit, required approvals, failure/retry history, restart/replacement, and clean/unclean recovery. Generic bridge CI does not substitute for this run.
+
+A completed run can then produce a separate record matching the [evidence schema](../spec/0.1/schemas/compatibility-evidence.schema.json), using the public sanitized-log digest and an `attestation` link to the reviewed artifacts. The formal schema accepts only `passed` or `failed`; `partial`, `not-run`, and informal observations belong in `compatibility/observations/`, not in `compatibility/evidence/`. Do not copy `bundle.json` into the evidence directory.
+
+CI validates **every** file in the flat `compatibility/evidence/` directory against the formal schema, including failed, historical, and unregistered records. Keep that directory limited to regular JSON evidence files: no notes, subdirectories, symlinks, or bundles. This structural check does not promote a record, judge freshness, or establish that the harness really ran. Only independently reviewed current passing evidence may enter `registry.json`. Leave the adapter's compatibility issue open until its actual acceptance criteria are satisfied.
+
+Local tooling checks (no additional harness installation):
+
+```sh
+node --test scripts/verification-bundle.test.mjs
+go test ./spec -run 'Test(AllCompatibilityEvidence|UnregisteredCompatibilityEvidenceIsValidated)$'
+```

--- a/compatibility/attempt.example.json
+++ b/compatibility/attempt.example.json
@@ -1,0 +1,16 @@
+{
+  "harnessFamily": "Example Harness",
+  "harnessVersion": "1.2.3",
+  "adapterId": "example-mcp",
+  "adapterVersion": "0.1.0",
+  "protocolVersion": "0.1",
+  "runtimeVersion": "v0.1.0-rc.4",
+  "operatingSystem": "linux",
+  "architecture": "amd64",
+  "profile": "mcp-adapter",
+  "repositoryCommit": "0000000000000000000000000000000000000000",
+  "verificationMode": "manual",
+  "attemptedAt": "2026-09-06T00:00:00Z",
+  "outcome": "not-run",
+  "limitations": ["Example only: replace every value with actual attempt metadata"]
+}

--- a/scripts/verification-bundle.mjs
+++ b/scripts/verification-bundle.mjs
@@ -1,0 +1,159 @@
+import { createHash } from 'node:crypto'
+import { closeSync, constants, fstatSync, lstatSync, mkdirSync, openSync, readSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
+import { fileURLToPath } from 'node:url'
+
+const maxLogBytes = 16 * 1024 * 1024
+const defaultSecretNames = ['OCTOBER_BUS_ADMIN_TOKEN', 'OCTOBER_BUS_SCOPE_TOKEN', 'OCTOBER_BUS_AGENT_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN', 'NPM_TOKEN', 'NODE_AUTH_TOKEN', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY']
+const fields = ['harnessFamily', 'harnessVersion', 'adapterId', 'adapterVersion', 'protocolVersion', 'runtimeVersion', 'operatingSystem', 'architecture', 'profile', 'repositoryCommit', 'verificationMode', 'attemptedAt', 'outcome', 'limitations']
+const check = (condition, message) => { if (!condition) throw new Error(message) }
+const digest = bytes => `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+
+function readLimited(path, limit) {
+  check(lstatSync(path).isFile(), 'Inputs must be regular files, not directories or symbolic links')
+  const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
+  try {
+    check(fstatSync(fd).isFile(), 'Inputs must be regular files')
+    check(fstatSync(fd).size <= limit, 'Input exceeds the size limit')
+    const buffer = Buffer.alloc(limit + 1)
+    let size = 0
+    while (size < buffer.length) {
+      const count = readSync(fd, buffer, size, buffer.length - size, null)
+      if (count === 0) break
+      size += count
+    }
+    check(size <= limit, 'Input exceeds the size limit')
+    return buffer.subarray(0, size)
+  } finally { closeSync(fd) }
+}
+
+function readJSON(path) {
+  const bytes = readLimited(path, 64 * 1024)
+  try { return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) }
+  catch { throw new Error('Input must contain valid UTF-8 JSON') }
+}
+
+export function validateAttempt(metadata) {
+  check(metadata !== null && typeof metadata === 'object' && !Array.isArray(metadata), 'Attempt metadata must be an object')
+  check(Object.keys(metadata).length === fields.length && fields.every(field => Object.hasOwn(metadata, field)), 'Attempt metadata has missing or unknown fields')
+  for (const field of fields.filter(field => field !== 'limitations')) {
+    check(typeof metadata[field] === 'string' && metadata[field].trim().length > 0 && metadata[field].length <= 256 && !/[\x00-\x1f\x7f]/.test(metadata[field]), `Invalid metadata field: ${field}`)
+  }
+  check(/^[a-z0-9][a-z0-9-]{0,63}$/.test(metadata.adapterId), 'Invalid adapterId')
+  check(/^\d+\.\d+$/.test(metadata.protocolVersion), 'Invalid protocolVersion')
+  check(/^[a-f0-9]{40}$/.test(metadata.repositoryCommit), 'Use a full immutable repository commit')
+  for (const [field, values] of Object.entries({ operatingSystem: ['macos', 'linux', 'windows'], architecture: ['amd64', 'arm64'], profile: ['mcp-adapter', 'native-adapter'], verificationMode: ['automated', 'assisted', 'manual'], outcome: ['passed', 'failed', 'partial', 'not-run'] })) {
+    check(values.includes(metadata[field]), `Invalid metadata field: ${field}`)
+  }
+  const instant = new Date(metadata.attemptedAt)
+  check(Number.isFinite(instant.getTime()) && instant.toISOString().replace('.000Z', 'Z') === metadata.attemptedAt.replace('.000Z', 'Z'), 'attemptedAt must be an ISO UTC timestamp')
+  check(Array.isArray(metadata.limitations) && metadata.limitations.length <= 50 && metadata.limitations.every(value => typeof value === 'string' && value.trim().length > 0 && value.length <= 1024), 'Invalid limitations')
+  return metadata
+}
+
+export function redactLog(input, { secrets = [], homeDirectory } = {}) {
+  let text = stripVTControlCharacters(input).replace(/\r\n?/g, '\n').replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '')
+  const rules = new Set(text === input ? [] : ['terminal-controls'])
+  const replace = (pattern, replacement, rule) => {
+    const next = text.replace(pattern, replacement)
+    if (next !== text) rules.add(rule)
+    text = next
+  }
+  const literal = (value, replacement, rule) => {
+    if (value && text.includes(value)) { text = text.split(value).join(replacement); rules.add(rule) }
+  }
+  const variants = secrets.flatMap(value => [value, encodeURIComponent(value), JSON.stringify(value).slice(1, -1)])
+  for (const value of [...new Set(variants)].sort((a, b) => b.length - a.length)) literal(value, '[REDACTED]', 'explicit-secrets')
+  if (homeDirectory && homeDirectory.length > 1) {
+    for (const value of [homeDirectory, JSON.stringify(homeDirectory).slice(1, -1), encodeURIComponent(homeDirectory)]) literal(value, '[HOME]', 'home-directory')
+  }
+  replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 [REDACTED]', 'authorization')
+  const key = '(?:[A-Za-z_][A-Za-z0-9_]*(?:token|secret|password|api_?key)|token|secret|password|api_?key|credential)'
+  replace(new RegExp(`("${key}"\\s*:\\s*)"(?:\\\\.|[^"\\\\])*"`, 'gi'), '$1"[REDACTED]"', 'credential-fields')
+  replace(new RegExp(`(\\b${key}\\s*=\\s*)(?:"(?:\\\\.|[^"\\\\])*"|'[^']*'|[^\\s,;&]+)`, 'gi'), '$1[REDACTED]', 'credential-fields')
+  replace(/(https?:\/\/)[^\s/@]+:[^\s/@]+@/gi, '$1[REDACTED]@', 'url-credentials')
+  return { text, rules: [...rules].sort() }
+}
+
+export function createVerificationBundle({ metadataPath, logPath, outDir, redactEnv = [], env = process.env }) {
+  for (const name of redactEnv) {
+    check(/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) && typeof env[name] === 'string' && env[name].length > 0, 'Each --redact-env must name a nonempty environment variable')
+  }
+  const secrets = [...new Set([...defaultSecretNames, ...redactEnv])].map(name => env[name]).filter(value => typeof value === 'string' && value.length > 0)
+  const redaction = { secrets, homeDirectory: env.HOME ?? env.USERPROFILE }
+  const metadata = validateAttempt(readJSON(metadataPath))
+  const metadataJSON = JSON.stringify(metadata)
+  check(redactLog(metadataJSON, redaction).text === metadataJSON, 'Metadata contains sensitive values; sanitize it before bundling')
+  let rawLog
+  try { rawLog = new TextDecoder('utf-8', { fatal: true }).decode(readLimited(logPath, maxLogBytes)) }
+  catch (error) {
+    if (error instanceof TypeError) throw new Error('Log must contain valid UTF-8 text')
+    throw error
+  }
+  check(rawLog.trim().length > 0, 'Log must not be empty; include setup observations for a not-run attempt')
+  const sanitized = redactLog(rawLog, redaction)
+  check(sanitized.text.trim().length > 0, 'Sanitized log must not be empty')
+  check(Buffer.byteLength(sanitized.text) <= maxLogBytes, 'Sanitized log exceeds the size limit')
+  const manifest = {
+    schemaVersion: 1, kind: 'october-bus-verification-bundle', verificationStatus: 'unreviewed',
+    createdAt: new Date().toISOString(), metadata,
+    log: { path: 'run.log', resultDigest: digest(sanitized.text), bytes: Buffer.byteLength(sanitized.text) },
+    redaction: { rules: sanitized.rules, manualReviewRequired: true }
+  }
+  // Never copy the raw log, overwrite an existing bundle, execute a harness,
+  // upload artifacts, or change the verified registry.
+  mkdirSync(outDir, { mode: 0o700 })
+  const write = (name, text) => writeFileSync(join(outDir, name), text, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+  write('run.log', sanitized.text)
+  write('bundle.json', `${JSON.stringify(manifest, null, 2)}\n`)
+  write('REVIEW.md', '# Unreviewed verification bundle\n\nRedaction is best effort, not a privacy guarantee. Inspect run.log and bundle.json for credentials, private prompts, personal paths, URLs, and project data before sharing.\n\nThis bundle does not certify a harness. Check the exact versions, immutable commit, all required runbook scenarios, approvals, failures, and limitations. Partial and not-run attempts are observations, not formal passing evidence.\n\nIf the log needs more redaction, regenerate the bundle from a corrected private input or with additional --redact-env names. Verify its digest after any change. Publish only after explicit human review; never upload the raw source log. Independent review is required before creating a formal evidence record or changing the verified registry.\n')
+  return manifest
+}
+
+export function verifyVerificationBundle(directory) {
+  check(lstatSync(directory).isDirectory(), 'Bundle must be a real directory, not a symbolic link')
+  const bundle = readJSON(join(directory, 'bundle.json'))
+  check(bundle?.schemaVersion === 1 && bundle.kind === 'october-bus-verification-bundle' && bundle.verificationStatus === 'unreviewed' && bundle.redaction?.manualReviewRequired === true, 'Invalid unreviewed bundle manifest')
+  validateAttempt(bundle.metadata)
+  check(bundle.log?.path === 'run.log', 'Invalid bundle log path')
+  const log = readLimited(join(directory, 'run.log'), maxLogBytes)
+  check(bundle.log.bytes === log.length && bundle.log.resultDigest === digest(log), 'Bundle log digest or size mismatch; regenerate the bundle')
+  return bundle
+}
+
+function main(args) {
+  if (args.length === 1 && args[0] === '--help') {
+    console.log('Create: node scripts/verification-bundle.mjs --metadata FILE --log FILE --out NEW_DIRECTORY [--redact-env NAME ...]\nCheck:  node scripts/verification-bundle.mjs verify DIRECTORY\nLocal unreviewed artifacts only. Redaction requires manual review before sharing.')
+    return
+  }
+  if (args.length === 2 && args[0] === 'verify') {
+    verifyVerificationBundle(args[1])
+    console.log('Bundle log digest valid. This is not a signature or harness certification; status remains unreviewed.')
+    return
+  }
+  const options = { redactEnv: [] }
+  const flags = { '--metadata': 'metadataPath', '--log': 'logPath', '--out': 'outDir' }
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index], value = args[index + 1]
+    check(typeof value === 'string' && !value.startsWith('--'), 'Expected a value after each option; see --help')
+    if (flag === '--redact-env') options.redactEnv.push(value)
+    else {
+      check(Object.hasOwn(flags, flag) && !Object.hasOwn(options, flags[flag]), 'Unknown or repeated option; see --help')
+      options[flags[flag]] = value
+    }
+  }
+  check(Object.values(flags).every(name => options[name]), 'Expected --metadata, --log, and --out; see --help')
+  createVerificationBundle(options)
+  console.log('Created a local, unreviewed bundle. Inspect it for sensitive data before sharing. Nothing was uploaded or verified.')
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try { main(process.argv.slice(2)) }
+  catch (error) {
+    // Native filesystem errors can contain private paths; JSON parser errors
+    // can quote input. Neither belongs in a shareable CLI diagnostic.
+    console.error(error.code ? `Verification bundle failed (${error.code}); check input files and the new output directory.` : error.message)
+    process.exitCode = 1
+  }
+}

--- a/scripts/verification-bundle.test.mjs
+++ b/scripts/verification-bundle.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+import { createVerificationBundle, redactLog, validateAttempt, verifyVerificationBundle } from './verification-bundle.mjs'
+
+const example = JSON.parse(readFileSync(new URL('../compatibility/attempt.example.json', import.meta.url)))
+const cli = fileURLToPath(new URL('./verification-bundle.mjs', import.meta.url))
+function fixture(t, changes = {}, log = 'Setup attempted; authentication unavailable.\n') {
+  const root = mkdtempSync(join(tmpdir(), 'bus-verification-test-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const metadataPath = join(root, 'attempt.json'), logPath = join(root, 'private.log'), outDir = join(root, 'bundle')
+  writeFileSync(metadataPath, JSON.stringify({ ...example, ...changes }))
+  writeFileSync(logPath, log)
+  return { root, metadataPath, logPath, outDir, env: {} }
+}
+
+test('redacts literal, escaped, encoded and labeled credentials plus private home paths', () => {
+  const secret = 'private/+secret="quoted"'
+  const input = [
+    secret, encodeURIComponent(secret), JSON.stringify(secret),
+    'Authorization: Bearer abc.def-123', 'Authorization: Basic YWJjZGVm',
+    '{"agentToken":"json-secret", "scopeToken": "escaped\\\"secret"}',
+    'OCTOBER_BUS_ADMIN_TOKEN="shell secret" TOKEN=bare-secret',
+    "CUSTOM_API_KEY='api secret' password=pass-secret",
+    'https://user:pass@example.test/?token=query-secret&ok=1',
+    '/Users/example/project/file', '\u001b[31mBearer\u001b[0m ansi-secret\r\nnormal result: acknowledged=1'
+  ].join('\n')
+  const { text, rules } = redactLog(input, { secrets: [secret], homeDirectory: '/Users/example' })
+  for (const value of [secret, encodeURIComponent(secret), 'abc.def-123', 'YWJjZGVm', 'json-secret', 'escaped', 'shell secret', 'bare-secret', 'api secret', 'pass-secret', 'user:pass', 'query-secret', '/Users/example', 'ansi-secret']) assert(!text.includes(value), value)
+  assert(text.includes('normal result: acknowledged=1'))
+  assert(text.includes('[HOME]/project/file'))
+  assert.deepEqual(rules, ['authorization', 'credential-fields', 'explicit-secrets', 'home-directory', 'terminal-controls', 'url-credentials'])
+})
+
+test('creates private, unreviewed artifacts with a digest of the sanitized log only', t => {
+  const f = fixture(t, {}, 'Bearer raw-secret\nKnown: runtime-secret\nSetup not run.\n')
+  const before = readFileSync(f.logPath, 'utf8')
+  const manifest = createVerificationBundle({ ...f, env: { OCTOBER_BUS_AGENT_TOKEN: 'runtime-secret' } })
+  const log = readFileSync(join(f.outDir, 'run.log'))
+  assert.equal(manifest.log.resultDigest, `sha256:${createHash('sha256').update(log).digest('hex')}`)
+  assert.equal(manifest.verificationStatus, 'unreviewed')
+  assert.equal(manifest.metadata.outcome, 'not-run')
+  assert.equal(manifest.redaction.manualReviewRequired, true)
+  assert.deepEqual(readdirSync(f.outDir).sort(), ['REVIEW.md', 'bundle.json', 'run.log'])
+  assert(!log.includes('raw-secret') && !log.includes('runtime-secret'))
+  assert.equal(readFileSync(f.logPath, 'utf8'), before, 'raw input must remain unchanged')
+  assert.deepEqual(verifyVerificationBundle(f.outDir), manifest)
+  if (process.platform !== 'win32') {
+    assert.equal(statSync(f.outDir).mode & 0o777, 0o700)
+    for (const name of readdirSync(f.outDir)) assert.equal(statSync(join(f.outDir, name)).mode & 0o777, 0o600)
+  }
+  assert.throws(() => createVerificationBundle(f), /EEXIST/)
+  assert.equal(readFileSync(join(f.outDir, 'run.log'), 'utf8'), log.toString())
+  writeFileSync(join(f.outDir, 'run.log'), 'edited')
+  assert.throws(() => verifyVerificationBundle(f.outDir), /digest or size mismatch/)
+})
+
+test('outcome labels never promote an attempt to formal verified evidence', t => {
+  for (const outcome of ['passed', 'failed', 'partial', 'not-run']) {
+    const f = fixture(t, { outcome })
+    const bundle = createVerificationBundle(f)
+    assert.equal(bundle.metadata.outcome, outcome)
+    assert.equal(bundle.verificationStatus, 'unreviewed')
+    assert(!readdirSync(f.outDir).includes('evidence.json'))
+  }
+  for (const changes of [{ outcome: 'verified' }, { repositoryCommit: 'main' }, { profile: 'local-runtime' }, { attemptedAt: '2026-02-30T00:00:00Z' }, { limitations: 'none' }, { extra: 'unknown' }]) assert.throws(() => validateAttempt({ ...example, ...changes }))
+})
+
+test('fails closed on missing redaction secrets, unsafe metadata and malformed inputs', t => {
+  const f = fixture(t)
+  assert.throws(() => createVerificationBundle({ ...f, redactEnv: ['MISSING'] }), /nonempty environment variable/)
+  writeFileSync(f.metadataPath, JSON.stringify({ ...example, limitations: ['private-value'] }))
+  assert.throws(() => createVerificationBundle({ ...f, redactEnv: ['PRIVATE_VALUE'], env: { PRIVATE_VALUE: 'private-value' } }), /Metadata contains sensitive/)
+  writeFileSync(f.metadataPath, '{"token":"do-not-print-this-secret", broken')
+  const failed = spawnSync(process.execPath, [cli, '--metadata', f.metadataPath, '--log', f.logPath, '--out', f.outDir], { encoding: 'utf8' })
+  assert.equal(failed.status, 1)
+  assert(!failed.stderr.includes('do-not-print-this-secret'))
+  writeFileSync(f.metadataPath, JSON.stringify(example))
+  for (const log of [Buffer.alloc(0), Buffer.from('\u001b[31m\u001b[0m'), Buffer.from([0xff]), Buffer.alloc(16 * 1024 * 1024 + 1, 65)]) {
+    writeFileSync(f.logPath, log)
+    assert.throws(() => createVerificationBundle(f), /empty|UTF-8|size limit/)
+  }
+  writeFileSync(f.logPath, '!'.repeat(2 * 1024 * 1024))
+  assert.throws(() => createVerificationBundle({ ...f, redactEnv: ['SHORT_SECRET'], env: { SHORT_SECRET: '!' } }), /Sanitized log exceeds/)
+})
+
+test('CLI supports creation, digest verification and strict option parsing', t => {
+  const f = fixture(t)
+  const args = ['--metadata', f.metadataPath, '--log', f.logPath, '--out', f.outDir]
+  for (const extra of [['--unknown', 'x'], ['--log', f.logPath], ['--redact-env']]) {
+    assert.equal(spawnSync(process.execPath, [cli, ...args, ...extra]).status, 1)
+  }
+  assert.equal(spawnSync(process.execPath, [cli, ...args]).status, 0)
+  assert.equal(spawnSync(process.execPath, [cli, 'verify', f.outDir]).status, 0)
+  assert.equal(spawnSync(process.execPath, [cli, '--help']).status, 0)
+  const manifest = JSON.parse(readFileSync(join(f.outDir, 'bundle.json')))
+  manifest.log.path = '../private.log'
+  writeFileSync(join(f.outDir, 'bundle.json'), JSON.stringify(manifest))
+  assert.throws(() => verifyVerificationBundle(f.outDir), /log path/)
+})
+
+test('does not follow symbolic-link inputs or bundle files', { skip: process.platform === 'win32' }, t => {
+  const f = fixture(t)
+  const link = join(f.root, 'linked.log')
+  symlinkSync(f.logPath, link)
+  assert.throws(() => createVerificationBundle({ ...f, logPath: link }), /regular files/)
+  createVerificationBundle(f)
+  const bundleLink = join(f.root, 'linked-bundle')
+  symlinkSync(f.outDir, bundleLink)
+  assert.throws(() => verifyVerificationBundle(bundleLink), /real directory/)
+})

--- a/spec/compatibility_evidence_test.go
+++ b/spec/compatibility_evidence_test.go
@@ -1,0 +1,93 @@
+package spec_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// Validate history and unregistered records too: excluding a malformed record
+// from registry.json must not hide it from CI. Attempt notes belong elsewhere.
+func validateEvidenceDirectory(directory string, schema *jsonschema.Resolved) error {
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return err
+	}
+	namePattern := regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*\.json$`)
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() || !namePattern.MatchString(entry.Name()) {
+			return fmt.Errorf("%s: evidence must be flat, regular JSON files", entry.Name())
+		}
+		data, err := os.ReadFile(filepath.Join(directory, entry.Name()))
+		if err != nil {
+			return err
+		}
+		var record any
+		if !utf8.Valid(data) || json.Unmarshal(data, &record) != nil {
+			return fmt.Errorf("%s: invalid evidence JSON", entry.Name())
+		}
+		if err := schema.Validate(record); err != nil {
+			return fmt.Errorf("%s: invalid compatibility evidence: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+func TestAllCompatibilityEvidence(t *testing.T) {
+	schema := resolvedSchema(t, filepath.Join("0.1", "schemas", "compatibility-evidence.schema.json"), "")
+	if err := validateEvidenceDirectory(filepath.Join("..", "compatibility", "evidence"), schema); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnregisteredCompatibilityEvidenceIsValidated(t *testing.T) {
+	schema := resolvedSchema(t, filepath.Join("0.1", "schemas", "compatibility-evidence.schema.json"), "")
+	fixture := readJSON(t, filepath.Join("..", "compatibility", "evidence", "codex-0.152.1-macos-arm64.json")).(map[string]any)
+	for _, outcome := range []string{"passed", "failed", "observed", "partial", "not-run"} {
+		t.Run(outcome, func(t *testing.T) {
+			directory := t.TempDir() // Deliberately no registry entry for this record.
+			fixture["result"] = outcome
+			data, err := json.Marshal(fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(directory, "unregistered.json"), data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			err = validateEvidenceDirectory(directory, schema)
+			if (err == nil) != (outcome == "passed" || outcome == "failed") {
+				t.Fatalf("unexpected validation result: %v", err)
+			}
+		})
+	}
+	for _, name := range []string{"bundle.json", "notes.md", "malformed.json"} {
+		t.Run(name, func(t *testing.T) {
+			directory := t.TempDir()
+			data := []byte(`{"outcome":"not-run"}`)
+			if name == "malformed.json" {
+				data = []byte(`{"result":`)
+			}
+			if err := os.WriteFile(filepath.Join(directory, name), data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := validateEvidenceDirectory(directory, schema); err == nil {
+				t.Fatal("attempt metadata or notes were accepted as formal evidence")
+			}
+		})
+	}
+	t.Run("nested-record", func(t *testing.T) {
+		directory := t.TempDir()
+		if err := os.Mkdir(filepath.Join(directory, "nested"), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateEvidenceDirectory(directory, schema); err == nil {
+			t.Fatal("nested evidence directory was accepted")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Repository-side implementation for issue #108. This does not close #108: maintainer-run account access, actual named-harness runs, publication, and independent certification still require human follow-through.

- Add a maintainer-assisted verification issue form and a documented immutable-revision, least-privilege run/review process.
- Add dependency-free local bundle creation and digest verification. Inputs stay unchanged; output is always unreviewed and contains a sanitized log, exact attempt metadata, and review instructions. No harness execution, uploads, registry edits, or automatic evidence promotion.
- Cover common credential formats and named secret environment variables, with mandatory manual privacy review. Bound input/output sizes, refuse symlink inputs and existing output directories, and create private POSIX permissions.
- Validate every regular JSON record in compatibility/evidence through the existing schema, including unregistered and historical records. Reject partial/not-run/observed values as formal evidence; preserve them as attempt observations instead.
- Run bundle regressions in the existing SDK CI job. The schema regressions run through existing Go CI on all platforms.

## Verification

- node --test scripts/verification-bundle.test.mjs: 6 tests passed
- GOTOOLCHAIN=go1.27.0 GOPROXY=off go test -race ./spec -count=1: passed, using cached tools and dependencies
- Issue-template and workflow YAML parse checks: passed
- Local documentation links and git diff --check: passed

No additional harness installations, accounts, or dependencies were needed. This is independent of the pending #109 metadata-consistency checker: the new Go gate validates all evidence files structurally; #109 adds active-registry consistency and release checks. No runtime/protocol behavior or verified-registry contents change.