### PR TITLE
docs: clarify introduction and keep planning notes local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /_audit/
+# Local planning and working notes.
+/_internal/
 node_modules/
 dist/
 bin/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
 
 **October Bus is an open communication and coordination layer for AI agents that need to work together.**
 
-Connect agents across harnesses and repositories. Let them find collaborators, exchange focused requests, and pick up shared work—with a durable record of what was accepted, who owns it, and what still needs attention.
-
-Bring the agents you already use. Their models, tools, private context, and permissions stay with their harnesses.
+Keep your harness. Add coordination. October Bus lets independent agents discover collaborators, exchange durable requests and replies, and coordinate shared tasks—while each harness keeps its own models, tools, private context, and permissions.
 
 ## Why it exists
 


### PR DESCRIPTION
## Summary
- Refine the README introduction: Keep your harness. Add coordination.
- Ignore the root _internal/ folder for local planning and working notes.
- Keep existing user-facing documentation tracked; the local launch plan is not included in this PR.

## Validation
- git diff --check passed.
- Confirmed _internal/v1-harness-launch-plan.md is ignored.
- Verified all 14 relative file links in the relocated local plan resolve.
- Full CI will run on this PR before merge.