### PR TITLE
feat: add experimental Grok adapter configuration (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If a harness cannot safely wake itself or prove that it is idle, it can implemen
 
 ## Harness integrations
 
-October Bus is harness-independent, not tied to Codex. This checkout includes candidates for **26 MCP hosts**, a **native Pi extension**, and a managed-launch path for **October Harness**. Start with Codex, Claude Code, Cursor, OpenCode, Gemini CLI or Copilot CLI; see the [full adapter list and setup](adapters/README.md). These are experimental integration paths, not 28 certified harnesses.
+October Bus is harness-independent, not tied to Codex. This checkout includes candidates for **27 MCP hosts**, a **native Pi extension**, and a managed-launch path for **October Harness**. Start with Codex, Claude Code, Cursor, OpenCode, Gemini CLI or Copilot CLI; see the [full adapter list and setup](adapters/README.md). These are experimental integration paths, not 29 certified harnesses.
 
 For custom integrations, use HTTP or the Go and TypeScript clients. A headless service manifest for Omarchy is also included.
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,6 +1,6 @@
 # Harness adapters
 
-October Bus ships configuration candidates for 26 MCP hosts, a native Pi extension, and a managed-launch path for October Harness's existing native integration. Configuration count is **not** a verified-support count: adapter revision 0.2.0 is experimental until each released host completes the [runbook](../compatibility/RUNBOOK.md). Historical Codex 0.1.0 / rc.4 evidence is retained, not transferred to this revision.
+October Bus ships configuration candidates for 27 MCP hosts, a native Pi extension, and a managed-launch path for October Harness's existing native integration. Configuration count is **not** a verified-support count: adapter revision 0.2.0 is experimental until each released host completes the [runbook](../compatibility/RUNBOOK.md). Historical Codex 0.1.0 / rc.4 evidence is retained, not transferred to this revision.
 
 ## Local setup
 
@@ -33,7 +33,7 @@ The bridge owns heartbeats and retirement on EOF, host termination or lease fail
 | Surface | Configuration candidates |
 | --- | --- |
 | Initial launch wave | [Codex](codex), [Claude Code](claude-code), [Cursor](cursor), [OpenCode](opencode), [Gemini CLI](gemini-cli), [Copilot CLI](copilot-cli) |
-| Other MCP hosts | [Amp](amp), [Antigravity](antigravity), [Auggie](auggie), [Autohand](autohand), [Cline](cline), [Continue](continue), [Crush](crush), [Factory Droid](factory-droid), [Freebuff CLI](freebuff), [Goose](goose), [Hermes](hermes), [Kilo Code](kilo-code), [Kimchi](kimchi), [Kimi Code](kimi-code), [Kiro](kiro), [Mistral Vibe](mistral-vibe), [OMP](omp), [Prime Agent](prime-agent), [Qwen Code](qwen-code) |
+| Other MCP hosts | [Amp](amp), [Antigravity](antigravity), [Auggie](auggie), [Autohand](autohand), [Cline](cline), [Continue](continue), [Crush](crush), [Factory Droid](factory-droid), [Freebuff CLI](freebuff), [Goose](goose), [Grok](grok), [Hermes](hermes), [Kilo Code](kilo-code), [Kimchi](kimchi), [Kimi Code](kimi-code), [Kiro](kiro), [Mistral Vibe](mistral-vibe), [OMP](omp), [Prime Agent](prime-agent), [Qwen Code](qwen-code) |
 | Sandbox-colocated MCP | [Devin](devin): generate paths inside its managed sandbox; remote exposure is not included |
 | Native session extension | [Pi](pi): public session hooks, daemon tool schemas, cancellation and cleanup |
 | Existing native integration | [October Harness](october-harness): public launcher contract, no duplicate extension |

--- a/adapters/grok/README.md
+++ b/adapters/grok/README.md
@@ -1,0 +1,20 @@
+# Grok adapter
+
+Status: experimental, adapter 0.2.0. Configuration reviewed on 2026-09-11; no named-harness versions or platforms certified for this revision. Refs [#30](https://github.com/october-dev/october-bus/issues/30).
+
+A configuration fixture is not a successful run in the actual host.
+
+Follow [shared setup](../README.md), then print a personalized snippet:
+
+```sh
+october-bus harness config grok --scope my-project --agent grok-reviewer --name "Grok Reviewer"
+october-bus doctor --harness grok --scope my-project
+```
+
+Configuration location: `~/.grok/config.toml`. The [template](config.toml.example) contains placeholders; use the generator, not the template verbatim. The generator never edits existing configuration or stores credentials in it. Review and merge just the October Bus entry. Retain the host's own tool approvals and workspace trust controls.
+
+The snippet is TOML, matching the host's own `[mcp_servers.<name>]` sections; merge the named entry into the existing file by hand. `grok mcp` manages the same entries from the CLI.
+
+Use `check_inbox` with `waitMs=1000` between work steps. The bridge registers and heartbeats outside the model loop, and attempts retirement when the host closes MCP. A hard kill relies on lease expiry. Each simultaneously connected window/project needs a distinct `--agent` ID; identical IDs deliberately replace the previous execution. Remove this server entry to disconnect, and verify retirement in the Bus before reassigning work.
+
+Before promotion, run the full [compatibility runbook](../../compatibility/RUNBOOK.md), both directions with an independent harness, denied-tool cases, reconnection/replacement, and exact-candidate evidence with model, launch mode and public sanitized artifacts. [Upstream configuration documentation](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/07-mcp-servers.md).

--- a/adapters/grok/adapter.json
+++ b/adapters/grok/adapter.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "id": "grok-mcp",
+  "adapterVersion": "0.2.0",
+  "harnessFamily": "Grok",
+  "status": "experimental",
+  "protocolVersions": [
+    "0.1"
+  ],
+  "transport": "mcp",
+  "delivery": "pull",
+  "lifecycleEvidence": "process",
+  "capabilities": [
+    "discovery",
+    "messaging",
+    "requests",
+    "tasks",
+    "escalation",
+    "bounded-context"
+  ],
+  "testedVersions": [],
+  "platforms": [],
+  "maintainer": "October",
+  "repository": "https://github.com/october-dev/october-bus",
+  "limitations": [
+    "Configuration reviewed against upstream documentation; this adapter revision has no named-harness certification",
+    "Pull-only: queued work does not start a model turn",
+    "One MCP configuration is one execution; duplicate agent IDs replace earlier executions"
+  ],
+  "conformanceCommand": "october-bus-conformance --profile mcp-adapter --start-runtime --adapter-command october-bus --adapter-arg mcp --adapter-arg stdio --check-self-registration",
+  "configuration": {
+    "file": "config.toml.example",
+    "format": "toml",
+    "location": "~/.grok/config.toml",
+    "executable": "grok",
+    "docs": "https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/07-mcp-servers.md",
+    "recommendedWaitMs": 1000
+  }
+}

--- a/adapters/grok/config.toml.example
+++ b/adapters/grok/config.toml.example
@@ -1,0 +1,6 @@
+[mcp_servers.october_bus]
+command = "{{command}}"
+args = ["mcp","stdio","--scope","{{scope}}","--agent","{{agent}}","--name","{{name}}","--data-dir","{{dataDir}}","--runtime-dir","{{runtimeDir}}"]
+enabled = true
+startup_timeout_sec = 20
+tool_timeout_sec = 60

--- a/docs/harness-boundaries.md
+++ b/docs/harness-boundaries.md
@@ -29,7 +29,7 @@ This supports colocated collaboration only. Connecting a remote host to a laptop
 | Target | Missing boundary / next evidence |
 | --- | --- |
 | Aider (#47) | [Scripting documentation](https://aider.chat/docs/scripting.html) establishes programmatic prompting, not a demonstrated full external-tool lifecycle. A prompt/terminal-text wrapper does not satisfy the Bus adapter contract. |
-| Grok (#30), DeepSeek (#41) | Identify a concrete released harness, or treat these as provider variations inside another host. Model APIs alone do not consume Bus work. |
+| DeepSeek (#41) | Identify a concrete released harness, or treat it as a provider variation inside another host. Model APIs alone do not consume Bus work. Grok (#30) moved to a configuration candidate via the Grok Build CLI's MCP client. |
 | Muse Code (#32) | Meta's [developer portal](https://dev.meta.ai/) requires login. Obtain accessible vendor documentation for external tools and session ownership; a skills folder or similarly named community MCP server does not establish that boundary. |
 
-For each unresolved target, supply the exact product/version, public tool/session hook, account/permission requirements and maintainer. Then implement the smallest shared-bridge or native shim and run the same independent-host evidence process. These four targets remain blocked, not silently counted as supported or marked complete. All 28 existing candidate paths still require released-host evidence and maintenance ownership.
+For each unresolved target, supply the exact product/version, public tool/session hook, account/permission requirements and maintainer. Then implement the smallest shared-bridge or native shim and run the same independent-host evidence process. These three targets remain blocked, not silently counted as supported or marked complete. All 29 existing candidate paths still require released-host evidence and maintenance ownership.


### PR DESCRIPTION
Refs #30.

## What

Adds the missing Grok adapter to the experimental set. #115 shipped 28 MCP host configurations but Grok was absent even though its feasibility gate is complete: the **Grok Build CLI** (`xai-org/grok-build`, Apache-2.0) is a coding-agent harness with a documented MCP client surface (`[mcp_servers.<name>]` in `~/.grok/config.toml`).

Files, mirroring the #115 pattern exactly:
- `adapters/grok/adapter.json` — `grok-mcp`, experimental, same revision/capabilities/limitations/conformanceCommand as the other MCP adapters; configuration block points at `config.toml.example` (TOML, `~/.grok/config.toml`, executable `grok`, upstream MCP docs link).
- `adapters/grok/config.toml.example` — TOML server entry using the standard placeholder set and args (`mcp stdio --scope … --agent … --name … --data-dir … --runtime-dir …`), matching Grok's documented `[mcp_servers.<name>]` shape with its `startup_timeout_sec`/`tool_timeout_sec` fields.
- `adapters/grok/README.md` — same structure as goose/cline: status + issue ref, the "a configuration fixture is not a successful run" honesty line, generator + doctor commands, waitMs guidance, runbook-before-promotion note.
- Enumeration surfaces #115 maintains: `adapters/README.md` (table + 26→27 MCP hosts), `README.md` (counts), `docs/harness-boundaries.md` (Grok moved out of the blocked-targets row; four→three blocked).

No certification claims: `status: experimental`, empty `testedVersions`/`platforms`, no named-harness evidence.

## Verification (real output)

- `go test ./adapters/... ./spec/... ./cmd/...` — all PASS (the embed auto-discovers the new adapter; the required-args/no-credentials/no-placeholders assertions cover it)
- `go vet ./...`, `go build ./...` — clean
- `october-bus harness list` shows `grok  Grok  experimental`
- `harness config grok --scope … --agent …` renders a valid TOML snippet with no `{{` placeholders and no credentials
- Mutation-verified: removing `--agent` from the example fails `TestEveryConfigurationRendersWithoutCredentials/grok`; restored green.

3-round independent review (no round was the builder, no model repeated): R1 correctness PASS (incl. fetching the upstream Grok MCP doc to confirm the TOML shape), R2 harsh's-bar 10/10 PASS, R3 adjudication SHIP.

AI-generated contribution.