### PR TITLE
feat(bus): let an agent cancel its own pending escalation (#113)

### DIFF
--- a/bus/client.go
+++ b/bus/client.go
@@ -378,6 +378,10 @@ func (c Client) Escalation(ctx context.Context, id string) (HumanEscalation, err
 	return request[HumanEscalation](ctx, c, http.MethodGet, "/v1/escalations/"+url.PathEscape(id), nil)
 }
 
+func (c Client) CancelEscalation(ctx context.Context, id string) (HumanEscalation, error) {
+	return request[HumanEscalation](ctx, c, http.MethodPost, "/v1/escalations/"+url.PathEscape(id)+"/cancel", nil)
+}
+
 func (c Client) ListEscalations(ctx context.Context) ([]HumanEscalation, error) {
 	return request[[]HumanEscalation](ctx, c, http.MethodGet, "/v1/scope/escalations", nil)
 }

--- a/bus/routes.go
+++ b/bus/routes.go
@@ -141,6 +141,9 @@ func (s *Server) newRouter() http.Handler {
 	registerRoute(router, "/v1/escalations/{escalationId}",
 		routeMethod{http.MethodGet, s.getEscalation},
 	)
+	registerRoute(router, "/v1/escalations/{escalationId}/cancel",
+		routeMethod{http.MethodPost, s.cancelEscalation},
+	)
 	registerRoute(router, "/v1/scope/escalations",
 		routeMethod{http.MethodGet, s.listEscalations},
 	)
@@ -798,6 +801,19 @@ func (s *Server) listEscalations(response http.ResponseWriter, request *http.Req
 		return err
 	}
 	result, err := s.runtime.ListEscalations(request.Context(), token)
+	if err != nil {
+		return err
+	}
+	writeResult(response, http.StatusOK, result)
+	return nil
+}
+
+func (s *Server) cancelEscalation(response http.ResponseWriter, request *http.Request) error {
+	token, err := bearer(request)
+	if err != nil {
+		return err
+	}
+	result, err := s.runtime.CancelEscalation(request.Context(), token, request.PathValue("escalationId"))
 	if err != nil {
 		return err
 	}

--- a/bus/runtime.go
+++ b/bus/runtime.go
@@ -624,6 +624,21 @@ func (r *Runtime) ListEscalations(ctx context.Context, scopeToken string) ([]Hum
 	return r.store.ListEscalations(ctx, scopeID)
 }
 
+func (r *Runtime) CancelEscalation(ctx context.Context, agentToken, escalationID string) (HumanEscalation, error) {
+	principal, err := r.Principal(ctx, agentToken)
+	if err != nil {
+		return HumanEscalation{}, err
+	}
+	if err := validateIdentity(escalationID, "escalationId", false); err != nil {
+		return HumanEscalation{}, err
+	}
+	result, err := r.store.CancelEscalation(ctx, principal.ScopeID, escalationID, principal.AgentID)
+	if err == nil {
+		r.notifyScope(principal.ScopeID)
+	}
+	return result, err
+}
+
 func (r *Runtime) ResolveEscalation(ctx context.Context, scopeToken, escalationID, answer string) (HumanEscalation, error) {
 	scopeID, err := r.scopeAuthority(ctx, scopeToken)
 	ctx = withScopeCredential(ctx, scopeToken)

--- a/bus/runtime_test.go
+++ b/bus/runtime_test.go
@@ -481,6 +481,36 @@ func TestHumanEscalationIsDurableAndScopeOwned(t *testing.T) {
 	require(t, err == nil && resolved.Status == "resolved" && resolved.Answer == "no", "unexpected resolution: %#v, %v", resolved, err)
 }
 
+func TestAgentCancelsOwnPendingEscalation(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	escalation, err := agents.runtime.AskHuman(ctx, agents.plannerToken, AskHumanInput{Question: "Deploy?", Options: []string{"yes", "no"}})
+	requireNoError(t, err)
+	cancelled, err := agents.runtime.CancelEscalation(ctx, agents.plannerToken, escalation.ID)
+	require(t, err == nil && cancelled.Status == "cancelled", "unexpected cancellation: %#v, %v", cancelled, err)
+	values, err := agents.runtime.ListEscalations(ctx, agents.scope.ScopeToken)
+	requireNoError(t, err)
+	require(t, len(values) == 1 && values[0].Status == "cancelled", "stored escalation not cancelled: %#v", values)
+	// A cancelled escalation no longer counts against the pending cap path: it is not pending.
+	_, err = agents.runtime.CancelEscalation(ctx, agents.plannerToken, escalation.ID)
+	requireCode(t, err, CodeConflict)
+}
+
+func TestAgentCannotCancelAnotherAgentsEscalation(t *testing.T) {
+	agents := setupAgents(t, ":memory:")
+	defer agents.runtime.Close()
+	ctx := context.Background()
+	escalation, err := agents.runtime.AskHuman(ctx, agents.plannerToken, AskHumanInput{Question: "Deploy?"})
+	requireNoError(t, err)
+	// The reviewer agent does not own the planner's escalation.
+	_, err = agents.runtime.CancelEscalation(ctx, agents.reviewerToken, escalation.ID)
+	requireCode(t, err, CodeConflict)
+	// Ownership failure must not mutate the stored escalation: it stays pending.
+	stored, err := agents.runtime.Escalation(ctx, agents.plannerToken, escalation.ID)
+	require(t, err == nil && stored.Status == "pending", "escalation mutated by foreign cancel: %#v, %v", stored, err)
+}
+
 func TestPendingEscalationsApplyPerAgentBackpressure(t *testing.T) {
 	agents := setupAgents(t, ":memory:")
 	defer agents.runtime.Close()

--- a/bus/storage_backend.go
+++ b/bus/storage_backend.go
@@ -49,6 +49,7 @@ type storageBackend interface {
 	Escalation(context.Context, string, string) (HumanEscalation, error)
 	ListEscalations(context.Context, string) ([]HumanEscalation, error)
 	ResolveEscalation(context.Context, string, string, string) (HumanEscalation, error)
+	CancelEscalation(context.Context, string, string, string) (HumanEscalation, error)
 
 	StorageSummary(context.Context, string) (StorageSummary, error)
 	PruneScope(context.Context, string, int64, bool) (PruneScopeResult, error)

--- a/bus/store.go
+++ b/bus/store.go
@@ -1572,6 +1572,35 @@ func (s *Store) ListEscalations(ctx context.Context, scopeID string) ([]HumanEsc
 	return escalations, rows.Err()
 }
 
+func (s *Store) CancelEscalation(ctx context.Context, scopeID, escalationID, agentID string) (HumanEscalation, error) {
+	tx, err := s.beginTx(ctx)
+	if err != nil {
+		return HumanEscalation{}, err
+	}
+	defer tx.Rollback()
+	now := nowMillis()
+	result, err := tx.ExecContext(ctx, `UPDATE escalations SET status='cancelled',resolved_at=? WHERE scope_id=? AND escalation_id=? AND agent_id=? AND status='pending'`,
+		now, scopeID, escalationID, agentID)
+	if err != nil {
+		return HumanEscalation{}, err
+	}
+	changed, _ := result.RowsAffected()
+	if changed != 1 {
+		return HumanEscalation{}, Errorf(CodeConflict, "Escalation is not pending or not owned by this agent")
+	}
+	if err := appendEvent(ctx, tx, scopeID, "escalation.cancelled", escalationID, eventAttributes("agentId", agentID, "status", "cancelled"), now); err != nil {
+		return HumanEscalation{}, err
+	}
+	escalation, err := escalationFrom(ctx, tx, scopeID, escalationID)
+	if err != nil {
+		return HumanEscalation{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return HumanEscalation{}, err
+	}
+	return escalation, nil
+}
+
 func (s *Store) ResolveEscalation(ctx context.Context, scopeID, escalationID, answer string) (HumanEscalation, error) {
 	tx, err := s.beginTx(ctx)
 	if err != nil {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -645,6 +645,10 @@ export class OctoberBusClient {
     return request(this.address, this.agentToken, 'GET', `/v1/escalations/${encodeURIComponent(id)}`, undefined, options)
   }
 
+  cancelEscalation(id: string, options?: OperationOptions): Promise<HumanEscalation> {
+    return request(this.address, this.agentToken, 'POST', `/v1/escalations/${encodeURIComponent(id)}/cancel`, undefined, options)
+  }
+
   mcpEndpoint(): { url: string; headers: Record<string, string> } {
     return { url: `${this.address}/mcp`, headers: { Authorization: `Bearer ${this.agentToken}` } }
   }

--- a/spec/0.1/README.md
+++ b/spec/0.1/README.md
@@ -155,7 +155,7 @@ Protocol 0.1 defines these event types:
 - `link.created`
 - `message.accepted`, `message.replied`, `message.reserved`, `message.released`, `message.delivered`, `message.acknowledged`, and `message.expired`
 - `task.created`, `task.claimed`, `task.released`, `task.completed`, and `task.progress_added`
-- `escalation.created` and `escalation.resolved`
+- `escalation.created`, `escalation.resolved`, and `escalation.cancelled`
 - `a2a.publication_created`, `a2a.publication_enabled`, and `a2a.publication_disabled`
 - `a2a.task_created`, `a2a.message_accepted`, and `a2a.task_state_changed`
 - `credential.created`, `credential.rotated`, `credential.enabled`, and `credential.disabled`
@@ -216,7 +216,7 @@ The reference runtime retains 1,000 values by default and permits a configured l
 
 An agent MAY create an escalation with a question and either no options or two to four options. Creating an escalation does not grant the agent permission or answer the question.
 
-Only scope authority resolves escalations. Agent authority can create and read escalations in its scope but cannot resolve them. The reference runtime limits pending escalations to 100 per agent and 1,000 per scope.
+Only scope authority resolves escalations. Agent authority can create and read escalations in its scope but cannot resolve them. An agent MAY cancel its own pending escalation; cancellation does not answer the question. The reference runtime limits pending escalations to 100 per agent and 1,000 per scope.
 
 ## Authority
 
@@ -224,7 +224,7 @@ Only scope authority resolves escalations. Agent authority can create and read e
 | --- | --- |
 | Admin token | Create, export, and import scopes and request local daemon shutdown |
 | Scope token | Register and list agents, create peer links, manage Agent Card publications and remote principals, manage output streams and readers, add and list tasks, follow scope events, inspect and prune storage, list and resolve escalations |
-| Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, publish to explicitly allowed output streams, create and read escalations |
+| Agent token | Heartbeat, discover peers, message linked peers, use inboxes, coordinate tasks, publish to explicitly allowed output streams, create, read, and cancel own escalations |
 | Scoped A2A credential | Invoke one published A2A agent interface when that operation is supported |
 | Scoped output credential | Read or publish one output stream according to its explicit permissions |
 


### PR DESCRIPTION
## Problem

The `escalations.status` CHECK admits `'cancelled'` (bus/schema.go:107, mirrored in spec/0.1/schemas/scope-archive.schema.json:151 and sdk/typescript/src/protocol.ts:363), and the scope-archive round-trip preserves it (bus/archive.go:842) — but **no code path ever set it**. An agent whose question became irrelevant (context changed, task completed another way, shutting down) could not withdraw it; stale pending escalations accumulated against the 100-per-agent cap with no self-service path.

Closes #113.

## Smallest solution — mirrors the resolve shape, agent-authenticated, ownership-checked

- **`POST /v1/escalations/{escalationId}/cancel`** — agent token; the runtime verifies the escalation belongs to the asking agent (agent_id match from the authenticated principal, not a client parameter), flips `pending → cancelled`, appends a metadata-only `escalation.cancelled` event, notifies the scope.
- **`Store.CancelEscalation`** mirrors `Store.ResolveEscalation`: one atomic `UPDATE escalations SET status='cancelled',resolved_at=? WHERE scope_id=? AND escalation_id=? AND agent_id=? AND status='pending'`, `CodeConflict` on non-pending or foreign owner. Ownership and the pending check are the UPDATE's own WHERE clause — no TOCTOU window, no status write before validation.
- **SDK**: `agent.cancelEscalation(id)` next to `askHuman`/`escalation` (client.ts), plus the Go client wrapper (bus/client.go).
- **Spec**: an agent MAY cancel its own pending escalation; cancellation does not answer the question. Authority table and event catalog updated to match.
- No schema change (enum already admits `'cancelled'`), no new event content rules (metadata-only like `escalation.resolved`).

## Regression tests (through the ordinary agent-token path)

- `TestAgentCancelsOwnPendingEscalation` — own pending escalation cancels, the **stored** row reads back `cancelled`, and re-cancelling a non-pending escalation is `CodeConflict`.
- `TestAgentCannotCancelAnotherAgentsEscalation` — a foreign agent's cancel is `CodeConflict` and the stored escalation stays `pending` (no mutation on ownership failure).

Both are mutation-verified non-vacuous: dropping the `agent_id` match fails the ownership test; an `AND 1=0` in the UPDATE fails the own-cancel test.

## Verification (full gate, real output)

- `go test ./... -count=1` — all 8 packages PASS (incl. conformance)
- `go vet ./...` — clean
- `go test -race ./bus/ -count=1` — PASS
- TS SDK: `npm run typecheck`, `npm run build`, `npm run test:errors` 11/11 — PASS

Adversarial probes: scope-token cancel → `CodeUnauthenticated` (agent-only); resolve-after-cancel → `CodeConflict`; archive round-trip accepts `cancelled` rows (archive.go:842, predates this branch).

## Review

3-round independent review (no round shared a model, none was the builder):
- Round 1 (correctness + test validity): PASS — 7/7 checks, mutation-verified, vet clean. Sole finding (Go client wrapper) fixed in this branch.
- Round 2 (harsh's-bar compliance, all 10 items): PASS, zero findings.
- Round 3 (final adjudication, claim-by-claim cross-check): **SHIP**.