### PR TITLE
feat: add experimental DeepSeek adapter configuration (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If a harness cannot safely wake itself or prove that it is idle, it can implemen
 
 ## Harness integrations
 
-October Bus is harness-independent, not tied to Codex. This checkout includes candidates for **26 MCP hosts**, a **native Pi extension**, and a managed-launch path for **October Harness**. Start with Codex, Claude Code, Cursor, OpenCode, Gemini CLI or Copilot CLI; see the [full adapter list and setup](adapters/README.md). These are experimental integration paths, not 28 certified harnesses.
+October Bus is harness-independent, not tied to Codex. This checkout includes candidates for **27 MCP hosts**, a **native Pi extension**, and a managed-launch path for **October Harness**. Start with Codex, Claude Code, Cursor, OpenCode, Gemini CLI or Copilot CLI; see the [full adapter list and setup](adapters/README.md). These are experimental integration paths, not 29 certified harnesses.
 
 For custom integrations, use HTTP or the Go and TypeScript clients. A headless service manifest for Omarchy is also included.
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,6 +1,6 @@
 # Harness adapters
 
-October Bus ships configuration candidates for 26 MCP hosts, a native Pi extension, and a managed-launch path for October Harness's existing native integration. Configuration count is **not** a verified-support count: adapter revision 0.2.0 is experimental until each released host completes the [runbook](../compatibility/RUNBOOK.md). Historical Codex 0.1.0 / rc.4 evidence is retained, not transferred to this revision.
+October Bus ships configuration candidates for 27 MCP hosts, a native Pi extension, and a managed-launch path for October Harness's existing native integration. Configuration count is **not** a verified-support count: adapter revision 0.2.0 is experimental until each released host completes the [runbook](../compatibility/RUNBOOK.md). Historical Codex 0.1.0 / rc.4 evidence is retained, not transferred to this revision.
 
 ## Local setup
 
@@ -33,7 +33,7 @@ The bridge owns heartbeats and retirement on EOF, host termination or lease fail
 | Surface | Configuration candidates |
 | --- | --- |
 | Initial launch wave | [Codex](codex), [Claude Code](claude-code), [Cursor](cursor), [OpenCode](opencode), [Gemini CLI](gemini-cli), [Copilot CLI](copilot-cli) |
-| Other MCP hosts | [Amp](amp), [Antigravity](antigravity), [Auggie](auggie), [Autohand](autohand), [Cline](cline), [Continue](continue), [Crush](crush), [Factory Droid](factory-droid), [Freebuff CLI](freebuff), [Goose](goose), [Hermes](hermes), [Kilo Code](kilo-code), [Kimchi](kimchi), [Kimi Code](kimi-code), [Kiro](kiro), [Mistral Vibe](mistral-vibe), [OMP](omp), [Prime Agent](prime-agent), [Qwen Code](qwen-code) |
+| Other MCP hosts | [Amp](amp), [Antigravity](antigravity), [Auggie](auggie), [Autohand](autohand), [Cline](cline), [Continue](continue), [Crush](crush), [DeepSeek](deepseek), [Factory Droid](factory-droid), [Freebuff CLI](freebuff), [Goose](goose), [Hermes](hermes), [Kilo Code](kilo-code), [Kimchi](kimchi), [Kimi Code](kimi-code), [Kiro](kiro), [Mistral Vibe](mistral-vibe), [OMP](omp), [Prime Agent](prime-agent), [Qwen Code](qwen-code) |
 | Sandbox-colocated MCP | [Devin](devin): generate paths inside its managed sandbox; remote exposure is not included |
 | Native session extension | [Pi](pi): public session hooks, daemon tool schemas, cancellation and cleanup |
 | Existing native integration | [October Harness](october-harness): public launcher contract, no duplicate extension |

--- a/adapters/deepseek/README.md
+++ b/adapters/deepseek/README.md
@@ -1,0 +1,22 @@
+# DeepSeek adapter
+
+Status: experimental, adapter 0.2.0. Configuration reviewed on 2026-09-11; no named-harness versions or platforms certified for this revision. Refs [#41](https://github.com/october-dev/october-bus/issues/41).
+
+A configuration fixture is not a successful run in the actual host.
+
+Follow [shared setup](../README.md), then print a personalized snippet:
+
+```sh
+october-bus harness config deepseek --scope my-project --agent dsh-reviewer --name "DeepSeek Reviewer"
+october-bus doctor --harness deepseek --scope my-project
+```
+
+Configuration location: `cordis.yml` in the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) profile configuration. The [template](cordis.yml.example) contains placeholders; use the generator, not the template verbatim. The generator never edits existing configuration or stores credentials in it. Review and merge just the October Bus entry, which merges into the dsh plugin list as one `@deepseek-ai/dsh-mcp-client` server entry. Retain the host's own tool approvals and workspace trust controls.
+
+The snippet uses JSON syntax, which is valid YAML; merge the named entry into the existing plugin list by hand.
+
+Use `check_inbox` with `waitMs=1000` between work steps. The bridge registers and heartbeats outside the model loop, and attempts retirement when the host closes MCP. A hard kill relies on lease expiry. Each simultaneously connected window/project needs a distinct `--agent` ID; identical IDs deliberately replace the previous execution. Remove this server entry to disconnect, and verify retirement in the Bus before reassigning work.
+
+The harness is a developer preview with announced compatibility-breaking changes; re-verify this configuration against a pinned released `dsh` version before relying on it.
+
+Before promotion, run the full [compatibility runbook](../../compatibility/RUNBOOK.md), both directions with an independent harness, denied-tool cases, reconnection/replacement, and exact-candidate evidence with model, launch mode and public sanitized artifacts. [Upstream configuration documentation](https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/mcp/mcp-client/README.md).

--- a/adapters/deepseek/adapter.json
+++ b/adapters/deepseek/adapter.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "id": "deepseek-mcp",
+  "adapterVersion": "0.2.0",
+  "harnessFamily": "DeepSeek",
+  "status": "experimental",
+  "protocolVersions": [
+    "0.1"
+  ],
+  "transport": "mcp",
+  "delivery": "pull",
+  "lifecycleEvidence": "process",
+  "capabilities": [
+    "discovery",
+    "messaging",
+    "requests",
+    "tasks",
+    "escalation",
+    "bounded-context"
+  ],
+  "testedVersions": [],
+  "platforms": [],
+  "maintainer": "October",
+  "repository": "https://github.com/october-dev/october-bus",
+  "limitations": [
+    "Configuration reviewed against upstream documentation; this adapter revision has no named-harness certification",
+    "Pull-only: queued work does not start a model turn",
+    "One MCP configuration is one execution; duplicate agent IDs replace earlier executions",
+    "The DeepSeek Harness (dsh) is a developer preview with announced compatibility-breaking changes; re-verify this configuration against a pinned released version before relying on it"
+  ],
+  "conformanceCommand": "october-bus-conformance --profile mcp-adapter --start-runtime --adapter-command october-bus --adapter-arg mcp --adapter-arg stdio --check-self-registration",
+  "configuration": {
+    "file": "cordis.yml.example",
+    "format": "yaml",
+    "location": "cordis.yml (dsh profile configuration)",
+    "executable": "dsh",
+    "docs": "https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/mcp/mcp-client/README.md",
+    "recommendedWaitMs": 1000
+  }
+}

--- a/adapters/deepseek/cordis.yml.example
+++ b/adapters/deepseek/cordis.yml.example
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "mcp-october-bus",
+    "name": "@deepseek-ai/dsh-mcp-client",
+    "config": {
+      "serverName": "october_bus",
+      "transport": "stdio",
+      "command": "{{command}}",
+      "args": [
+        "mcp",
+        "stdio",
+        "--scope",
+        "{{scope}}",
+        "--agent",
+        "{{agent}}",
+        "--name",
+        "{{name}}",
+        "--data-dir",
+        "{{dataDir}}",
+        "--runtime-dir",
+        "{{runtimeDir}}"
+      ]
+    }
+  }
+]

--- a/docs/harness-boundaries.md
+++ b/docs/harness-boundaries.md
@@ -29,7 +29,7 @@ This supports colocated collaboration only. Connecting a remote host to a laptop
 | Target | Missing boundary / next evidence |
 | --- | --- |
 | Aider (#47) | [Scripting documentation](https://aider.chat/docs/scripting.html) establishes programmatic prompting, not a demonstrated full external-tool lifecycle. A prompt/terminal-text wrapper does not satisfy the Bus adapter contract. |
-| Grok (#30), DeepSeek (#41) | Identify a concrete released harness, or treat these as provider variations inside another host. Model APIs alone do not consume Bus work. |
+| Grok (#30) | Identify a concrete released harness, or treat it as a provider variation inside another host. Model APIs alone do not consume Bus work. DeepSeek (#41) moved to a configuration candidate via the DeepSeek Harness (dsh) MCP client plugin. |
 | Muse Code (#32) | Meta's [developer portal](https://dev.meta.ai/) requires login. Obtain accessible vendor documentation for external tools and session ownership; a skills folder or similarly named community MCP server does not establish that boundary. |
 
-For each unresolved target, supply the exact product/version, public tool/session hook, account/permission requirements and maintainer. Then implement the smallest shared-bridge or native shim and run the same independent-host evidence process. These four targets remain blocked, not silently counted as supported or marked complete. All 28 existing candidate paths still require released-host evidence and maintenance ownership.
+For each unresolved target, supply the exact product/version, public tool/session hook, account/permission requirements and maintainer. Then implement the smallest shared-bridge or native shim and run the same independent-host evidence process. These three targets remain blocked, not silently counted as supported or marked complete. All 29 existing candidate paths still require released-host evidence and maintenance ownership.


### PR DESCRIPTION
Refs #41.

## What

Adds the DeepSeek adapter to the experimental set, resolving the issue's boundary question: the concrete released harness is the **DeepSeek Harness (`dsh`)** ([deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness), MIT, developer preview) with a first-party MCP client bridge plugin **`@deepseek-ai/dsh-mcp-client`** — one cordis YAML entry per MCP server, `transport: stdio` with `command`/`args`, tools surfacing as `mcp__<serverName>__<tool>`.

Files, mirroring the #115 pattern (and the grok adapter in #116):
- `adapters/deepseek/adapter.json` — `deepseek-mcp`, experimental, same revision/capabilities/conformanceCommand as siblings; the standard 3 limitations plus a fourth disclosing the harness's developer-preview breaking-change warning. Configuration block: `cordis.yml.example` (YAML), executable `dsh`, upstream MCP client docs link.
- `adapters/deepseek/cordis.yml.example` — one `@deepseek-ai/dsh-mcp-client` entry in the verified upstream shape (`id`/`name`/`config.serverName`/`transport`/`command`/`args`), written in JSON syntax so it is valid YAML and passes the `json.Valid` gate in `adapters/config_test.go` (same approach as goose's YAML example). Standard placeholders + args.
- `adapters/deepseek/README.md` — goose structure: status + issue ref, honesty line, generator + doctor commands, config-location note (the upstream doc pins no absolute path; the entry merges into the dsh profile's plugin list), waitMs guidance, runbook-before-promotion, preview caveat.
- Enumeration surfaces: `adapters/README.md` (26→27 MCP hosts + table row), `README.md` (counts), `docs/harness-boundaries.md` (DeepSeek out of the blocked-targets row; the Grok part stays as-is since #116 is still open — whichever merges second rebases, and the counts were chosen to compose: post-#116 this becomes 28 hosts / 30 paths / Grok row deleted).

No certification claims: `status: experimental`, empty `testedVersions`/`platforms`.

## Verification (real output)

- `go test -count=1 ./adapters/... ./spec/... ./cmd/...` — all PASS
- `go vet ./...`, `go build ./...` — clean
- `october-bus harness list` shows `deepseek  DeepSeek  experimental`
- `harness config deepseek --scope … --agent …` renders a valid entry with no `{{` placeholders and no credentials
- Mutation-verified: removing `--agent` from the example fails `TestEveryConfigurationRendersWithoutCredentials/deepseek`; restored green.

3-round independent review (no round was the builder, no model repeated): R1 correctness PASS (incl. fetching the upstream dsh-mcp-client doc to confirm the config shape), R2 harsh's-bar 10/10 PASS, R3 adjudication SHIP.

AI-generated contribution.